### PR TITLE
feat: Real-time WebSocket Event Server

### DIFF
--- a/backend/app/api/websocket.py
+++ b/backend/app/api/websocket.py
@@ -1,13 +1,19 @@
-"""WebSocket endpoint for real-time event streaming.
+"""WebSocket endpoint and polling-fallback REST API for real-time events.
 
-Connect: ws://host/ws?token=<uuid>
-Messages: subscribe, unsubscribe, broadcast, pong (JSON)
+Connect: ws://host/ws?token=<jwt_or_uuid>
+Polling: GET /api/events/{channel}?since=ISO8601&limit=50
+Status:  GET /api/events/status
+Types:   GET /api/events/types
 """
 
 import asyncio
+from datetime import datetime
+from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, HTTPException, Query, WebSocket, WebSocketDisconnect
+from pydantic import BaseModel
 
+from app.models.event import EventType
 from app.services.websocket_manager import manager
 
 router = APIRouter(tags=["websocket"])
@@ -16,12 +22,12 @@ router = APIRouter(tags=["websocket"])
 @router.websocket("/ws")
 async def websocket_endpoint(
     ws: WebSocket,
-    token: str = Query(..., description="Bearer token (UUID user ID)"),
-):
+    token: str = Query(..., description="Bearer token (JWT or UUID)"),
+) -> None:
+    """Accept a WebSocket connection, authenticate, and route messages."""
     connection_id = await manager.connect(ws, token)
     if connection_id is None:
         return
-
     heartbeat_task = asyncio.create_task(manager.heartbeat(connection_id))
     try:
         while True:
@@ -34,3 +40,72 @@ async def websocket_endpoint(
     finally:
         heartbeat_task.cancel()
         await manager.disconnect(connection_id)
+
+
+# -- Response models --
+
+class EventListResponse(BaseModel):
+    """Paginated list of buffered events for a channel."""
+    events: List[Dict[str, Any]]
+    channel: str
+    count: int
+
+
+class ConnectionStatusResponse(BaseModel):
+    """WebSocket connection statistics."""
+    active_connections: int
+    max_connections: int
+    total_channels: int
+    channels: Dict[str, int]
+
+
+class EventTypesResponse(BaseModel):
+    """Supported event types with descriptions."""
+    event_types: List[str]
+    description: Dict[str, str]
+
+
+# -- Static routes before dynamic {channel} route --
+
+@router.get("/api/events/status", response_model=ConnectionStatusResponse)
+async def get_connection_status() -> ConnectionStatusResponse:
+    """Return current WebSocket connection statistics."""
+    return ConnectionStatusResponse(**manager.get_connection_info())
+
+
+@router.get("/api/events/types", response_model=EventTypesResponse)
+async def get_event_types() -> EventTypesResponse:
+    """Return all supported event types."""
+    descriptions = {
+        EventType.BOUNTY_UPDATE.value: "Bounty lifecycle state changes",
+        EventType.PR_SUBMITTED.value: "New PR submitted against a bounty",
+        EventType.REVIEW_PROGRESS.value: "AI review pipeline progress",
+        EventType.PAYOUT_SENT.value: "On-chain $FNDRY payout confirmed",
+        EventType.CLAIM_UPDATE.value: "Bounty claim lifecycle changes",
+    }
+    return EventTypesResponse(
+        event_types=[t.value for t in EventType],
+        description=descriptions,
+    )
+
+
+@router.get("/api/events/{channel}", response_model=EventListResponse)
+async def get_channel_events(
+    channel: str,
+    since: Optional[str] = Query(None, description="ISO-8601 UTC cutoff"),
+    limit: int = Query(50, ge=1, le=200),
+) -> EventListResponse:
+    """Polling fallback — fetch recent buffered events for a channel.
+
+    Clients that cannot maintain a WebSocket should poll this endpoint
+    at 5-30 s intervals, passing the timestamp of the last received
+    event as the ``since`` parameter.
+    """
+    since_dt: Optional[datetime] = None
+    if since is not None:
+        try:
+            since_dt = datetime.fromisoformat(since.replace("Z", "+00:00"))
+        except ValueError:
+            raise HTTPException(400, "Invalid 'since' — must be ISO-8601")
+    events = manager.get_buffered_events(channel, since=since_dt, limit=limit)
+    return EventListResponse(events=events, channel=channel, count=len(events))

--- a/backend/app/models/event.py
+++ b/backend/app/models/event.py
@@ -1,0 +1,131 @@
+"""Typed event models for the real-time WebSocket event server.
+
+Defines Pydantic models for all event types emitted through pub/sub:
+bounty_update, pr_submitted, review_progress, payout_sent, claim_update.
+"""
+
+import uuid
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class EventType(str, Enum):
+    """All supported real-time event types."""
+
+    BOUNTY_UPDATE = "bounty_update"
+    PR_SUBMITTED = "pr_submitted"
+    REVIEW_PROGRESS = "review_progress"
+    PAYOUT_SENT = "payout_sent"
+    CLAIM_UPDATE = "claim_update"
+
+
+class BountyUpdatePayload(BaseModel):
+    """Payload for bounty lifecycle changes."""
+
+    bounty_id: str = Field(..., min_length=1)
+    title: str = Field(..., min_length=1, max_length=200)
+    previous_status: Optional[str] = None
+    new_status: str = Field(..., min_length=1)
+    tier: Optional[int] = Field(None, ge=1, le=3)
+    reward_amount: Optional[float] = Field(None, ge=0)
+    model_config = {"from_attributes": True}
+
+
+class PullRequestSubmittedPayload(BaseModel):
+    """Payload for new PR submissions against a bounty."""
+
+    bounty_id: str = Field(..., min_length=1)
+    submission_id: str = Field(..., min_length=1)
+    pr_url: str = Field(..., min_length=1)
+    submitted_by: str = Field(..., min_length=1)
+    model_config = {"from_attributes": True}
+
+    @field_validator("pr_url")
+    @classmethod
+    def validate_pr_url(cls, value: str) -> str:
+        """Ensure the PR URL points to GitHub."""
+        if not value.startswith(("https://github.com/", "http://github.com/")):
+            raise ValueError("pr_url must be a valid GitHub URL")
+        return value
+
+
+class ReviewProgressPayload(BaseModel):
+    """Payload for AI review pipeline progress."""
+
+    bounty_id: str = Field(..., min_length=1)
+    submission_id: str = Field(..., min_length=1)
+    reviewer: str = Field(..., min_length=1)
+    score: Optional[float] = Field(None, ge=0, le=10)
+    status: str = Field(..., min_length=1)
+    details: Optional[str] = Field(None, max_length=2000)
+    model_config = {"from_attributes": True}
+
+
+class PayoutSentPayload(BaseModel):
+    """Payload for confirmed on-chain payout events."""
+
+    bounty_id: str = Field(..., min_length=1)
+    recipient_wallet: str = Field(..., min_length=32, max_length=48)
+    amount: float = Field(..., gt=0)
+    tx_hash: Optional[str] = None
+    solscan_url: Optional[str] = None
+    model_config = {"from_attributes": True}
+
+
+class ClaimUpdatePayload(BaseModel):
+    """Payload for bounty claim lifecycle changes."""
+
+    bounty_id: str = Field(..., min_length=1)
+    claimer: str = Field(..., min_length=1)
+    action: str = Field(..., min_length=1)
+    deadline: Optional[datetime] = None
+    model_config = {"from_attributes": True}
+
+    @field_validator("action")
+    @classmethod
+    def validate_action(cls, value: str) -> str:
+        """Ensure action is one of the allowed claim actions."""
+        allowed = {"claimed", "released", "expired"}
+        if value not in allowed:
+            raise ValueError(
+                f"Invalid claim action: '{value}'. Must be one of: {sorted(allowed)}"
+            )
+        return value
+
+
+PAYLOAD_TYPE_MAP: Dict[EventType, type] = {
+    EventType.BOUNTY_UPDATE: BountyUpdatePayload,
+    EventType.PR_SUBMITTED: PullRequestSubmittedPayload,
+    EventType.REVIEW_PROGRESS: ReviewProgressPayload,
+    EventType.PAYOUT_SENT: PayoutSentPayload,
+    EventType.CLAIM_UPDATE: ClaimUpdatePayload,
+}
+
+
+class EventEnvelope(BaseModel):
+    """Standard envelope wrapping every real-time event."""
+
+    event_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    event_type: EventType
+    channel: str = Field(..., min_length=1)
+    timestamp: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
+    payload: Dict[str, Any] = Field(default_factory=dict)
+    model_config = {"from_attributes": True}
+
+
+def create_event(
+    event_type: EventType, channel: str, payload: Dict[str, Any],
+) -> EventEnvelope:
+    """Create and validate an event envelope for the given type."""
+    payload_model = PAYLOAD_TYPE_MAP.get(event_type)
+    if payload_model is not None:
+        validated = payload_model(**payload)
+        payload = validated.model_dump(mode="json")
+    return EventEnvelope(
+        event_type=event_type, channel=channel, payload=payload,
+    )

--- a/backend/app/services/websocket_manager.py
+++ b/backend/app/services/websocket_manager.py
@@ -1,12 +1,20 @@
-"""WebSocket manager with auth, heartbeat, rate limiting, and Redis-first pub/sub."""
+"""WebSocket manager with JWT auth, heartbeat, rate limiting, and Redis-first pub/sub.
+
+Adds JWT auth (UUID fallback), max-connection limits, typed event
+emission, and in-memory event buffer for the polling fallback endpoint.
+PostgreSQL migration path: websocket_connections table (connection_id PK,
+user_id FK, connected_at TIMESTAMPTZ, channels TEXT[]).
+"""
 
 import asyncio
+import collections
 import json
 import logging
 import os
 import time
 from dataclasses import dataclass, field
-from typing import Dict, Optional, Protocol, Set
+from datetime import datetime, timezone
+from typing import Any, Deque, Dict, List, Optional, Protocol, Set
 
 from fastapi import WebSocket
 from starlette.websockets import WebSocketState
@@ -16,7 +24,9 @@ logger = logging.getLogger(__name__)
 HEARTBEAT_INTERVAL = int(os.getenv("WS_HEARTBEAT_INTERVAL", "30"))
 RATE_LIMIT_WINDOW = int(os.getenv("WS_RATE_LIMIT_WINDOW", "60"))
 RATE_LIMIT_MAX = int(os.getenv("WS_RATE_LIMIT_MAX", "100"))
+MAX_CONNECTIONS = int(os.getenv("WS_MAX_CONNECTIONS", "1000"))
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+EVENT_BUFFER_SIZE = int(os.getenv("WS_EVENT_BUFFER_SIZE", "200"))
 
 
 class PubSubAdapter(Protocol):
@@ -131,6 +141,7 @@ class WebSocketManager:
         self._subscriptions: Dict[str, Set[str]] = {}
         self._rate_buckets: Dict[str, _RateBucket] = {}
         self._adapter = adapter
+        self._event_buffer: Dict[str, Deque[Dict[str, Any]]] = {}
 
     # -- lifecycle --
 
@@ -155,6 +166,7 @@ class WebSocketManager:
                 pass
         self._connections.clear()
         self._subscriptions.clear()
+        self._event_buffer.clear()
         if self._adapter:
             await self._adapter.close()
 
@@ -162,9 +174,20 @@ class WebSocketManager:
 
     @staticmethod
     async def authenticate(token: Optional[str]) -> Optional[str]:
-        """Validate bearer token (UUID), return user_id or None."""
+        """Validate bearer token (JWT or UUID), return user_id or None.
+
+        Tries JWT decoding first via auth_service, then falls back to
+        raw UUID acceptance for backward compatibility.
+        """
         if not token:
             return None
+        # Try JWT access token first
+        try:
+            from app.services.auth_service import decode_token
+            return decode_token(token, "access")
+        except Exception:
+            pass
+        # Fallback: accept raw UUID tokens
         import uuid as _uuid
         try:
             _uuid.UUID(token)
@@ -205,10 +228,16 @@ class WebSocketManager:
     # -- connect / disconnect --
 
     async def connect(self, ws: WebSocket, token: Optional[str]) -> Optional[str]:
-        """Accept WS after auth. Returns connection_id or None."""
+        """Accept WS after auth. Returns connection_id or None.
+
+        Enforces MAX_CONNECTIONS limit (close code 4002 when full).
+        """
         user_id = await self.authenticate(token)
         if user_id is None:
             await ws.close(code=4001)
+            return None
+        if len(self._connections) >= MAX_CONNECTIONS:
+            await ws.close(code=4002)
             return None
         await ws.accept()
         import uuid as _uuid
@@ -342,6 +371,75 @@ class WebSocketManager:
             return {"type": "broadcasted", "channel": channel, "recipients": n}
 
         return {"type": "error", "detail": f"unknown message type: {msg_type}"}
+
+    # -- typed event emission --
+
+    async def emit_event(
+        self, event_type: str, channel: str, payload: Dict[str, Any],
+    ) -> int:
+        """Emit a validated typed event to a channel and buffer it.
+
+        Args:
+            event_type: One of the EventType enum values.
+            channel: Target pub/sub channel.
+            payload: Event-specific data dict.
+
+        Returns:
+            Number of local subscribers that received the event.
+        """
+        from app.models.event import EventType as ET, create_event
+
+        envelope = create_event(ET(event_type), channel, payload)
+        event_dict = envelope.model_dump(mode="json")
+
+        buffer = self._event_buffer.setdefault(
+            channel, collections.deque(maxlen=EVENT_BUFFER_SIZE)
+        )
+        buffer.append(event_dict)
+
+        return await self.broadcast(
+            channel, event_dict, sender_user_id="system"
+        )
+
+    def get_buffered_events(
+        self, channel: str, since: Optional[datetime] = None, limit: int = 50,
+    ) -> List[Dict[str, Any]]:
+        """Retrieve buffered events for polling fallback.
+
+        Args:
+            channel: The channel to read events from.
+            since: Optional UTC cutoff timestamp.
+            limit: Maximum number of events to return.
+
+        Returns:
+            List of event dicts, oldest first.
+        """
+        buffer = self._event_buffer.get(channel, collections.deque())
+        events = list(buffer)
+        if since is not None:
+            since_str = since.isoformat()
+            events = [e for e in events if e.get("timestamp", "") > since_str]
+        return events[-limit:]
+
+    def get_connection_count(self) -> int:
+        """Return total number of active WebSocket connections."""
+        return len(self._connections)
+
+    def get_channel_subscriber_count(self, channel: str) -> int:
+        """Return number of subscribers for a specific channel."""
+        return len(self._subscriptions.get(channel, set()))
+
+    def get_connection_info(self) -> Dict[str, Any]:
+        """Return summary statistics about current WebSocket state."""
+        channel_counts = {
+            channel: len(subs) for channel, subs in self._subscriptions.items()
+        }
+        return {
+            "active_connections": len(self._connections),
+            "max_connections": MAX_CONNECTIONS,
+            "total_channels": len(self._subscriptions),
+            "channels": channel_counts,
+        }
 
 
 manager = WebSocketManager()

--- a/backend/tests/test_websocket_events.py
+++ b/backend/tests/test_websocket_events.py
@@ -1,0 +1,241 @@
+"""Tests for real-time WebSocket event server: JWT auth, max connections,
+typed events, polling fallback, connection info."""
+
+import json
+import uuid
+from datetime import datetime, timezone, timedelta
+from typing import Optional
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketState
+
+from app.models.event import EventType, ReviewProgressPayload, create_event
+from app.services.websocket_manager import InMemoryPubSubAdapter, WebSocketManager
+
+VALID_TOKEN = str(uuid.uuid4())
+
+
+class FakeWebSocket:
+    """Minimal WebSocket double for unit tests."""
+    def __init__(self):
+        self.client_state = WebSocketState.CONNECTED
+        self.accepted = self.closed = False
+        self.close_code: Optional[int] = None
+        self.sent: list = []
+
+    async def accept(self): self.accepted = True
+    async def close(self, code=1000):
+        self.closed = True; self.close_code = code
+        self.client_state = WebSocketState.DISCONNECTED
+    async def send_json(self, data): self.sent.append(data)
+    async def send_text(self, data): self.sent.append(json.loads(data))
+
+
+@pytest.fixture
+def mgr():
+    m = WebSocketManager()
+    m._adapter = InMemoryPubSubAdapter(m)
+    return m
+
+
+@pytest_asyncio.fixture
+async def connected(mgr):
+    ws = FakeWebSocket()
+    cid = await mgr.connect(ws, VALID_TOKEN)
+    return mgr, cid, ws
+
+
+class TestEventModels:
+    def test_bounty_update(self):
+        e = create_event(EventType.BOUNTY_UPDATE, "b:1",
+            {"bounty_id": "1", "title": "Fix", "new_status": "in_progress"})
+        assert e.payload["new_status"] == "in_progress"
+
+    def test_pr_submitted(self):
+        e = create_event(EventType.PR_SUBMITTED, "b:1",
+            {"bounty_id": "1", "submission_id": "s1",
+             "pr_url": "https://github.com/SolFoundry/solfoundry/pull/1",
+             "submitted_by": "dev1"})
+        assert e.payload["pr_url"].startswith("https://github.com/")
+
+    def test_review_progress(self):
+        e = create_event(EventType.REVIEW_PROGRESS, "b:1",
+            {"bounty_id": "1", "submission_id": "s1",
+             "reviewer": "gpt", "score": 8.5, "status": "completed"})
+        assert e.payload["score"] == 8.5
+
+    def test_payout_sent(self):
+        e = create_event(EventType.PAYOUT_SENT, "b:1",
+            {"bounty_id": "1", "amount": 500000.0,
+             "recipient_wallet": "97VihHW2Br7BKUU16c7RxjiEMHsD4dWisGDT2Y3LyJxF"})
+        assert e.payload["amount"] == 500000.0
+
+    def test_claim_update(self):
+        e = create_event(EventType.CLAIM_UPDATE, "b:1",
+            {"bounty_id": "1", "claimer": "dev1", "action": "claimed"})
+        assert e.payload["action"] == "claimed"
+
+    def test_invalid_pr_url(self):
+        with pytest.raises(ValueError, match="GitHub URL"):
+            create_event(EventType.PR_SUBMITTED, "b:1",
+                {"bounty_id": "1", "submission_id": "s1",
+                 "pr_url": "https://gitlab.com/r/1", "submitted_by": "d"})
+
+    def test_invalid_claim_action(self):
+        with pytest.raises(ValueError, match="Invalid claim action"):
+            create_event(EventType.CLAIM_UPDATE, "b:1",
+                {"bounty_id": "1", "claimer": "d", "action": "stolen"})
+
+    def test_score_out_of_range(self):
+        with pytest.raises(ValueError):
+            ReviewProgressPayload(bounty_id="1", submission_id="s",
+                reviewer="gpt", score=11.0, status="done")
+
+    def test_unique_ids(self):
+        a = create_event(EventType.BOUNTY_UPDATE, "b:1",
+            {"bounty_id": "1", "title": "A", "new_status": "open"})
+        b = create_event(EventType.BOUNTY_UPDATE, "b:1",
+            {"bounty_id": "1", "title": "B", "new_status": "open"})
+        assert a.event_id != b.event_id
+
+    def test_serialization(self):
+        e = create_event(EventType.BOUNTY_UPDATE, "b:1",
+            {"bounty_id": "1", "title": "T", "new_status": "open"})
+        d = e.model_dump(mode="json")
+        assert d["event_type"] == "bounty_update"
+
+
+class TestJWTAuth:
+    @pytest.mark.asyncio
+    async def test_jwt_accepted(self, mgr):
+        with patch("app.services.websocket_manager.WebSocketManager.authenticate",
+                   return_value="u1"):
+            ws = FakeWebSocket()
+            assert await mgr.connect(ws, "jwt.tok") is not None
+
+    @pytest.mark.asyncio
+    async def test_uuid_accepted(self, mgr):
+        ws = FakeWebSocket()
+        assert await mgr.connect(ws, VALID_TOKEN) is not None
+
+    @pytest.mark.asyncio
+    async def test_bad_token_rejected(self, mgr):
+        ws = FakeWebSocket()
+        assert await mgr.connect(ws, "bad") is None
+        assert ws.close_code == 4001
+
+    @pytest.mark.asyncio
+    async def test_none_rejected(self, mgr):
+        ws = FakeWebSocket()
+        assert await mgr.connect(ws, None) is None
+
+
+class TestMaxConnections:
+    @pytest.mark.asyncio
+    async def test_limit_enforced(self, mgr):
+        with patch("app.services.websocket_manager.MAX_CONNECTIONS", 2):
+            w = [FakeWebSocket() for _ in range(3)]
+            assert await mgr.connect(w[0], str(uuid.uuid4())) is not None
+            assert await mgr.connect(w[1], str(uuid.uuid4())) is not None
+            assert await mgr.connect(w[2], str(uuid.uuid4())) is None
+            assert w[2].close_code == 4002
+
+    @pytest.mark.asyncio
+    async def test_slot_freed(self, mgr):
+        with patch("app.services.websocket_manager.MAX_CONNECTIONS", 1):
+            ws = FakeWebSocket()
+            cid = await mgr.connect(ws, str(uuid.uuid4()))
+            await mgr.disconnect(cid)
+            assert await mgr.connect(FakeWebSocket(), str(uuid.uuid4())) is not None
+
+
+class TestEventEmission:
+    @pytest.mark.asyncio
+    async def test_delivers_to_subscribers(self, connected):
+        mgr, cid, ws = connected
+        await mgr.subscribe(cid, "bounty:a")
+        n = await mgr.emit_event("bounty_update", "bounty:a",
+            {"bounty_id": "a", "title": "F", "new_status": "in_progress"})
+        assert n == 1 and ws.sent[0]["data"]["event_type"] == "bounty_update"
+
+    @pytest.mark.asyncio
+    async def test_buffers_for_polling(self, mgr):
+        await mgr.emit_event("bounty_update", "b:x",
+            {"bounty_id": "x", "title": "N", "new_status": "open"})
+        assert len(mgr.get_buffered_events("b:x")) == 1
+
+    @pytest.mark.asyncio
+    async def test_invalid_type_raises(self, mgr):
+        with pytest.raises(ValueError):
+            await mgr.emit_event("nope", "c:1", {})
+
+
+class TestPollingFallback:
+    @pytest.mark.asyncio
+    async def test_empty_channel(self, mgr):
+        assert mgr.get_buffered_events("none") == []
+
+    @pytest.mark.asyncio
+    async def test_since_filter(self, mgr):
+        await mgr.emit_event("bounty_update", "b:f",
+            {"bounty_id": "o", "title": "O", "new_status": "open"})
+        assert len(mgr.get_buffered_events("b:f",
+            since=datetime.now(timezone.utc) + timedelta(seconds=1))) == 0
+
+    @pytest.mark.asyncio
+    async def test_limit(self, mgr):
+        for i in range(10):
+            await mgr.emit_event("bounty_update", "b:m",
+                {"bounty_id": f"b{i}", "title": f"B{i}", "new_status": "open"})
+        assert len(mgr.get_buffered_events("b:m", limit=3)) == 3
+
+
+class TestConnectionInfo:
+    @pytest.mark.asyncio
+    async def test_count(self, mgr):
+        assert mgr.get_connection_count() == 0
+        ws = FakeWebSocket()
+        cid = await mgr.connect(ws, VALID_TOKEN)
+        assert mgr.get_connection_count() == 1
+        await mgr.disconnect(cid)
+        assert mgr.get_connection_count() == 0
+
+    @pytest.mark.asyncio
+    async def test_channel_subscribers(self, connected):
+        mgr, cid, _ = connected
+        await mgr.subscribe(cid, "b:1")
+        assert mgr.get_channel_subscriber_count("b:1") == 1
+
+    @pytest.mark.asyncio
+    async def test_info_summary(self, connected):
+        mgr, cid, _ = connected
+        await mgr.subscribe(cid, "b:1")
+        info = mgr.get_connection_info()
+        assert info["active_connections"] == 1
+        assert "max_connections" in info
+
+
+class TestRESTEndpoints:
+    def test_event_types(self):
+        from app.main import app
+        r = TestClient(app).get("/api/events/types")
+        assert r.status_code == 200
+        assert len(r.json()["event_types"]) == 5
+
+    def test_status(self):
+        from app.main import app
+        r = TestClient(app).get("/api/events/status")
+        assert r.status_code == 200 and "active_connections" in r.json()
+
+    def test_channel_empty(self):
+        from app.main import app
+        r = TestClient(app).get("/api/events/bounty:none")
+        assert r.status_code == 200 and r.json()["count"] == 0
+
+    def test_channel_bad_since(self):
+        from app.main import app
+        r = TestClient(app).get("/api/events/b:1?since=bad")
+        assert r.status_code == 400


### PR DESCRIPTION
## Description

Extends the existing WebSocket server with typed event models, JWT authentication, connection management, and a polling fallback API.

Closes #166

### Features
- JWT auth with UUID fallback for dev mode
- 5 typed event models (bounty_update, pr_submitted, review_progress, payout_sent, claim_update)
- Connection limit (MAX_CONNECTIONS, env configurable)
- Event ring buffer for replay
- Polling fallback: GET /api/events/{channel}?since=ISO&limit=50
- GET /api/events/status — connection stats
- GET /api/events/types — available event types
- 29 new tests, 0 regressions on existing 22 tests
- Docstrings on all exports

## Solana Wallet for Payout
**Wallet:** `97VihHW2Br7BKUU16c7RxjiEMHsD4dWisGDT2Y3LyJxF`

## Checklist
- [x] Code is clean and tested
- [x] Follows the issue spec exactly
- [x] One PR per bounty
- [x] Tests included