### PR TITLE
feat: Agent Registration API (Closes #203)

### DIFF
--- a/backend/app/api/agents.py
+++ b/backend/app/api/agents.py
@@ -1,0 +1,52 @@
+"""Agent registration and management API router."""
+
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Query
+
+from app.models.agent import (
+    AgentCreate,
+    AgentListResponse,
+    AgentResponse,
+    AgentUpdate,
+)
+from app.services import agent_service
+
+router = APIRouter(prefix="/agents", tags=["agents"])
+
+
+@router.post("/register", response_model=AgentResponse, status_code=201)
+async def register_agent(data: AgentCreate):
+    return agent_service.register_agent(data)
+
+
+@router.get("", response_model=AgentListResponse)
+async def list_agents(
+    role: Optional[str] = Query(None, description="Filter by agent role"),
+    available: Optional[bool] = Query(None, alias="available", description="Filter by availability"),
+    page: int = Query(1, ge=1, description="Page number"),
+    limit: int = Query(20, ge=1, le=100, description="Items per page"),
+):
+    return agent_service.list_agents(role=role, available=available, page=page, limit=limit)
+
+
+@router.get("/{agent_id}", response_model=AgentResponse)
+async def get_agent(agent_id: str):
+    agent = agent_service.get_agent(agent_id)
+    if not agent:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    return agent
+
+
+@router.patch("/{agent_id}", response_model=AgentResponse)
+async def update_agent(agent_id: str, data: AgentUpdate):
+    agent = agent_service.update_agent(agent_id, data)
+    if not agent:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    return agent
+
+
+@router.delete("/{agent_id}", status_code=204)
+async def delete_agent(agent_id: str):
+    if not agent_service.delete_agent(agent_id):
+        raise HTTPException(status_code=404, detail="Agent not found")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,6 +7,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from app.api.agents import router as agents_router
 from app.api.auth import router as auth_router
 from app.api.contributors import router as contributors_router
 from app.api.bounties import router as bounties_router
@@ -83,6 +84,9 @@ app.add_middleware(
 # ── Route Registration ──────────────────────────────────────────────────────
 # Auth: /auth/* (prefix defined in router)
 app.include_router(auth_router)
+
+# Agents: /agents/* → /api prefix added here
+app.include_router(agents_router, prefix="/api")
 
 # Contributors: /contributors/* → needs /api prefix added here
 app.include_router(contributors_router, prefix="/api")

--- a/backend/app/models/agent.py
+++ b/backend/app/models/agent.py
@@ -1,0 +1,110 @@
+"""Agent database and Pydantic models."""
+
+import uuid
+from datetime import datetime, timezone
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
+from sqlalchemy import Boolean, Column, DateTime, Float, Integer, JSON, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+AgentRole = Literal[
+    "backend-engineer",
+    "frontend-engineer",
+    "scraping-engineer",
+    "bot-engineer",
+    "ai-engineer",
+    "security-analyst",
+    "systems-engineer",
+    "devops-engineer",
+    "smart-contract-engineer",
+]
+
+
+class AgentDB(Base):
+    __tablename__ = "agents"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    name = Column(String(100), nullable=False, index=True)
+    role = Column(String(50), nullable=False, index=True)
+    capabilities = Column(JSON, default=list, nullable=False)
+    languages = Column(JSON, default=list, nullable=False)
+    apis = Column(JSON, default=list, nullable=False)
+    operator_wallet = Column(String(100), nullable=False)
+    bio = Column(Text, nullable=True)
+    avatar_url = Column(String(500), nullable=True)
+    is_available = Column(Boolean, default=True, nullable=False)
+    is_active = Column(Boolean, default=True, nullable=False)
+    bounties_completed = Column(Integer, default=0, nullable=False)
+    total_earnings = Column(Float, default=0.0, nullable=False)
+    reputation_score = Column(Integer, default=0, nullable=False)
+    created_at = Column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+
+class AgentBase(BaseModel):
+    name: str = Field(..., min_length=1, max_length=100)
+    role: str
+    capabilities: list[str] = []
+    languages: list[str] = []
+    apis: list[str] = []
+    operator_wallet: str = Field(..., min_length=1, max_length=100)
+    bio: Optional[str] = None
+    avatar_url: Optional[str] = None
+
+
+class AgentCreate(AgentBase):
+    pass
+
+
+class AgentUpdate(BaseModel):
+    name: Optional[str] = Field(None, min_length=1, max_length=100)
+    bio: Optional[str] = None
+    avatar_url: Optional[str] = None
+    capabilities: Optional[list[str]] = None
+    languages: Optional[list[str]] = None
+    apis: Optional[list[str]] = None
+    is_available: Optional[bool] = None
+
+
+class AgentResponse(AgentBase):
+    id: str
+    is_available: bool
+    is_active: bool
+    bounties_completed: int
+    total_earnings: float
+    reputation_score: int
+    created_at: datetime
+    updated_at: datetime
+    model_config = {"from_attributes": True}
+
+
+class AgentListItem(BaseModel):
+    id: str
+    name: str
+    role: str
+    capabilities: list[str] = []
+    languages: list[str] = []
+    is_available: bool
+    bounties_completed: int
+    reputation_score: int
+    model_config = {"from_attributes": True}
+
+
+class AgentListResponse(BaseModel):
+    items: list[AgentListItem]
+    total: int
+    page: int
+    limit: int

--- a/backend/app/services/agent_service.py
+++ b/backend/app/services/agent_service.py
@@ -1,0 +1,122 @@
+"""In-memory agent service for MVP."""
+
+import uuid
+from datetime import datetime, timezone
+from typing import Optional
+
+from app.models.agent import (
+    AgentCreate,
+    AgentDB,
+    AgentListItem,
+    AgentListResponse,
+    AgentResponse,
+    AgentUpdate,
+)
+
+_store: dict[str, AgentDB] = {}
+
+
+def _db_to_response(db: AgentDB) -> AgentResponse:
+    return AgentResponse(
+        id=str(db.id),
+        name=db.name,
+        role=db.role,
+        capabilities=db.capabilities or [],
+        languages=db.languages or [],
+        apis=db.apis or [],
+        operator_wallet=db.operator_wallet,
+        bio=db.bio,
+        avatar_url=db.avatar_url,
+        is_available=db.is_available,
+        is_active=db.is_active,
+        bounties_completed=db.bounties_completed,
+        total_earnings=db.total_earnings,
+        reputation_score=db.reputation_score,
+        created_at=db.created_at,
+        updated_at=db.updated_at,
+    )
+
+
+def _db_to_list_item(db: AgentDB) -> AgentListItem:
+    return AgentListItem(
+        id=str(db.id),
+        name=db.name,
+        role=db.role,
+        capabilities=db.capabilities or [],
+        languages=db.languages or [],
+        is_available=db.is_available,
+        bounties_completed=db.bounties_completed,
+        reputation_score=db.reputation_score,
+    )
+
+
+def register_agent(data: AgentCreate) -> AgentResponse:
+    db = AgentDB(
+        id=uuid.uuid4(),
+        name=data.name,
+        role=data.role,
+        capabilities=data.capabilities,
+        languages=data.languages,
+        apis=data.apis,
+        operator_wallet=data.operator_wallet,
+        bio=data.bio,
+        avatar_url=data.avatar_url,
+        is_available=True,
+        is_active=True,
+        bounties_completed=0,
+        total_earnings=0.0,
+        reputation_score=0,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    _store[str(db.id)] = db
+    return _db_to_response(db)
+
+
+def list_agents(
+    role: Optional[str] = None,
+    available: Optional[bool] = None,
+    page: int = 1,
+    limit: int = 20,
+) -> AgentListResponse:
+    results = [r for r in _store.values() if r.is_active]
+    if role:
+        results = [r for r in results if r.role == role]
+    if available is not None:
+        results = [r for r in results if r.is_available == available]
+    total = len(results)
+    skip = (page - 1) * limit
+    return AgentListResponse(
+        items=[_db_to_list_item(r) for r in results[skip : skip + limit]],
+        total=total,
+        page=page,
+        limit=limit,
+    )
+
+
+def get_agent(agent_id: str) -> Optional[AgentResponse]:
+    db = _store.get(agent_id)
+    if not db or not db.is_active:
+        return None
+    return _db_to_response(db)
+
+
+def update_agent(
+    agent_id: str, data: AgentUpdate
+) -> Optional[AgentResponse]:
+    db = _store.get(agent_id)
+    if not db or not db.is_active:
+        return None
+    for key, value in data.model_dump(exclude_unset=True).items():
+        setattr(db, key, value)
+    db.updated_at = datetime.now(timezone.utc)
+    return _db_to_response(db)
+
+
+def delete_agent(agent_id: str) -> bool:
+    db = _store.get(agent_id)
+    if not db:
+        return False
+    db.is_active = False
+    db.updated_at = datetime.now(timezone.utc)
+    return True

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -1,0 +1,200 @@
+"""Tests for agent registration and management API."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.services import agent_service
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def clear_store():
+    agent_service._store.clear()
+    yield
+    agent_service._store.clear()
+
+
+def _make_payload(**overrides):
+    defaults = {
+        "name": "TestAgent",
+        "role": "ai-engineer",
+        "capabilities": ["nlp", "code-generation"],
+        "languages": ["python", "typescript"],
+        "apis": ["openai", "anthropic"],
+        "operator_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+    }
+    defaults.update(overrides)
+    return defaults
+
+
+def _register(**overrides):
+    resp = client.post("/api/agents/register", json=_make_payload(**overrides))
+    assert resp.status_code == 201
+    return resp.json()
+
+
+# ── Create ───────────────────────────────────────────────────────────────────
+
+def test_register_success():
+    resp = client.post("/api/agents/register", json=_make_payload())
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["name"] == "TestAgent"
+    assert data["role"] == "ai-engineer"
+    assert data["is_available"] is True
+    assert data["is_active"] is True
+    assert data["bounties_completed"] == 0
+
+
+def test_register_all_roles():
+    roles = [
+        "backend-engineer",
+        "frontend-engineer",
+        "scraping-engineer",
+        "bot-engineer",
+        "ai-engineer",
+        "security-analyst",
+        "systems-engineer",
+        "devops-engineer",
+        "smart-contract-engineer",
+    ]
+    for i, role in enumerate(roles):
+        resp = client.post(
+            "/api/agents/register",
+            json=_make_payload(name=f"Agent{i}", role=role),
+        )
+        assert resp.status_code == 201, f"Failed for role: {role}"
+
+
+def test_register_missing_required_field():
+    payload = _make_payload()
+    del payload["operator_wallet"]
+    resp = client.post("/api/agents/register", json=payload)
+    assert resp.status_code == 422
+
+
+# ── Get by ID ─────────────────────────────────────────────────────────────────
+
+def test_get_agent_by_id():
+    agent = _register()
+    resp = client.get(f"/api/agents/{agent['id']}")
+    assert resp.status_code == 200
+    assert resp.json()["id"] == agent["id"]
+
+
+def test_get_agent_not_found():
+    resp = client.get("/api/agents/nonexistent-id")
+    assert resp.status_code == 404
+
+
+# ── List ──────────────────────────────────────────────────────────────────────
+
+def test_list_empty():
+    resp = client.get("/api/agents")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 0
+    assert data["items"] == []
+
+
+def test_list_with_agents():
+    _register(name="Agent1")
+    _register(name="Agent2")
+    resp = client.get("/api/agents")
+    assert resp.status_code == 200
+    assert resp.json()["total"] == 2
+
+
+def test_list_filter_by_role():
+    _register(name="AIAgent", role="ai-engineer")
+    _register(name="BackendAgent", role="backend-engineer")
+    _register(name="AIAgent2", role="ai-engineer")
+    resp = client.get("/api/agents?role=ai-engineer")
+    data = resp.json()
+    assert data["total"] == 2
+    for item in data["items"]:
+        assert item["role"] == "ai-engineer"
+
+
+def test_list_filter_by_available():
+    agent1 = _register(name="Agent1")
+    _register(name="Agent2")
+    # Mark agent1 as unavailable
+    client.patch(f"/api/agents/{agent1['id']}", json={"is_available": False})
+    resp = client.get("/api/agents?available=true")
+    data = resp.json()
+    assert data["total"] == 1
+    assert data["items"][0]["name"] == "Agent2"
+
+
+def test_list_pagination():
+    for i in range(5):
+        _register(name=f"Agent{i}")
+    resp = client.get("/api/agents?page=1&limit=2")
+    data = resp.json()
+    assert data["total"] == 5
+    assert len(data["items"]) == 2
+    assert data["page"] == 1
+    assert data["limit"] == 2
+
+
+def test_list_pagination_page2():
+    for i in range(5):
+        _register(name=f"Agent{i}")
+    resp = client.get("/api/agents?page=2&limit=3")
+    data = resp.json()
+    assert data["total"] == 5
+    assert len(data["items"]) == 2  # 5 total, page 2 of 3 = 2 remaining
+
+
+# ── Update ────────────────────────────────────────────────────────────────────
+
+def test_update_capabilities():
+    agent = _register()
+    resp = client.patch(
+        f"/api/agents/{agent['id']}",
+        json={"capabilities": ["vision", "reasoning"]},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["capabilities"] == ["vision", "reasoning"]
+
+
+def test_update_availability():
+    agent = _register()
+    resp = client.patch(f"/api/agents/{agent['id']}", json={"is_available": False})
+    assert resp.status_code == 200
+    assert resp.json()["is_available"] is False
+
+
+def test_update_not_found():
+    resp = client.patch("/api/agents/nonexistent", json={"bio": "test"})
+    assert resp.status_code == 404
+
+
+# ── Delete (soft) ─────────────────────────────────────────────────────────────
+
+def test_delete_agent():
+    agent = _register()
+    resp = client.delete(f"/api/agents/{agent['id']}")
+    assert resp.status_code == 204
+
+
+def test_delete_agent_hides_from_list():
+    agent = _register()
+    client.delete(f"/api/agents/{agent['id']}")
+    resp = client.get("/api/agents")
+    assert resp.json()["total"] == 0
+
+
+def test_delete_agent_hides_from_get():
+    agent = _register()
+    client.delete(f"/api/agents/{agent['id']}")
+    resp = client.get(f"/api/agents/{agent['id']}")
+    assert resp.status_code == 404
+
+
+def test_delete_not_found():
+    resp = client.delete("/api/agents/nonexistent")
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
Implements a full CRUD REST API for agent registration and management, following the exact same patterns as the existing contributors API.

## Changes
- `backend/app/models/agent.py` — Pydantic models: `AgentCreate`, `AgentResponse`, `AgentListResponse`, `AgentUpdate`, `AgentListItem`
- `backend/app/services/agent_service.py` — In-memory dict store with register, list, get, update, soft-delete operations
- `backend/app/api/agents.py` — FastAPI router: `POST /api/agents/register`, `GET /api/agents`, `GET /api/agents/{id}`, `PATCH /api/agents/{id}`, `DELETE /api/agents/{id}`
- `backend/app/main.py` — Wired agents router at `/api` prefix
- `backend/tests/test_agents.py` — 15 tests covering create, get, list, update, delete, pagination, role filter, availability filter

## Testing
```bash
cd backend && pytest tests/test_agents.py -v
```
Tests cover: registration, all 9 agent roles, missing fields, get by ID, 404 cases, list empty/populated, filter by role, filter by availability, pagination (page 1 & 2), update capabilities/availability, soft delete, delete hides from list and get.

## Solana Wallet
`7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU`