### PR TITLE
feat: Loading Skeletons & Empty States (Closes #262)

### DIFF
--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -1,0 +1,211 @@
+/**
+ * EmptyState — Centered empty / zero-data UI components for SolFoundry.
+ *
+ * Components:
+ * - <EmptyState />              — generic, fully customisable
+ * - <EmptyStateBounties />      — pre-built for the bounties list
+ * - <EmptyStateContributors />  — pre-built for the contributors list
+ * - <EmptyStateActivity />      — pre-built for the activity feed
+ *
+ * @module EmptyState
+ */
+import React from 'react';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface EmptyStateAction {
+  label: string;
+  onClick: () => void;
+}
+
+export interface EmptyStateProps {
+  /** Optional icon / illustration (React node) */
+  icon?: React.ReactNode;
+  /** Bold heading */
+  title: string;
+  /** Muted supporting message */
+  message: string;
+  /** Optional primary call-to-action button */
+  action?: EmptyStateAction;
+  /** Extra Tailwind classes on the root element */
+  className?: string;
+}
+
+// ─── Default Icons ────────────────────────────────────────────────────────────
+
+function BountiesIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="w-12 h-12"
+    >
+      <circle cx="12" cy="12" r="10" />
+      <path d="M12 8v4l3 3" />
+    </svg>
+  );
+}
+
+function ContributorsIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="w-12 h-12"
+    >
+      <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+      <circle cx="9" cy="7" r="4" />
+      <path d="M23 21v-2a4 4 0 0 0-3-3.87" />
+      <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+    </svg>
+  );
+}
+
+function ActivityIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="w-12 h-12"
+    >
+      <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
+    </svg>
+  );
+}
+
+// ─── EmptyState ───────────────────────────────────────────────────────────────
+
+/**
+ * EmptyState — generic centred placeholder shown when there is no data to display.
+ */
+export function EmptyState({
+  icon,
+  title,
+  message,
+  action,
+  className = '',
+}: EmptyStateProps) {
+  return (
+    <div
+      className={`
+        flex flex-col items-center justify-center text-center
+        py-16 px-6 gap-4
+        ${className}
+      `}
+    >
+      {/* Icon */}
+      {icon && (
+        <span className="text-gray-500 opacity-50 mb-2" aria-hidden="true">
+          {icon}
+        </span>
+      )}
+
+      {/* Title */}
+      <h3 className="text-lg font-semibold text-white">{title}</h3>
+
+      {/* Message */}
+      <p className="text-sm text-gray-400 max-w-sm">{message}</p>
+
+      {/* CTA */}
+      {action && (
+        <button
+          type="button"
+          onClick={action.onClick}
+          className="
+            mt-2 px-5 py-2.5 rounded-lg
+            bg-[#9945FF] hover:bg-[#9945FF]/80
+            text-sm font-medium text-white
+            transition-colors duration-150
+            focus:outline-none focus:ring-2 focus:ring-[#9945FF]/50
+          "
+        >
+          {action.label}
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ─── Pre-built variants ───────────────────────────────────────────────────────
+
+export interface EmptyStateBountiesProps {
+  onCreateBounty?: () => void;
+  className?: string;
+}
+
+/**
+ * EmptyStateBounties — shown when no bounties match the current filter.
+ */
+export function EmptyStateBounties({
+  onCreateBounty,
+  className = '',
+}: EmptyStateBountiesProps) {
+  return (
+    <EmptyState
+      icon={<BountiesIcon />}
+      title="No bounties found"
+      message="There are no open bounties right now. Be the first to post one and attract top contributors from the Solana ecosystem."
+      action={
+        onCreateBounty
+          ? { label: 'Post a Bounty', onClick: onCreateBounty }
+          : undefined
+      }
+      className={className}
+    />
+  );
+}
+
+export interface EmptyStateContributorsProps {
+  className?: string;
+}
+
+/**
+ * EmptyStateContributors — shown when a project has no contributors yet.
+ */
+export function EmptyStateContributors({
+  className = '',
+}: EmptyStateContributorsProps) {
+  return (
+    <EmptyState
+      icon={<ContributorsIcon />}
+      title="No contributors yet"
+      message="No one has claimed a bounty on this project yet. Submit a PR and be the first contributor to earn $FNDRY rewards."
+      className={className}
+    />
+  );
+}
+
+export interface EmptyStateActivityProps {
+  className?: string;
+}
+
+/**
+ * EmptyStateActivity — shown when the activity feed is empty.
+ */
+export function EmptyStateActivity({ className = '' }: EmptyStateActivityProps) {
+  return (
+    <EmptyState
+      icon={<ActivityIcon />}
+      title="No recent activity"
+      message="Nothing has happened here yet. Activity appears as bounties are posted, PRs are submitted, and rewards are paid out."
+      className={className}
+    />
+  );
+}
+
+export default EmptyState;

--- a/frontend/src/components/Skeleton.tsx
+++ b/frontend/src/components/Skeleton.tsx
@@ -1,0 +1,168 @@
+/**
+ * Skeleton — Animated loading placeholder components for SolFoundry.
+ *
+ * Components:
+ * - <Skeleton />          — single animated pulse bar
+ * - <SkeletonCard />      — card with title, content lines, and footer
+ * - <SkeletonList />      — n × SkeletonCard
+ * - <SkeletonTable />     — rows × cols table skeleton
+ *
+ * All use Tailwind animate-pulse with gray-700 background to match the dark theme.
+ *
+ * @module Skeleton
+ */
+import React from 'react';
+
+// ─── Base Skeleton ─────────────────────────────────────────────────────────────
+
+export interface SkeletonProps {
+  /** Extra Tailwind classes (width, height, rounded, etc.) */
+  className?: string;
+}
+
+/**
+ * Skeleton — a single animated pulse placeholder.
+ *
+ * @example
+ *   <Skeleton className="h-4 w-32 rounded" />
+ */
+export function Skeleton({ className = '' }: SkeletonProps) {
+  return (
+    <div
+      aria-hidden="true"
+      className={`bg-gray-700 animate-pulse rounded ${className}`}
+    />
+  );
+}
+
+// ─── Skeleton Card ────────────────────────────────────────────────────────────
+
+export interface SkeletonCardProps {
+  /** Extra Tailwind classes on the card wrapper */
+  className?: string;
+}
+
+/**
+ * SkeletonCard — card-shaped skeleton with a title bar, 3 content lines, and footer.
+ */
+export function SkeletonCard({ className = '' }: SkeletonCardProps) {
+  return (
+    <div
+      aria-hidden="true"
+      aria-label="Loading content"
+      className={`
+        bg-gray-800 border border-white/10 rounded-xl p-5 space-y-4
+        ${className}
+      `}
+    >
+      {/* Header row: title + badge placeholder */}
+      <div className="flex items-center justify-between gap-4">
+        <Skeleton className="h-5 w-2/5 rounded" />
+        <Skeleton className="h-5 w-16 rounded-full" />
+      </div>
+
+      {/* Content lines */}
+      <div className="space-y-2">
+        <Skeleton className="h-3.5 w-full rounded" />
+        <Skeleton className="h-3.5 w-11/12 rounded" />
+        <Skeleton className="h-3.5 w-4/6 rounded" />
+      </div>
+
+      {/* Footer row */}
+      <div className="flex items-center justify-between pt-2 border-t border-white/5 gap-4">
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-6 w-6 rounded-full" />
+          <Skeleton className="h-3.5 w-20 rounded" />
+        </div>
+        <Skeleton className="h-7 w-24 rounded-lg" />
+      </div>
+    </div>
+  );
+}
+
+// ─── Skeleton List ────────────────────────────────────────────────────────────
+
+export interface SkeletonListProps {
+  /** Number of SkeletonCards to render (default: 3) */
+  count?: number;
+  /** Extra Tailwind classes on the list wrapper */
+  className?: string;
+}
+
+/**
+ * SkeletonList — renders `count` SkeletonCard placeholders in a vertical list.
+ */
+export function SkeletonList({ count = 3, className = '' }: SkeletonListProps) {
+  return (
+    <div
+      aria-label="Loading list"
+      aria-busy="true"
+      className={`space-y-4 ${className}`}
+    >
+      {Array.from({ length: count }, (_, i) => (
+        <SkeletonCard key={i} />
+      ))}
+    </div>
+  );
+}
+
+// ─── Skeleton Table ───────────────────────────────────────────────────────────
+
+export interface SkeletonTableProps {
+  /** Number of data rows (default: 5) */
+  rows?: number;
+  /** Number of columns (default: 4) */
+  cols?: number;
+  /** Extra Tailwind classes on the table wrapper */
+  className?: string;
+}
+
+/**
+ * SkeletonTable — renders an animated table skeleton with header + body rows.
+ */
+export function SkeletonTable({
+  rows = 5,
+  cols = 4,
+  className = '',
+}: SkeletonTableProps) {
+  return (
+    <div
+      aria-label="Loading table"
+      aria-busy="true"
+      className={`
+        bg-gray-800 border border-white/10 rounded-xl overflow-hidden
+        ${className}
+      `}
+    >
+      {/* Table header */}
+      <div className="flex gap-3 px-5 py-3 border-b border-white/10 bg-gray-900/50">
+        {Array.from({ length: cols }, (_, i) => (
+          <Skeleton
+            key={i}
+            className={`h-3.5 rounded flex-1 ${i === 0 ? 'max-w-[8rem]' : ''}`}
+          />
+        ))}
+      </div>
+
+      {/* Table body */}
+      <div className="divide-y divide-white/5">
+        {Array.from({ length: rows }, (_, rowIdx) => (
+          <div key={rowIdx} className="flex gap-3 px-5 py-4 items-center">
+            {Array.from({ length: cols }, (_, colIdx) => (
+              <Skeleton
+                key={colIdx}
+                className={`
+                  h-3.5 rounded flex-1
+                  ${colIdx === 0 ? 'max-w-[8rem]' : ''}
+                  ${rowIdx % 2 === 1 ? 'opacity-80' : ''}
+                `}
+              />
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default Skeleton;


### PR DESCRIPTION
## Summary
Adds a complete set of animated loading skeleton placeholders and empty-state components. Skeletons use Tailwind `animate-pulse` and match the existing dark theme. Empty states feature icons, titles, muted descriptions, and optional CTA buttons.

## Changes
- `frontend/src/components/Skeleton.tsx` — Skeleton, SkeletonCard, SkeletonList, SkeletonTable
- `frontend/src/components/EmptyState.tsx` — EmptyState, EmptyStateBounties, EmptyStateContributors, EmptyStateActivity

Closes #262

## Solana Wallet
`7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU`