### PR TITLE
feat(frontend): add FNDRY token price display component

### DIFF
--- a/frontend/src/__tests__/TokenomicsPage.test.tsx
+++ b/frontend/src/__tests__/TokenomicsPage.test.tsx
@@ -32,7 +32,7 @@ describe('TokenomicsPage', () => {
     await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(/FNDRY Tokenomics/));
     expect(screen.getByText(/Total Supply/)).toBeInTheDocument();
     expect(screen.getByText(/Circulating/)).toBeInTheDocument();
-    expect(screen.getByText(/Treasury/)).toBeInTheDocument();
+    expect(screen.getByText(/^Treasury$/)).toBeInTheDocument();
     expect(screen.getByText(/Distributed/)).toBeInTheDocument();
   });
 

--- a/frontend/src/components/common/TokenPrice.test.tsx
+++ b/frontend/src/components/common/TokenPrice.test.tsx
@@ -1,0 +1,78 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TokenPrice } from './TokenPrice';
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+const mockResponse = {
+  pairs: [
+    {
+      priceUsd: '0.0042',
+      marketCap: 24_200,
+      volume: { h24: 9_500 },
+      priceChange: { h24: 3.56 },
+    },
+  ],
+};
+
+describe('TokenPrice', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('shows loading state while first request is pending', () => {
+    mockFetch.mockReturnValue(new Promise(() => {}));
+    render(<TokenPrice mode="compact" />);
+
+    expect(screen.getByRole('status', { name: /loading token price/i })).toBeInTheDocument();
+  });
+
+  it('renders compact mode with price and 24h change', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve(mockResponse) });
+    render(<TokenPrice mode="compact" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('$0.0042')).toBeInTheDocument();
+    });
+    expect(screen.getByText('+3.56%')).toBeInTheDocument();
+    expect(screen.queryByText('Market Cap')).not.toBeInTheDocument();
+  });
+
+  it('renders full mode with market cap and 24h volume formatting', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve(mockResponse) });
+    render(<TokenPrice mode="full" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('$0.0042')).toBeInTheDocument();
+    });
+    expect(screen.getByText('24h Change')).toBeInTheDocument();
+    expect(screen.getByText('Market Cap')).toBeInTheDocument();
+    expect(screen.getByText('$24.2K')).toBeInTheDocument();
+    expect(screen.getByText('24h Volume')).toBeInTheDocument();
+    expect(screen.getByText('$9.5K')).toBeInTheDocument();
+  });
+
+  it('shows error state when API fails', async () => {
+    mockFetch.mockRejectedValue(new Error('Network error'));
+    render(<TokenPrice mode="compact" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Price unavailable')).toBeInTheDocument();
+    });
+  });
+
+  it('auto-refreshes every 60 seconds', async () => {
+    vi.useFakeTimers();
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve(mockResponse) });
+
+    render(<TokenPrice mode="compact" />);
+    await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/components/common/TokenPrice.tsx
+++ b/frontend/src/components/common/TokenPrice.tsx
@@ -1,0 +1,182 @@
+import { useEffect, useMemo, useState } from 'react';
+
+type TokenPriceMode = 'compact' | 'full';
+
+interface TokenPriceData {
+  priceUsd: number;
+  priceChange24h: number;
+  marketCap: number;
+  volume24h: number;
+}
+
+interface DexScreenerPair {
+  priceUsd?: string;
+  marketCap?: number;
+  fdv?: number;
+  volume?: {
+    h24?: number;
+  };
+  priceChange?: {
+    h24?: number;
+  };
+}
+
+interface DexScreenerResponse {
+  pairs?: DexScreenerPair[];
+}
+
+export interface TokenPriceProps {
+  mode?: TokenPriceMode;
+  className?: string;
+  refreshMs?: number;
+}
+
+const TOKEN_ADDRESS = 'C2TvY8E8B75EF2UP8cTpTp3EDUjTgjWmpaGnT74VBAGS';
+const DEXSCREENER_URL = `https://api.dexscreener.com/latest/dex/tokens/${TOKEN_ADDRESS}`;
+const DEFAULT_REFRESH_MS = 60_000;
+
+function formatPrice(value: number) {
+  const fractionDigits = Math.abs(value) >= 1 ? 2 : 4;
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  }).format(value);
+}
+
+function formatCompactUsd(value: number) {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    notation: 'compact',
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  }).format(value);
+}
+
+function formatChange(value: number) {
+  const sign = value > 0 ? '+' : '';
+  return `${sign}${value.toFixed(2)}%`;
+}
+
+function parseDexScreenerResponse(data: DexScreenerResponse): TokenPriceData {
+  const pair = data.pairs?.[0];
+  if (!pair || !pair.priceUsd) {
+    throw new Error('Price unavailable');
+  }
+
+  return {
+    priceUsd: Number(pair.priceUsd),
+    priceChange24h: pair.priceChange?.h24 ?? 0,
+    marketCap: pair.marketCap ?? pair.fdv ?? 0,
+    volume24h: pair.volume?.h24 ?? 0,
+  };
+}
+
+export function TokenPrice({ mode = 'compact', className = '', refreshMs = DEFAULT_REFRESH_MS }: TokenPriceProps) {
+  const [data, setData] = useState<TokenPriceData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const fetchTokenPrice = async () => {
+      try {
+        const response = await fetch(DEXSCREENER_URL);
+        if (!response.ok) {
+          throw new Error('Price unavailable');
+        }
+
+        const parsed = parseDexScreenerResponse(await response.json());
+        if (mounted) {
+          setData(parsed);
+          setError(false);
+        }
+      } catch {
+        if (mounted) {
+          setError(true);
+        }
+      } finally {
+        if (mounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchTokenPrice();
+    const intervalId = window.setInterval(fetchTokenPrice, refreshMs);
+
+    return () => {
+      mounted = false;
+      window.clearInterval(intervalId);
+    };
+  }, [refreshMs]);
+
+  const changeClasses = useMemo(() => {
+    if (!data) {
+      return 'text-gray-400';
+    }
+    if (data.priceChange24h > 0) {
+      return 'text-emerald-400';
+    }
+    if (data.priceChange24h < 0) {
+      return 'text-red-400';
+    }
+    return 'text-gray-400';
+  }, [data]);
+
+  if (loading) {
+    return (
+      <div
+        role="status"
+        aria-label="Loading token price"
+        className={`inline-flex items-center gap-2 ${className}`.trim()}
+      >
+        <span className="h-2 w-14 rounded-full bg-white/10 animate-pulse" />
+        {mode === 'full' && <span className="h-2 w-20 rounded-full bg-white/10 animate-pulse" />}
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className={`text-sm text-gray-400 ${className}`.trim()} role="status">
+        Price unavailable
+      </div>
+    );
+  }
+
+  if (mode === 'compact') {
+    return (
+      <div className={`inline-flex items-center gap-2 rounded-lg border border-white/10 bg-white/5 px-3 py-1.5 ${className}`.trim()}>
+        <span className="text-sm font-semibold text-white">{formatPrice(data.priceUsd)}</span>
+        <span className={`text-xs font-medium ${changeClasses}`}>{formatChange(data.priceChange24h)}</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`grid grid-cols-2 md:grid-cols-4 gap-4 ${className}`.trim()}>
+      <div className="rounded-xl border border-gray-700 bg-surface-100 p-4">
+        <p className="text-xs text-gray-400">Price</p>
+        <p className="text-xl font-bold text-white mt-1">{formatPrice(data.priceUsd)}</p>
+      </div>
+      <div className="rounded-xl border border-gray-700 bg-surface-100 p-4">
+        <p className="text-xs text-gray-400">24h Change</p>
+        <p className={`text-xl font-bold mt-1 ${changeClasses}`}>{formatChange(data.priceChange24h)}</p>
+      </div>
+      <div className="rounded-xl border border-gray-700 bg-surface-100 p-4">
+        <p className="text-xs text-gray-400">Market Cap</p>
+        <p className="text-xl font-bold text-white mt-1">{formatCompactUsd(data.marketCap)}</p>
+      </div>
+      <div className="rounded-xl border border-gray-700 bg-surface-100 p-4">
+        <p className="text-xs text-gray-400">24h Volume</p>
+        <p className="text-xl font-bold text-white mt-1">{formatCompactUsd(data.volume24h)}</p>
+      </div>
+    </div>
+  );
+}
+
+export default TokenPrice;

--- a/frontend/src/components/common/index.ts
+++ b/frontend/src/components/common/index.ts
@@ -11,3 +11,5 @@ export type { EmptyStateProps, EmptyStateVariant, NoBountiesProps, NoContributio
 export { Toast } from './Toast';
 export type { ToastProps } from './Toast';
 export { ToastContainer } from './ToastContainer';
+export { TokenPrice } from './TokenPrice';
+export type { TokenPriceProps } from './TokenPrice';

--- a/frontend/src/components/layout/SiteLayout.tsx
+++ b/frontend/src/components/layout/SiteLayout.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import OnboardingWizard from '../OnboardingWizard';
 import { ThemeToggle } from './ThemeToggle';
+import { TokenPrice } from '../common';
 
 // ============================================================================
 // Types
@@ -265,6 +266,8 @@ function Header({
 
         {/* Right: Actions */}
         <div className="flex items-center gap-3">
+          <TokenPrice mode="compact" className="hidden lg:inline-flex" />
+
           {/* Theme Toggle */}
           <ThemeToggle />
 

--- a/frontend/src/components/tokenomics/TokenomicsPage.tsx
+++ b/frontend/src/components/tokenomics/TokenomicsPage.tsx
@@ -1,4 +1,5 @@
 import { useTreasuryStats } from '../../hooks/useTreasuryStats';
+import { TokenPrice } from '../common';
 
 /** Format a number for display: 1B / 200M / 10K / locale string. */
 const fmt = (n: number) => n >= 1e9 ? `${(n/1e9).toFixed(1)}B` : n >= 1e6 ? `${(n/1e6).toFixed(1)}M` : n >= 1e3 ? `${(n/1e3).toFixed(1)}K` : n.toLocaleString();
@@ -62,6 +63,9 @@ export function TokenomicsPage() {
         <h1 className="text-2xl font-bold text-white">{t.tokenName} Tokenomics</h1>
         <p className="text-sm text-gray-400 mt-1">Contract: <code className="text-xs">{t.tokenCA}</code></p>
       </div>
+
+      <TokenPrice mode="full" />
+
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         <StatCard label="Total Supply" value={fmt(t.totalSupply)} />
         <StatCard label="Circulating" value={fmt(t.circulatingSupply)} sub={`${pct(t.circulatingSupply, t.totalSupply)}% of supply`} />


### PR DESCRIPTION
## Summary
- Add TokenPrice component with DexScreener fetch for FNDRY token
- Implement compact mode (navbar) and full mode (tokenomics page)
- Add loading/error states and 60s auto-refresh
- Add unit tests for loading, error, formatting, API mock, and refresh

## Files
- frontend/src/components/common/TokenPrice.tsx
- frontend/src/components/common/TokenPrice.test.tsx
- frontend/src/components/common/index.ts
- frontend/src/components/layout/SiteLayout.tsx
- frontend/src/components/tokenomics/TokenomicsPage.tsx
- frontend/src/__tests__/TokenomicsPage.test.tsx

## Issue
- Closes #347

Wallet Address : 3CZ9kv5yYyMb8gr6u8ZRCt2wgehZBZdJo8HnMr9XNCzR

## Test
- npm test -- src/components/common/TokenPrice.test.tsx
- npm test -- src/components/common/TokenPrice.test.tsx src/__tests__/TokenomicsPage.test.tsx