### PR TITLE
feat: add /health endpoint with DB and Redis connectivity checks

### DIFF
--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -1,0 +1,69 @@
+"""Health check endpoint for uptime monitoring and load balancers."""
+
+import logging
+import os
+import time
+from datetime import datetime, timezone
+
+from fastapi import APIRouter
+from sqlalchemy import text
+
+from app.database import engine
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["health"])
+
+# Module-level start time for uptime calculation
+_start_time: float = time.monotonic()
+
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+
+
+async def _check_database() -> str:
+    try:
+        async with engine.connect() as conn:
+            await conn.execute(text("SELECT 1"))
+        return "connected"
+    except Exception as e:
+        logger.warning("Health check: database unreachable: %s", e)
+        return "disconnected"
+
+
+async def _check_redis() -> str:
+    try:
+        import redis.asyncio as aioredis
+
+        r = aioredis.from_url(REDIS_URL, socket_connect_timeout=2)
+        await r.ping()
+        await r.aclose()
+        return "connected"
+    except Exception as e:
+        logger.warning("Health check: redis unreachable: %s", e)
+        return "disconnected"
+
+
+@router.get("/health", summary="Service health check")
+async def health_check() -> dict:
+    """Return service status including database and Redis connectivity.
+
+    No authentication required. Designed to be fast (< 500ms).
+    Returns 200 in both healthy and degraded states so load balancers
+    can distinguish a live-but-degraded service from a hard failure.
+    """
+    db_status, redis_status = await _check_database(), await _check_redis()
+
+    overall = (
+        "healthy" if db_status == "connected" and redis_status == "connected" else "degraded"
+    )
+
+    return {
+        "status": overall,
+        "version": "1.0.0",
+        "uptime_seconds": round(time.monotonic() - _start_time),
+        "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "services": {
+            "database": db_status,
+            "redis": redis_status,
+        },
+    }

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.contributors import router as contributors_router
+from app.api.health import router as health_router
 from app.api.leaderboard import router as leaderboard_router
 from app.api.webhooks.github import router as github_webhook_router
 
@@ -31,8 +32,4 @@ app.add_middleware(
 app.include_router(contributors_router)
 app.include_router(leaderboard_router)
 app.include_router(github_webhook_router, prefix="/api/webhooks", tags=["webhooks"])
-
-
-@app.get("/health")
-async def health_check():
-    return {"status": "ok"}
+app.include_router(health_router)

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,99 @@
+"""Unit tests for the /health endpoint (Issue #343).
+
+Covers four scenarios:
+- All services healthy
+- Database down
+- Redis down
+- Both down
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from fastapi import FastAPI
+
+from app.api.health import router as health_router
+
+# Minimal test app
+_test_app = FastAPI()
+_test_app.include_router(health_router)
+
+
+@pytest.mark.asyncio
+async def test_health_all_services_up():
+    """Returns 'healthy' when DB and Redis are both reachable."""
+    with (
+        patch("app.api.health._check_database", new=AsyncMock(return_value="connected")),
+        patch("app.api.health._check_redis", new=AsyncMock(return_value="connected")),
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=_test_app), base_url="http://test"
+        ) as client:
+            resp = await client.get("/health")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "healthy"
+    assert data["version"] == "1.0.0"
+    assert isinstance(data["uptime_seconds"], int)
+    assert "timestamp" in data
+    assert data["services"]["database"] == "connected"
+    assert data["services"]["redis"] == "connected"
+
+
+@pytest.mark.asyncio
+async def test_health_database_down():
+    """Returns 'degraded' and marks database as 'disconnected' when DB is unreachable."""
+    with (
+        patch("app.api.health._check_database", new=AsyncMock(return_value="disconnected")),
+        patch("app.api.health._check_redis", new=AsyncMock(return_value="connected")),
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=_test_app), base_url="http://test"
+        ) as client:
+            resp = await client.get("/health")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "degraded"
+    assert data["services"]["database"] == "disconnected"
+    assert data["services"]["redis"] == "connected"
+
+
+@pytest.mark.asyncio
+async def test_health_redis_down():
+    """Returns 'degraded' and marks redis as 'disconnected' when Redis is unreachable."""
+    with (
+        patch("app.api.health._check_database", new=AsyncMock(return_value="connected")),
+        patch("app.api.health._check_redis", new=AsyncMock(return_value="disconnected")),
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=_test_app), base_url="http://test"
+        ) as client:
+            resp = await client.get("/health")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "degraded"
+    assert data["services"]["database"] == "connected"
+    assert data["services"]["redis"] == "disconnected"
+
+
+@pytest.mark.asyncio
+async def test_health_both_services_down():
+    """Returns 'degraded' with both services 'disconnected'."""
+    with (
+        patch("app.api.health._check_database", new=AsyncMock(return_value="disconnected")),
+        patch("app.api.health._check_redis", new=AsyncMock(return_value="disconnected")),
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=_test_app), base_url="http://test"
+        ) as client:
+            resp = await client.get("/health")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "degraded"
+    assert data["services"]["database"] == "disconnected"
+    assert data["services"]["redis"] == "disconnected"


### PR DESCRIPTION
Closes #343

## Summary

- Added `backend/app/api/health.py` with a proper `GET /health` router that meets the full bounty spec
- Replaced the stub one-liner in `main.py` with the new router
- Database checked via `SELECT 1` using the existing `engine`; Redis checked via `ping` using `REDIS_URL` env var (same source as the WebSocket manager)
- Returns `"healthy"` when both services are up, `"degraded"` when either is down, with per-service `"connected"` / `"disconnected"` detail
- No new dependencies added

## Response format

```json
{
  "status": "healthy",
  "version": "1.0.0",
  "uptime_seconds": 42,
  "timestamp": "2026-03-21T12:00:00Z",
  "services": {
    "database": "connected",
    "redis": "connected"
  }
}
```

## Tests (`backend/tests/test_health.py`)

| Scenario | Expected `status` |
|---|---|
| Both services up | `healthy` |
| DB down | `degraded`, `database: disconnected` |
| Redis down | `degraded`, `redis: disconnected` |
| Both down | `degraded`, both `disconnected` |

## Solana wallet for bounty payout

`brutusworker-arch.sol` — please DM on Discord or comment here to confirm payout address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a `/health` endpoint that reports system status and individual service connectivity (database and Redis)
  * Returns real-time metrics including uptime, timestamp, and per-service health indicators
  * Overall status displays as "healthy" when all services are connected, or "degraded" when issues are detected

* **Tests**
  * Added comprehensive test suite for the health check endpoint

<!-- end of auto-generated comment: release notes by coderabbit.ai -->