### PR TITLE
Bounty: Backend Health Check Endpoint - 50,000 $FNDRY

### DIFF
--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -1,0 +1,107 @@
+"""Health check endpoint for monitoring and load balancers.
+
+Public endpoint that returns system status including database and Redis connectivity.
+"""
+
+import logging
+import os
+import time
+from datetime import datetime, timezone
+from typing import Dict, Optional
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+from sqlalchemy import text
+
+from app.database import engine
+
+logger = logging.getLogger(__name__)
+
+# Track application start time for uptime calculation
+_start_time: float = time.time()
+
+# Redis URL from environment
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+
+
+class HealthResponse(BaseModel):
+    """Health check response schema."""
+    status: str  # "healthy" or "degraded"
+    version: str
+    uptime_seconds: float
+    timestamp: str
+    services: Dict[str, str]  # service_name -> "connected" or "disconnected"
+
+
+router = APIRouter(tags=["health"])
+
+
+async def check_database() -> str:
+    """Check database connectivity.
+    
+    Returns:
+        "connected" if database is accessible, "disconnected" otherwise.
+    """
+    try:
+        async with engine.connect() as conn:
+            await conn.execute(text("SELECT 1"))
+        return "connected"
+    except Exception as e:
+        logger.error("Health check DB failure: %s", e)
+        return "disconnected"
+
+
+async def check_redis() -> str:
+    """Check Redis connectivity.
+    
+    Returns:
+        "connected" if Redis is accessible, "disconnected" otherwise.
+    """
+    try:
+        import redis.asyncio as aioredis
+        
+        client = aioredis.from_url(REDIS_URL, decode_responses=True)
+        try:
+            await client.ping()
+            return "connected"
+        finally:
+            await client.close()
+    except Exception as e:
+        logger.warning("Health check Redis failure: %s", e)
+        return "disconnected"
+
+
+@router.get("/health", response_model=HealthResponse)
+async def health_check() -> HealthResponse:
+    """Get system health status.
+    
+    Returns health status including:
+    - Overall status (healthy/degraded)
+    - Version
+    - Uptime in seconds
+    - Current timestamp
+    - Service statuses (database, redis)
+    
+    No authentication required - public endpoint.
+    """
+    # Check services
+    db_status = await check_database()
+    redis_status = await check_redis()
+    
+    # Determine overall status
+    all_healthy = db_status == "connected" and redis_status == "connected"
+    overall_status = "healthy" if all_healthy else "degraded"
+    
+    # Calculate uptime
+    uptime = time.time() - _start_time
+    
+    return HealthResponse(
+        status=overall_status,
+        version="1.0.0",
+        uptime_seconds=round(uptime, 2),
+        timestamp=datetime.now(timezone.utc).isoformat(),
+        services={
+            "database": db_status,
+            "redis": redis_status,
+        },
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,6 +20,7 @@ from app.api.payouts import router as payouts_router
 from app.api.webhooks.github import router as github_webhook_router
 from app.api.websocket import router as websocket_router
 from app.api.agents import router as agents_router
+from app.api.health import router as health_router
 from app.database import init_db, close_db, engine
 from app.services.auth_service import AuthError
 from app.services.websocket_manager import manager as ws_manager
@@ -242,31 +243,8 @@ app.include_router(websocket_router)
 # Agents: /api/agents/*
 app.include_router(agents_router, prefix="/api")
 
-
-@app.get("/health")
-async def health_check():
-    from app.services.github_sync import get_last_sync
-    from app.services.bounty_service import _bounty_store
-    from app.services.contributor_service import _store
-    from sqlalchemy import text
-
-    db_status = "ok"
-    try:
-        async with engine.connect() as conn:
-            await conn.execute(text("SELECT 1"))
-    except Exception as e:
-        logger.error("Health check DB failure: %s", e)
-        db_status = "error"
-
-    last_sync = get_last_sync()
-    return {
-        "status": "ok" if db_status == "ok" else "degraded",
-        "database": db_status,
-        "bounties": len(_bounty_store),
-        "contributors": len(_store),
-        "last_sync": last_sync.isoformat() if last_sync else None,
-        "version": "0.1.0",
-    }
+# Health: /health (public endpoint for monitoring)
+app.include_router(health_router)
 
 
 @app.post("/api/sync", tags=["admin"])

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,136 @@
+"""Tests for health check API endpoint.
+
+This module tests:
+- All services healthy response
+- Database disconnected scenario
+- Redis disconnected scenario
+- Both services down scenario
+- Response time constraint
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+import time
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.api import health as health_module
+
+
+@pytest.fixture
+def client():
+    """Create a test client."""
+    return TestClient(app)
+
+
+class TestHealthEndpoint:
+    """Test suite for /health endpoint."""
+
+    def test_all_healthy(self, client):
+        """Test response when all services are connected."""
+        with patch.object(health_module, 'check_database', new_callable=AsyncMock) as mock_db, \
+             patch.object(health_module, 'check_redis', new_callable=AsyncMock) as mock_redis:
+            mock_db.return_value = "connected"
+            mock_redis.return_value = "connected"
+            
+            response = client.get("/health")
+            
+            assert response.status_code == 200
+            data = response.json()
+            assert data["status"] == "healthy"
+            assert data["version"] == "1.0.0"
+            assert data["uptime_seconds"] >= 0
+            assert "timestamp" in data
+            assert data["services"]["database"] == "connected"
+            assert data["services"]["redis"] == "connected"
+
+    def test_database_down(self, client):
+        """Test response when database is disconnected."""
+        with patch.object(health_module, 'check_database', new_callable=AsyncMock) as mock_db, \
+             patch.object(health_module, 'check_redis', new_callable=AsyncMock) as mock_redis:
+            mock_db.return_value = "disconnected"
+            mock_redis.return_value = "connected"
+            
+            response = client.get("/health")
+            
+            assert response.status_code == 200
+            data = response.json()
+            assert data["status"] == "degraded"
+            assert data["services"]["database"] == "disconnected"
+            assert data["services"]["redis"] == "connected"
+
+    def test_redis_down(self, client):
+        """Test response when Redis is disconnected."""
+        with patch.object(health_module, 'check_database', new_callable=AsyncMock) as mock_db, \
+             patch.object(health_module, 'check_redis', new_callable=AsyncMock) as mock_redis:
+            mock_db.return_value = "connected"
+            mock_redis.return_value = "disconnected"
+            
+            response = client.get("/health")
+            
+            assert response.status_code == 200
+            data = response.json()
+            assert data["status"] == "degraded"
+            assert data["services"]["database"] == "connected"
+            assert data["services"]["redis"] == "disconnected"
+
+    def test_both_down(self, client):
+        """Test response when both services are disconnected."""
+        with patch.object(health_module, 'check_database', new_callable=AsyncMock) as mock_db, \
+             patch.object(health_module, 'check_redis', new_callable=AsyncMock) as mock_redis:
+            mock_db.return_value = "disconnected"
+            mock_redis.return_value = "disconnected"
+            
+            response = client.get("/health")
+            
+            assert response.status_code == 200
+            data = response.json()
+            assert data["status"] == "degraded"
+            assert data["services"]["database"] == "disconnected"
+            assert data["services"]["redis"] == "disconnected"
+
+    def test_response_time(self, client):
+        """Test that response time is under 500ms."""
+        with patch.object(health_module, 'check_database', new_callable=AsyncMock) as mock_db, \
+             patch.object(health_module, 'check_redis', new_callable=AsyncMock) as mock_redis:
+            mock_db.return_value = "connected"
+            mock_redis.return_value = "connected"
+            
+            start = time.time()
+            response = client.get("/health")
+            elapsed = (time.time() - start) * 1000  # Convert to ms
+            
+            assert response.status_code == 200
+            assert elapsed < 500, f"Response time {elapsed}ms exceeds 500ms limit"
+
+    def test_uptime_increases(self, client):
+        """Test that uptime_seconds increases over time."""
+        with patch.object(health_module, 'check_database', new_callable=AsyncMock) as mock_db, \
+             patch.object(health_module, 'check_redis', new_callable=AsyncMock) as mock_redis:
+            mock_db.return_value = "connected"
+            mock_redis.return_value = "connected"
+            
+            response1 = client.get("/health")
+            uptime1 = response1.json()["uptime_seconds"]
+            
+            # Small delay
+            time.sleep(0.1)
+            
+            response2 = client.get("/health")
+            uptime2 = response2.json()["uptime_seconds"]
+            
+            assert uptime2 > uptime1, "Uptime should increase over time"
+
+    def test_no_auth_required(self, client):
+        """Test that health endpoint requires no authentication."""
+        with patch.object(health_module, 'check_database', new_callable=AsyncMock) as mock_db, \
+             patch.object(health_module, 'check_redis', new_callable=AsyncMock) as mock_redis:
+            mock_db.return_value = "connected"
+            mock_redis.return_value = "connected"
+            
+            # Request without any auth headers
+            response = client.get("/health")
+            
+            # Should succeed without 401 Unauthorized
+            assert response.status_code == 200


### PR DESCRIPTION
## Bounty: Backend Health Check Endpoint (#343)

**Reward:** 50,000 $FNDRY

### Implementation

- `GET /health` endpoint at `backend/app/api/health.py`
- Returns JSON with status, version, uptime_seconds, timestamp, services
- Checks database connectivity (simple query, catches exceptions)
- Checks Redis connectivity (ping, catches exceptions)
- Returns `degraded` status if any service is down
- No authentication required (public endpoint)
- Response time under 500ms
- Unit tests for: all healthy, DB down, Redis down, both down

### Test Results

```
tests/test_health.py::TestHealthEndpoint::test_all_healthy PASSED
tests/test_health.py::TestHealthEndpoint::test_database_down PASSED
tests/test_health.py::TestHealthEndpoint::test_redis_down PASSED
tests/test_health.py::TestHealthEndpoint::test_both_down PASSED
tests/test_health.py::TestHealthEndpoint::test_response_time PASSED
tests/test_health.py::TestHealthEndpoint::test_uptime_increases PASSED
tests/test_health.py::TestHealthEndpoint::test_no_auth_required PASSED
============================== 7 passed in 4.40s
```

### Solana Wallet Address

`9U1vGkmL5MELJ8B6KSKURQ51NN6hKmxFxVyXmd7xZxWY`

Closes #343