### PR TITLE
feat: Add Breadcrumb navigation (Closes #346)

### DIFF
--- a/frontend/src/components/layout/Breadcrumbs.tsx
+++ b/frontend/src/components/layout/Breadcrumbs.tsx
@@ -1,0 +1,151 @@
+import React from 'react';
+import { useLocation, Link } from 'react-router-dom';
+
+// ============================================================================
+// Route label map
+// ============================================================================
+
+/**
+ * Maps known path segments to human-readable labels.
+ * Dynamic segments (IDs, usernames) fall back to the raw segment.
+ */
+const SEGMENT_LABELS: Record<string, string> = {
+  bounties: 'Bounties',
+  create: 'Create',
+  leaderboard: 'Leaderboard',
+  dashboard: 'Dashboard',
+  creator: 'Creator Dashboard',
+  agents: 'Agents',
+  profile: 'Profile',
+  settings: 'Settings',
+  tokenomics: 'Tokenomics',
+  'how-it-works': 'How It Works',
+  contributors: 'Contributors',
+};
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+interface Crumb {
+  label: string;
+  href: string;
+  isCurrent: boolean;
+}
+
+function buildCrumbs(pathname: string): Crumb[] {
+  const segments = pathname.split('/').filter(Boolean);
+  const crumbs: Crumb[] = [{ label: 'Home', href: '/', isCurrent: segments.length === 0 }];
+
+  segments.forEach((segment, idx) => {
+    const href = '/' + segments.slice(0, idx + 1).join('/');
+    const label = SEGMENT_LABELS[segment] ?? decodeURIComponent(segment);
+    crumbs.push({ label, href, isCurrent: idx === segments.length - 1 });
+  });
+
+  return crumbs;
+}
+
+/**
+ * Collapse breadcrumbs on mobile: show first + last 2 segments,
+ * replacing the middle with "…" if there are more than 3.
+ */
+function mobileCrumbs(crumbs: Crumb[]): Array<Crumb | { ellipsis: true }> {
+  if (crumbs.length <= 3) return crumbs;
+  return [crumbs[0], { ellipsis: true }, ...crumbs.slice(-2)];
+}
+
+// ============================================================================
+// Breadcrumbs Component
+// ============================================================================
+
+export interface BreadcrumbsProps {
+  className?: string;
+}
+
+/**
+ * Breadcrumbs — Automatic breadcrumb navigation generated from the current route.
+ *
+ * - Uses React Router's useLocation()
+ * - Segments map to human-readable labels via SEGMENT_LABELS
+ * - All but the last segment are clickable <Link> elements
+ * - Separator: "›"
+ * - On mobile (< sm): shows first + last 2 segments, collapses middle with "…"
+ * - No new dependencies (React Router already in use)
+ */
+export function Breadcrumbs({ className = '' }: BreadcrumbsProps) {
+  const { pathname } = useLocation();
+  const crumbs = buildCrumbs(pathname);
+
+  // Only render when there's something beyond Home
+  if (crumbs.length <= 1) return null;
+
+  const desktopCrumbs = crumbs;
+  const mobileCrumbList = mobileCrumbs(crumbs);
+
+  return (
+    <nav
+      aria-label="Breadcrumb"
+      className={`font-mono text-sm ${className}`}
+    >
+      {/* Desktop: full breadcrumb list */}
+      <ol className="hidden sm:flex items-center flex-wrap gap-1" role="list">
+        {desktopCrumbs.map((crumb, idx) => (
+          <React.Fragment key={idx}>
+            {idx > 0 && (
+              <li aria-hidden="true" className="text-gray-600 select-none">›</li>
+            )}
+            <li>
+              {crumb.isCurrent ? (
+                <span
+                  className="text-gray-300 font-medium"
+                  aria-current="page"
+                >
+                  {crumb.label}
+                </span>
+              ) : (
+                <Link
+                  to={crumb.href}
+                  className="text-gray-500 hover:text-[#9945FF] transition-colors"
+                >
+                  {crumb.label}
+                </Link>
+              )}
+            </li>
+          </React.Fragment>
+        ))}
+      </ol>
+
+      {/* Mobile: collapsed breadcrumb list */}
+      <ol className="flex sm:hidden items-center flex-wrap gap-1" role="list">
+        {mobileCrumbList.map((item, idx) => (
+          <React.Fragment key={idx}>
+            {idx > 0 && (
+              <li aria-hidden="true" className="text-gray-600 select-none">›</li>
+            )}
+            {'ellipsis' in item ? (
+              <li className="text-gray-600 select-none" aria-label="more pages">…</li>
+            ) : (
+              <li>
+                {item.isCurrent ? (
+                  <span className="text-gray-300 font-medium" aria-current="page">
+                    {item.label}
+                  </span>
+                ) : (
+                  <Link
+                    to={item.href}
+                    className="text-gray-500 hover:text-[#9945FF] transition-colors"
+                  >
+                    {item.label}
+                  </Link>
+                )}
+              </li>
+            )}
+          </React.Fragment>
+        ))}
+      </ol>
+    </nav>
+  );
+}
+
+export default Breadcrumbs;

--- a/frontend/src/components/layout/SiteLayout.tsx
+++ b/frontend/src/components/layout/SiteLayout.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import OnboardingWizard from '../OnboardingWizard';
 import { ThemeToggle } from './ThemeToggle';
+import { Breadcrumbs } from './Breadcrumbs';
 
 // ============================================================================
 // Types
@@ -163,6 +164,10 @@ export function SiteLayout({
 
       {/* Main Content */}
       <main className="min-h-screen pt-16">
+        {/* Breadcrumbs — below top nav, above page content */}
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3 border-b border-white/5">
+          <Breadcrumbs />
+        </div>
         {children}
       </main>
 

--- a/frontend/src/components/layout/index.ts
+++ b/frontend/src/components/layout/index.ts
@@ -1,2 +1,3 @@
 export { Sidebar } from './Sidebar';
 export { Header } from './Header';
+export { Breadcrumbs } from './Breadcrumbs';


### PR DESCRIPTION
## Summary

Closes #346 — 🏭 Bounty: Breadcrumb Navigation — 50,000 $FNDRY

**Changes:**
- New: `frontend/src/components/layout/Breadcrumbs.tsx`
- Updated: `SiteLayout.tsx` renders `<Breadcrumbs />` below top nav, above page content
- Updated: `layout/index.ts` exports `Breadcrumbs`

**Acceptance criteria met:**
- [x] Component at `frontend/src/components/layout/Breadcrumbs.tsx`
- [x] Auto-generates breadcrumbs from `useLocation()` (React Router)
- [x] Examples: `/bounties/123` → Home › Bounties › 123, `/dashboard` → Home › Dashboard
- [x] All segments except current page are clickable `<Link>` elements
- [x] Separator: `›`
- [x] Integrated into page layout (below nav, above content) in SiteLayout
- [x] Dark theme styling consistent with site
- [x] Responsive — collapses on mobile to first + last 2 segments with `…` ellipsis
- [x] No new dependencies (uses React Router's `useLocation` already in the project)

## Test plan
- [ ] Navigate to `/bounties` → shows "Home › Bounties"
- [ ] Navigate to `/bounties/123` → shows "Home › Bounties › 123"
- [ ] Navigate to `/profile/HuiNeng6` → shows "Home › Profile › HuiNeng6"
- [ ] Navigate to `/dashboard` → shows "Home › Dashboard"
- [ ] Navigate to `/` → breadcrumbs hidden (single segment)
- [ ] Resize to mobile → middle segments collapse to `…`

🤖 Generated with [Claude Code](https://claude.com/claude-code)