### PR TITLE
feat: Add bounty stats API endpoint - 75,000 $FNDRY

### DIFF
--- a/backend/app/api/stats.py
+++ b/backend/app/api/stats.py
@@ -1,0 +1,154 @@
+"""Bounty stats API endpoint.
+
+Public endpoint returning aggregate statistics about the bounty program.
+Cached for 5 minutes to avoid recomputing on every request.
+"""
+
+import logging
+import time
+from datetime import datetime, timezone
+from typing import Dict, List, Optional
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from app.services.bounty_service import _bounty_store
+from app.services.contributor_service import _store as _contributor_store
+
+logger = logging.getLogger(__name__)
+
+# Cache configuration
+_cache_ttl_seconds = 300  # 5 minutes
+_cache: Dict[str, tuple[float, dict]] = {}
+
+
+class TierStats(BaseModel):
+    """Statistics for a single tier."""
+    open: int
+    completed: int
+
+
+class TopContributor(BaseModel):
+    """Top contributor information."""
+    username: str
+    bounties_completed: int
+
+
+class StatsResponse(BaseModel):
+    """Bounty program statistics response."""
+    total_bounties_created: int
+    total_bounties_completed: int
+    total_bounties_open: int
+    total_contributors: int
+    total_fndry_paid: int
+    total_prs_reviewed: int
+    bounties_by_tier: Dict[str, TierStats]
+    top_contributor: Optional[TopContributor]
+
+
+router = APIRouter(tags=["stats"])
+
+
+def _compute_stats() -> dict:
+    """Compute bounty statistics from data stores."""
+    # Bounty counts
+    total_created = len(_bounty_store)
+    total_completed = 0
+    total_open = 0
+    total_fndry_paid = 0
+    total_prs_reviewed = 0
+    
+    # Tier breakdown
+    tier_stats: Dict[str, Dict[str, int]] = {
+        "tier-1": {"open": 0, "completed": 0},
+        "tier-2": {"open": 0, "completed": 0},
+        "tier-3": {"open": 0, "completed": 0},
+    }
+    
+    # Count bounties
+    for bounty in _bounty_store.values():
+        # Status counts
+        if bounty.status == "completed":
+            total_completed += 1
+            total_fndry_paid += bounty.reward_amount
+            
+            # Count PRs from submissions
+            total_prs_reviewed += len([s for s in bounty.submissions if s.pr_url])
+        elif bounty.status in ("open", "in_progress"):
+            total_open += 1
+        
+        # Tier counts
+        tier = bounty.tier
+        if tier in tier_stats:
+            if bounty.status == "completed":
+                tier_stats[tier]["completed"] += 1
+            elif bounty.status in ("open", "in_progress"):
+                tier_stats[tier]["open"] += 1
+    
+    # Contributor counts
+    total_contributors = len(_contributor_store)
+    
+    # Top contributor (by bounties_completed)
+    top_contributor = None
+    if _contributor_store:
+        top = max(
+            _contributor_store.values(),
+            key=lambda c: c.total_bounties_completed,
+        )
+        if top.total_bounties_completed > 0:
+            top_contributor = {
+                "username": top.username,
+                "bounties_completed": top.total_bounties_completed,
+            }
+    
+    return {
+        "total_bounties_created": total_created,
+        "total_bounties_completed": total_completed,
+        "total_bounties_open": total_open,
+        "total_contributors": total_contributors,
+        "total_fndry_paid": total_fndry_paid,
+        "total_prs_reviewed": total_prs_reviewed,
+        "bounties_by_tier": {
+            tier: {"open": data["open"], "completed": data["completed"]}
+            for tier, data in tier_stats.items()
+        },
+        "top_contributor": top_contributor,
+    }
+
+
+def _get_cached_stats() -> dict:
+    """Get stats from cache or compute fresh."""
+    cache_key = "bounty_stats"
+    now = time.time()
+    
+    # Check cache
+    if cache_key in _cache:
+        cached_at, data = _cache[cache_key]
+        if now - cached_at < _cache_ttl_seconds:
+            logger.debug("Returning cached stats (age: %.1fs)", now - cached_at)
+            return data
+    
+    # Compute fresh
+    data = _compute_stats()
+    _cache[cache_key] = (now, data)
+    logger.info("Computed fresh stats, cached for %ds", _cache_ttl_seconds)
+    return data
+
+
+@router.get("/api/stats", response_model=StatsResponse)
+async def get_stats() -> StatsResponse:
+    """Get bounty program statistics.
+    
+    Returns aggregate statistics about the bounty program:
+    - Total bounties (created, completed, open)
+    - Total contributors
+    - Total $FNDRY paid out
+    - Total PRs reviewed
+    - Breakdown by tier
+    - Top contributor
+    
+    No authentication required - public endpoint.
+    Cached for 5 minutes.
+    """
+    data = _get_cached_stats()
+    return StatsResponse(**data)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,6 +20,7 @@ from app.api.payouts import router as payouts_router
 from app.api.webhooks.github import router as github_webhook_router
 from app.api.websocket import router as websocket_router
 from app.api.agents import router as agents_router
+from app.api.stats import router as stats_router
 from app.database import init_db, close_db, engine
 from app.services.auth_service import AuthError
 from app.services.websocket_manager import manager as ws_manager
@@ -241,6 +242,9 @@ app.include_router(websocket_router)
 
 # Agents: /api/agents/*
 app.include_router(agents_router, prefix="/api")
+
+# Stats: /api/stats (public endpoint)
+app.include_router(stats_router)
 
 
 @app.get("/health")

--- a/backend/tests/test_stats.py
+++ b/backend/tests/test_stats.py
@@ -1,0 +1,155 @@
+"""Tests for bounty stats API endpoint.
+
+This module tests:
+- Normal stats response
+- Empty state (no bounties, no contributors)
+- Cache behavior (returns cached data within TTL)
+"""
+
+import pytest
+import time
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.api import stats as stats_module
+
+
+@pytest.fixture
+def client():
+    """Create a test client."""
+    return TestClient(app)
+
+
+@pytest.fixture
+def clear_stores():
+    """Clear bounty and contributor stores before each test."""
+    from app.services.bounty_service import _bounty_store
+    from app.services.contributor_service import _store as _contributor_store
+    _bounty_store.clear()
+    _contributor_store.clear()
+    # Also clear cache
+    stats_module._cache.clear()
+    yield
+    _bounty_store.clear()
+    _contributor_store.clear()
+    stats_module._cache.clear()
+
+
+class TestStatsEndpoint:
+    """Test suite for /api/stats endpoint."""
+
+    def test_empty_state(self, client, clear_stores):
+        """Test response when no bounties or contributors exist."""
+        response = client.get("/api/stats")
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_bounties_created"] == 0
+        assert data["total_bounties_completed"] == 0
+        assert data["total_bounties_open"] == 0
+        assert data["total_contributors"] == 0
+        assert data["total_fndry_paid"] == 0
+        assert data["total_prs_reviewed"] == 0
+        assert data["top_contributor"] is None
+
+    def test_normal_response(self, client, clear_stores):
+        """Test response with bounties and contributors."""
+        from app.services.bounty_service import _bounty_store
+        from app.services.contributor_service import _store as _contributor_store
+        from app.models.bounty import BountyDB
+        from app.models.contributor import ContributorDB
+        import uuid
+        from datetime import datetime, timezone
+        
+        # Create a contributor
+        contributor_id = str(uuid.uuid4())
+        contributor = ContributorDB(
+            id=uuid.UUID(contributor_id),
+            username="testuser",
+            total_bounties_completed=5,
+        )
+        _contributor_store[contributor_id] = contributor
+        
+        # Create bounties
+        bounty1 = BountyDB(
+            id="bounty-1",
+            title="Test Bounty 1",
+            tier="tier-1",
+            reward_amount=50000,
+            status="completed",
+            submissions=[],
+        )
+        bounty2 = BountyDB(
+            id="bounty-2",
+            title="Test Bounty 2",
+            tier="tier-2",
+            reward_amount=75000,
+            status="open",
+            submissions=[],
+        )
+        _bounty_store["bounty-1"] = bounty1
+        _bounty_store["bounty-2"] = bounty2
+        
+        response = client.get("/api/stats")
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_bounties_created"] == 2
+        assert data["total_bounties_completed"] == 1
+        assert data["total_bounties_open"] == 1
+        assert data["total_contributors"] == 1
+        assert data["total_fndry_paid"] == 50000
+        assert data["top_contributor"]["username"] == "testuser"
+        assert data["top_contributor"]["bounties_completed"] == 5
+        assert data["bounties_by_tier"]["tier-1"]["completed"] == 1
+        assert data["bounties_by_tier"]["tier-2"]["open"] == 1
+
+    def test_cache_behavior(self, client, clear_stores):
+        """Test that cache is used within TTL."""
+        # First request computes fresh
+        response1 = client.get("/api/stats")
+        assert response1.status_code == 200
+        
+        # Check cache was populated
+        assert "bounty_stats" in stats_module._cache
+        
+        # Second request should use cache
+        response2 = client.get("/api/stats")
+        assert response2.status_code == 200
+        
+        # Both should have same data
+        assert response1.json() == response2.json()
+
+    def test_no_auth_required(self, client, clear_stores):
+        """Test that stats endpoint requires no authentication."""
+        # Request without any auth headers
+        response = client.get("/api/stats")
+        
+        # Should succeed without 401 Unauthorized
+        assert response.status_code == 200
+
+    def test_tier_breakdown(self, client, clear_stores):
+        """Test tier breakdown statistics."""
+        from app.services.bounty_service import _bounty_store
+        from app.models.bounty import BountyDB
+        
+        # Create bounties in different tiers
+        bounties = [
+            BountyDB(id="t1-open", title="T1 Open", tier="tier-1", reward_amount=50000, status="open", submissions=[]),
+            BountyDB(id="t1-done", title="T1 Done", tier="tier-1", reward_amount=50000, status="completed", submissions=[]),
+            BountyDB(id="t2-open", title="T2 Open", tier="tier-2", reward_amount=75000, status="open", submissions=[]),
+            BountyDB(id="t3-done", title="T3 Done", tier="tier-3", reward_amount=100000, status="completed", submissions=[]),
+        ]
+        for b in bounties:
+            _bounty_store[b.id] = b
+        
+        response = client.get("/api/stats")
+        data = response.json()
+        
+        assert data["bounties_by_tier"]["tier-1"]["open"] == 1
+        assert data["bounties_by_tier"]["tier-1"]["completed"] == 1
+        assert data["bounties_by_tier"]["tier-2"]["open"] == 1
+        assert data["bounties_by_tier"]["tier-2"]["completed"] == 0
+        assert data["bounties_by_tier"]["tier-3"]["open"] == 0
+        assert data["bounties_by_tier"]["tier-3"]["completed"] == 1


### PR DESCRIPTION
## Bounty: Bounty Stats API Endpoint (#344)

**Reward:** 75,000 $FNDRY

### Implementation

- GET /api/stats endpoint
- Returns: total bounties, completed, open, contributors, $FNDRY paid, PRs reviewed
- Tier breakdown (tier-1, tier-2, tier-3)
- Top contributor
- Cached 5 minutes
- Public endpoint
- Unit tests included
- No new dependencies

### Wallet

9U1vGkmL5MELJ8B6KSKURQ51NN6hKmxFxVyXmd7xZxWY

Closes #344