### PR TITLE
feat: Add MarkdownRenderer component - 75,000 $FNDRY

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,10 @@
     "postcss": "^8.5.8",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-markdown": "^9.0.0",
     "react-router-dom": "^6.23.1",
+    "react-syntax-highlighter": "^15.5.0",
+    "remark-gfm": "^4.0.0",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
@@ -26,6 +29,7 @@
     "@testing-library/user-event": "^14.5.2",
     "@types/node": "^22.0.0",
     "@types/react": "^18.3.3",
+    "@types/react-syntax-highlighter": "^15.5.11",
     "@vitejs/plugin-react": "^4.3.0",
     "jsdom": "^25.0.0",
     "typescript": "^5.4.5",

--- a/frontend/src/components/common/MarkdownRenderer.test.tsx
+++ b/frontend/src/components/common/MarkdownRenderer.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MarkdownRenderer } from './MarkdownRenderer';
+
+describe('MarkdownRenderer', () => {
+  it('renders basic text', () => {
+    render(<MarkdownRenderer content="Hello world" />);
+    expect(screen.getByText('Hello world')).toBeInTheDocument();
+  });
+
+  it('renders headings', () => {
+    const { container } = render(<MarkdownRenderer content="# Heading 1\n## Heading 2\n### Heading 3" />);
+    expect(container.querySelector('h1')).toHaveTextContent('Heading 1');
+    expect(container.querySelector('h2')).toHaveTextContent('Heading 2');
+    expect(container.querySelector('h3')).toHaveTextContent('Heading 3');
+  });
+
+  it('renders bold and italic text', () => {
+    const { container } = render(<MarkdownRenderer content="**bold** and *italic*" />);
+    expect(container.querySelector('strong')).toHaveTextContent('bold');
+    expect(container.querySelector('em')).toHaveTextContent('italic');
+  });
+
+  it('renders inline code', () => {
+    const { container } = render(<MarkdownRenderer content="Use `npm install` to install" />);
+    const code = container.querySelector('code');
+    expect(code).toHaveTextContent('npm install');
+    expect(code?.className).toContain('text-[#14F195]');
+  });
+
+  it('renders code blocks with syntax highlighting', () => {
+    const { container } = render(
+      <MarkdownRenderer content={'```javascript\nconst x = 1;\n```'} />
+    );
+    // SyntaxHighlighter renders in a div
+    expect(container.querySelector('.rounded-lg')).toBeInTheDocument();
+  });
+
+  it('renders links that open in new tab', () => {
+    const { container } = render(
+      <MarkdownRenderer content="[Link](https://example.com)" />
+    );
+    const link = container.querySelector('a');
+    expect(link).toHaveAttribute('href', 'https://example.com');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('renders unordered lists', () => {
+    const { container } = render(
+      <MarkdownRenderer content="- Item 1\n- Item 2\n- Item 3" />
+    );
+    const list = container.querySelector('ul');
+    expect(list).toBeInTheDocument();
+    expect(list?.querySelectorAll('li')).toHaveLength(3);
+  });
+
+  it('renders ordered lists', () => {
+    const { container } = render(
+      <MarkdownRenderer content="1. First\n2. Second\n3. Third" />
+    );
+    const list = container.querySelector('ol');
+    expect(list).toBeInTheDocument();
+    expect(list?.querySelectorAll('li')).toHaveLength(3);
+  });
+
+  it('renders blockquotes', () => {
+    const { container } = render(
+      <MarkdownRenderer content="> This is a quote" />
+    );
+    const quote = container.querySelector('blockquote');
+    expect(quote).toBeInTheDocument();
+    expect(quote?.className).toContain('border-[#9945FF]');
+  });
+
+  it('renders tables', () => {
+    const content = `| Name | Age |
+|------|-----|
+| John | 25  |
+| Jane | 30  |`;
+    const { container } = render(<MarkdownRenderer content={content} />);
+    expect(container.querySelector('table')).toBeInTheDocument();
+    expect(container.querySelectorAll('th')).toHaveLength(2);
+    expect(container.querySelectorAll('td')).toHaveLength(4);
+  });
+
+  it('handles empty content gracefully', () => {
+    render(<MarkdownRenderer content="" />);
+    expect(screen.getByText('No content to display')).toBeInTheDocument();
+  });
+
+  it('handles null/undefined content gracefully', () => {
+    render(<MarkdownRenderer content={null as any} />);
+    expect(screen.getByText('No content to display')).toBeInTheDocument();
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(
+      <MarkdownRenderer content="Test" className="custom-class" />
+    );
+    expect(container.firstChild).toHaveClass('custom-class');
+  });
+
+  it('renders horizontal rules', () => {
+    const { container } = render(<MarkdownRenderer content="Before\n\n---\n\nAfter" />);
+    expect(container.querySelector('hr')).toBeInTheDocument();
+  });
+
+  it('renders GFM features (strikethrough)', () => {
+    const { container } = render(<MarkdownRenderer content="~~strikethrough~~" />);
+    expect(container.querySelector('del')).toHaveTextContent('strikethrough');
+  });
+});

--- a/frontend/src/components/common/MarkdownRenderer.tsx
+++ b/frontend/src/components/common/MarkdownRenderer.tsx
@@ -1,0 +1,192 @@
+import React, { useMemo } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
+
+/**
+ * MarkdownRenderer - Renders Markdown content with syntax highlighting
+ *
+ * Features:
+ * - Standard Markdown: headings, bold, italic, code blocks, lists, links
+ * - Syntax highlighting for code blocks (dark theme)
+ * - Links open in new tab (secure)
+ * - XSS-safe (react-markdown sanitizes by default)
+ * - Supports tables, blockquotes, inline code
+ * - Dark theme styling matching existing site
+ */
+
+export interface MarkdownRendererProps {
+  /** Markdown content to render */
+  content: string;
+  /** Optional additional CSS classes */
+  className?: string;
+}
+
+export function MarkdownRenderer({ content, className = '' }: MarkdownRendererProps) {
+  // Memoize the rendered content
+  const rendered = useMemo(() => {
+    if (!content) return null;
+
+    return (
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          // Code blocks with syntax highlighting
+          code({ inline, className: codeClassName, children, ...props }: any) {
+            const match = /language-(\w+)/.exec(codeClassName || '');
+            const language = match ? match[1] : '';
+
+            if (!inline && language) {
+              return (
+                <SyntaxHighlighter
+                  style={vscDarkPlus}
+                  language={language}
+                  PreTag="div"
+                  className="rounded-lg !bg-[#1a1a1a] !p-4 my-4 overflow-x-auto"
+                  customStyle={{
+                    margin: 0,
+                    background: '#1a1a1a',
+                    padding: '1rem',
+                  }}
+                >
+                  {String(children).replace(/\n$/, '')}
+                </SyntaxHighlighter>
+              );
+            }
+
+            // Inline code
+            if (inline) {
+              return (
+                <code
+                  className="bg-[#14F195]/10 text-[#14F195] px-1.5 py-0.5 rounded text-sm font-mono"
+                  {...props}
+                >
+                  {children}
+                </code>
+              );
+            }
+
+            // Code block without language
+            return (
+              <code
+                className="block bg-[#1a1a1a] p-4 rounded-lg my-4 font-mono text-sm overflow-x-auto"
+                {...props}
+              >
+                {children}
+              </code>
+            );
+          },
+
+          // Links open in new tab
+          a({ href, children, ...props }: any) {
+            return (
+              <a
+                href={href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[#14F195] hover:text-[#9945FF] transition-colors underline"
+                {...props}
+              >
+                {children}
+              </a>
+            );
+          },
+
+          // Headings
+          h1: ({ children }) => (
+            <h1 className="text-3xl font-bold text-white mt-6 mb-4">{children}</h1>
+          ),
+          h2: ({ children }) => (
+            <h2 className="text-2xl font-bold text-white mt-5 mb-3">{children}</h2>
+          ),
+          h3: ({ children }) => (
+            <h3 className="text-xl font-bold text-white mt-4 mb-2">{children}</h3>
+          ),
+          h4: ({ children }) => (
+            <h4 className="text-lg font-bold text-white mt-3 mb-2">{children}</h4>
+          ),
+
+          // Paragraphs
+          p: ({ children }) => (
+            <p className="text-gray-300 leading-relaxed mb-4">{children}</p>
+          ),
+
+          // Lists
+          ul: ({ children }) => (
+            <ul className="list-disc list-inside text-gray-300 mb-4 space-y-1">
+              {children}
+            </ul>
+          ),
+          ol: ({ children }) => (
+            <ol className="list-decimal list-inside text-gray-300 mb-4 space-y-1">
+              {children}
+            </ol>
+          ),
+          li: ({ children }) => (
+            <li className="text-gray-300">{children}</li>
+          ),
+
+          // Blockquotes
+          blockquote: ({ children }) => (
+            <blockquote className="border-l-4 border-[#9945FF] pl-4 py-2 my-4 bg-[#9945FF]/5 rounded-r">
+              {children}
+            </blockquote>
+          ),
+
+          // Tables
+          table: ({ children }) => (
+            <div className="overflow-x-auto my-4">
+              <table className="min-w-full border border-white/10 rounded-lg">
+                {children}
+              </table>
+            </div>
+          ),
+          thead: ({ children }) => (
+            <thead className="bg-[#9945FF]/10">{children}</thead>
+          ),
+          th: ({ children }) => (
+            <th className="px-4 py-2 text-left text-white font-semibold border-b border-white/10">
+              {children}
+            </th>
+          ),
+          td: ({ children }) => (
+            <td className="px-4 py-2 text-gray-300 border-b border-white/5">{children}</td>
+          ),
+          tr: ({ children }) => (
+            <tr className="hover:bg-white/5 transition-colors">{children}</tr>
+          ),
+
+          // Horizontal rule
+          hr: () => <hr className="border-white/10 my-6" />,
+
+          // Strong and emphasis
+          strong: ({ children }) => (
+            <strong className="font-bold text-white">{children}</strong>
+          ),
+          em: ({ children }) => (
+            <em className="italic text-gray-200">{children}</em>
+          ),
+        }}
+      >
+        {content}
+      </ReactMarkdown>
+    );
+  }, [content]);
+
+  if (!content) {
+    return (
+      <div className={`text-gray-500 italic ${className}`}>
+        No content to display
+      </div>
+    );
+  }
+
+  return (
+    <div className={`markdown-body prose prose-invert max-w-none ${className}`}>
+      {rendered}
+    </div>
+  );
+}
+
+export default MarkdownRenderer;

--- a/frontend/src/components/common/index.ts
+++ b/frontend/src/components/common/index.ts
@@ -11,3 +11,5 @@ export type { EmptyStateProps, EmptyStateVariant, NoBountiesProps, NoContributio
 export { Toast } from './Toast';
 export type { ToastProps } from './Toast';
 export { ToastContainer } from './ToastContainer';
+export { MarkdownRenderer } from './MarkdownRenderer';
+export type { MarkdownRendererProps } from './MarkdownRenderer';


### PR DESCRIPTION
## Bounty: Markdown Renderer Component (#345)

**Reward:** 75,000 $FNDRY

### Implementation

- `MarkdownRenderer.tsx` at `frontend/src/components/common/`
- Props: `content: string`, `className?: string`
- Renders standard Markdown: headings, bold, italic, code blocks, lists, links, blockquotes, tables
- Code blocks with syntax highlighting (react-syntax-highlighter, vscDarkPlus theme)
- Links open in new tab (`target="_blank"`, `rel="noopener noreferrer"`)
- XSS-safe (react-markdown sanitizes by default)
- Dark theme styling matching existing site
- Unit tests: headings, code blocks, links, lists, tables, empty content, GFM features

### Dependencies Added

- `react-markdown` ^9.0.0
- `remark-gfm` ^4.0.0
- `react-syntax-highlighter` ^15.5.0
- `@types/react-syntax-highlighter` ^15.5.11 (dev)

### Solana Wallet Address

`9U1vGkmL5MELJ8B6KSKURQ51NN6hKmxFxVyXmd7xZxWY`

Closes #345