### PR TITLE
feat(bounties): sort persistence via URL params and directional icons (#482)

### DIFF
--- a/frontend/src/components/bounties/BountySortBar.tsx
+++ b/frontend/src/components/bounties/BountySortBar.tsx
@@ -1,27 +1,73 @@
 import type { BountySortBy } from '../../types/bounty';
 import { SORT_OPTIONS } from '../../types/bounty';
 
+/** Ascending arrow icon (points up). */
+function ArrowUp({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      className={className ?? 'w-3 h-3'}
+      aria-hidden="true"
+    >
+      <path
+        fillRule="evenodd"
+        d="M8 2.25a.75.75 0 0 1 .566.258l4 4.5a.75.75 0 1 1-1.132.984L8.75 4.56V13a.75.75 0 0 1-1.5 0V4.56L4.566 7.992a.75.75 0 0 1-1.132-.984l4-4.5A.75.75 0 0 1 8 2.25Z"
+        clipRule="evenodd"
+      />
+    </svg>
+  );
+}
+
+/** Descending arrow icon (points down). */
+function ArrowDown({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      className={className ?? 'w-3 h-3'}
+      aria-hidden="true"
+    >
+      <path
+        fillRule="evenodd"
+        d="M8 13.75a.75.75 0 0 1-.566-.258l-4-4.5a.75.75 0 1 1 1.132-.984L7.25 11.44V3a.75.75 0 0 1 1.5 0v8.44l2.684-3.432a.75.75 0 1 1 1.132.984l-4 4.5A.75.75 0 0 1 8 13.75Z"
+        clipRule="evenodd"
+      />
+    </svg>
+  );
+}
+
 export function BountySortBar({ sortBy, onSortChange }: { sortBy: BountySortBy; onSortChange: (s: BountySortBy) => void }) {
   return (
     <div className="flex items-center gap-2 overflow-x-auto" data-testid="bounty-sort-bar">
       <span className="text-xs text-gray-500 whitespace-nowrap">Sort by:</span>
-      {SORT_OPTIONS.map(o => (
-        <button
-          key={o.value}
-          type="button"
-          onClick={() => onSortChange(o.value)}
-          className={
-            'rounded-lg px-3 py-1.5 text-xs font-medium whitespace-nowrap transition-colors ' +
-            (sortBy === o.value
-              ? 'bg-solana-green/15 text-solana-green'
-              : 'text-gray-400 hover:text-white hover:bg-surface-200')
-          }
-          aria-pressed={sortBy === o.value}
-          data-testid={'sort-' + o.value}
-        >
-          {o.label}
-        </button>
-      ))}
+      {SORT_OPTIONS.map(o => {
+        const isActive = sortBy === o.value;
+        return (
+          <button
+            key={o.value}
+            type="button"
+            onClick={() => onSortChange(o.value)}
+            className={
+              'inline-flex items-center gap-1 rounded-lg px-3 py-1.5 text-xs font-medium whitespace-nowrap transition-colors ' +
+              (isActive
+                ? 'bg-solana-green/15 text-solana-green'
+                : 'text-gray-400 hover:text-white hover:bg-surface-200')
+            }
+            aria-pressed={isActive}
+            data-testid={'sort-' + o.value}
+          >
+            {o.label}
+            {isActive && (
+              o.direction === 'asc'
+                ? <ArrowUp className="w-3 h-3" />
+                : <ArrowDown className="w-3 h-3" />
+            )}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/frontend/src/hooks/useBountyBoard.ts
+++ b/frontend/src/hooks/useBountyBoard.ts
@@ -2,7 +2,7 @@
  * Bounty fetching via apiClient + React Query with search and fallback.
  * @module hooks/useBountyBoard
  */
-import { useState, useMemo, useCallback, useRef } from 'react';
+import { useState, useMemo, useCallback, useRef, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import type { Bounty, BountyBoardFilters, BountySortBy, SearchResponse } from '../types/bounty';
 import { DEFAULT_FILTERS } from '../types/bounty';
@@ -19,6 +19,21 @@ const STATUS_MAP: Record<string, BountyStatus> = {
   paid: 'paid',
   cancelled: 'cancelled',
 };
+
+const TIER_ORDER: Record<string, number> = { T1: 1, T2: 2, T3: 3 };
+
+const VALID_SORT_VALUES: BountySortBy[] = [
+  'newest', 'oldest', 'reward_high', 'reward_low', 'tier_high', 'deadline', 'submissions', 'best_match',
+];
+
+/** Read the `sort` URL param and return a validated BountySortBy value. */
+function readSortFromUrl(): BountySortBy {
+  if (typeof window === 'undefined') return 'newest';
+  const params = new URLSearchParams(window.location.search);
+  const raw = params.get('sort');
+  if (raw && (VALID_SORT_VALUES as string[]).includes(raw)) return raw as BountySortBy;
+  return 'newest';
+}
 
 /** Map raw API bounty response to strongly-typed Bounty object. */
 function mapApiBounty(raw: Record<string, unknown>): Bounty {
@@ -74,8 +89,10 @@ const SORT_COMPAT: Record<string, BountySortBy> = { reward: 'reward_high' };
 function localSort(bounties: Bounty[], sortBy: BountySortBy): Bounty[] {
   const sorted = [...bounties];
   switch (sortBy) {
+    case 'oldest': return sorted.sort((left, right) => new Date(left.createdAt).getTime() - new Date(right.createdAt).getTime());
     case 'reward_high': return sorted.sort((left, right) => right.rewardAmount - left.rewardAmount);
     case 'reward_low': return sorted.sort((left, right) => left.rewardAmount - right.rewardAmount);
+    case 'tier_high': return sorted.sort((left, right) => (TIER_ORDER[left.tier] ?? 99) - (TIER_ORDER[right.tier] ?? 99));
     case 'deadline': return sorted.sort((left, right) => new Date(left.deadline).getTime() - new Date(right.deadline).getTime());
     case 'submissions': return sorted.sort((left, right) => right.submissionCount - left.submissionCount);
     case 'best_match':
@@ -103,13 +120,39 @@ function applyLocalFilters(allBounties: Bounty[], activeFilters: BountyBoardFilt
   return localSort(results, sortBy);
 }
 
+/** Sync the `sort` URL query param without triggering a navigation/reload. */
+function updateSortUrl(sortBy: BountySortBy) {
+  if (typeof window === 'undefined') return;
+  const url = new URL(window.location.href);
+  if (sortBy === 'newest') {
+    url.searchParams.delete('sort');
+  } else {
+    url.searchParams.set('sort', sortBy);
+  }
+  window.history.replaceState(null, '', url.toString());
+}
+
 /** Bounty board hook with React Query caching, server-side search, and client-side fallback. */
 export function useBountyBoard() {
   const [filters, setFilters] = useState<BountyBoardFilters>(DEFAULT_FILTERS);
-  const [sortBy, setSortByRaw] = useState<BountySortBy>('newest');
+  const [sortBy, setSortByRaw] = useState<BountySortBy>(readSortFromUrl);
   const [page, setPage] = useState(1);
   const perPage = 20;
   const searchAvailableRef = useRef(true);
+
+  // Sync URL param whenever sort changes
+  useEffect(() => {
+    updateSortUrl(sortBy);
+  }, [sortBy]);
+
+  // Re-read sort from URL on browser back/forward navigation
+  useEffect(() => {
+    function handlePopState() {
+      setSortByRaw(readSortFromUrl());
+    }
+    window.addEventListener('popstate', handlePopState);
+    return () => window.removeEventListener('popstate', handlePopState);
+  }, []);
 
   const setSortBy = useCallback((sortField: BountySortBy | string) => {
     setSortByRaw((SORT_COMPAT[sortField] || sortField) as BountySortBy);

--- a/frontend/src/types/bounty.ts
+++ b/frontend/src/types/bounty.ts
@@ -1,6 +1,6 @@
 export type BountyTier = 'T1' | 'T2' | 'T3';
 export type BountyStatus = 'open' | 'in-progress' | 'under_review' | 'completed' | 'disputed' | 'paid' | 'cancelled';
-export type BountySortBy = 'newest' | 'reward_high' | 'reward_low' | 'deadline' | 'submissions' | 'best_match';
+export type BountySortBy = 'newest' | 'oldest' | 'reward_high' | 'reward_low' | 'tier_high' | 'deadline' | 'submissions' | 'best_match';
 export type SubmissionStatus = 'pending' | 'approved' | 'disputed' | 'paid' | 'rejected';
 
 export interface ModelReviewScore {
@@ -137,13 +137,15 @@ export const STATUS_OPTIONS: { value: BountyStatus | 'all'; label: string }[] = 
   { value: 'cancelled', label: 'Cancelled' },
 ];
 
-export const SORT_OPTIONS: { value: BountySortBy; label: string }[] = [
-  { value: 'newest', label: 'Newest' },
-  { value: 'reward_high', label: 'Highest Reward' },
-  { value: 'reward_low', label: 'Lowest Reward' },
-  { value: 'deadline', label: 'Ending Soon' },
-  { value: 'submissions', label: 'Most Submissions' },
-  { value: 'best_match', label: 'Best Match' },
+export const SORT_OPTIONS: { value: BountySortBy; label: string; direction: 'asc' | 'desc' }[] = [
+  { value: 'newest', label: 'Newest', direction: 'desc' },
+  { value: 'oldest', label: 'Oldest', direction: 'asc' },
+  { value: 'reward_high', label: 'Highest Reward', direction: 'desc' },
+  { value: 'reward_low', label: 'Lowest Reward', direction: 'asc' },
+  { value: 'tier_high', label: 'Tier', direction: 'desc' },
+  { value: 'deadline', label: 'Ending Soon', direction: 'asc' },
+  { value: 'submissions', label: 'Most Submissions', direction: 'desc' },
+  { value: 'best_match', label: 'Best Match', direction: 'desc' },
 ];
 
 export const CREATOR_TYPE_OPTIONS: { value: 'all' | 'platform' | 'community'; label: string }[] = [


### PR DESCRIPTION
Enhances bounty sorting with URL persistence and directional indicators:

- Sort preference synced to URL param (`?sort=reward_high`) for shareable links
- Ascending/descending arrow indicators on sort buttons
- All required sort options implemented (Newest, Oldest, Highest/Lowest Reward, Tier)
- Sort persists on page navigation and browser back/forward
- Works alongside all search and filter options

Closes #482

**Wallet:** GhUgLwY9ky48FechbmvN7XBHkNRJZRwBmw36g8r6KKpG