### PR TITLE
feat: bounty tags/labels component system (#487)

### DIFF
--- a/frontend/src/components/bounties/BountyCard.tsx
+++ b/frontend/src/components/bounties/BountyCard.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import type { Bounty } from '../../types/bounty';
+import type { TagType } from './BountyTag';
 import { TierBadge } from './TierBadge';
 import { StatusIndicator } from './StatusIndicator';
 import { SkillTags } from './SkillTags';
@@ -35,7 +36,15 @@ function CreatorBadge({ type }: { type: 'platform' | 'community' }) {
   );
 }
 
-export function BountyCard({ bounty: b, onClick }: { bounty: Bounty; onClick: (id: string) => void }) {
+export function BountyCard({
+  bounty: b,
+  onClick,
+  onTagClick,
+}: {
+  bounty: Bounty;
+  onClick: (id: string) => void;
+  onTagClick?: (type: TagType, value: string) => void;
+}) {
   const [tr, setTr] = useState(() => formatTimeRemaining(b.deadline));
   useEffect(() => { const i = setInterval(() => setTr(formatTimeRemaining(b.deadline)), 6e4); return () => clearInterval(i); }, [b.deadline]);
   const exp = new Date(b.deadline).getTime() <= Date.now();
@@ -55,7 +64,7 @@ export function BountyCard({ bounty: b, onClick }: { bounty: Bounty; onClick: (i
         <h3 className="text-sm font-semibold text-white mb-2 group-hover:text-solana-green">{b.title}</h3>
         <p className="text-xs text-gray-500 mb-3">{b.projectName}</p>
         <div className="flex items-baseline gap-1 mb-3"><span className="text-lg font-bold text-solana-green">{formatReward(b.rewardAmount)}</span><span className="text-xs text-gray-500">{b.currency}</span></div>
-        <SkillTags skills={b.skills} maxVisible={3} />
+        <SkillTags skills={b.skills} maxVisible={3} onTagClick={onTagClick} />
         <div className="flex justify-between pt-3 mt-3 border-t border-surface-300">
           <span className={'text-xs ' + (urg ? 'text-[#FF6B6B]' : 'text-gray-500')} data-testid="time-remaining">{tr}</span>
           <span className="text-xs text-gray-500">{b.submissionCount} submission{b.submissionCount !== 1 ? 's' : ''}</span>

--- a/frontend/src/components/bounties/BountyTag.tsx
+++ b/frontend/src/components/bounties/BountyTag.tsx
@@ -1,0 +1,88 @@
+export type TagType = 'skill' | 'category';
+
+const CATEGORY_COLORS: Record<string, { bg: string; text: string; border: string }> = {
+  frontend:        { bg: '#3B82F6', text: '#ffffff', border: '#2563EB' },
+  backend:         { bg: '#8B5CF6', text: '#ffffff', border: '#7C3AED' },
+  'smart-contract':{ bg: '#F59E0B', text: '#ffffff', border: '#D97706' },
+  devops:          { bg: '#6B7280', text: '#ffffff', border: '#4B5563' },
+  documentation:   { bg: '#10B981', text: '#ffffff', border: '#059669' },
+  docs:            { bg: '#10B981', text: '#ffffff', border: '#059669' },
+  security:        { bg: '#EF4444', text: '#ffffff', border: '#DC2626' },
+  design:          { bg: '#EC4899', text: '#ffffff', border: '#DB2777' },
+  content:         { bg: '#14B8A6', text: '#ffffff', border: '#0D9488' },
+};
+
+// GitHub-style label colors for well-known tech stacks
+const SKILL_COLORS: Record<string, { bg: string; text: string; border: string }> = {
+  typescript:  { bg: '#0284c7', text: '#ffffff', border: '#0369a1' },
+  javascript:  { bg: '#ca8a04', text: '#ffffff', border: '#a16207' },
+  rust:        { bg: '#b45309', text: '#ffffff', border: '#92400e' },
+  python:      { bg: '#15803d', text: '#ffffff', border: '#166534' },
+  solidity:    { bg: '#6d28d9', text: '#ffffff', border: '#5b21b6' },
+  react:       { bg: '#0e7490', text: '#ffffff', border: '#155e75' },
+  fastapi:     { bg: '#065f46', text: '#ffffff', border: '#064e3b' },
+  anchor:      { bg: '#7c3aed', text: '#ffffff', border: '#6d28d9' },
+  solana:      { bg: '#14F195', text: '#0f172a', border: '#10b981' },
+  'node.js':   { bg: '#166534', text: '#ffffff', border: '#14532d' },
+};
+
+const DEFAULT_SKILL_COLOR = { bg: '#374151', text: '#d1d5db', border: '#4B5563' };
+
+function resolveColors(type: TagType, value: string): { bg: string; text: string; border: string } {
+  const key = value.toLowerCase();
+  if (type === 'category') {
+    return CATEGORY_COLORS[key] ?? DEFAULT_SKILL_COLOR;
+  }
+  return SKILL_COLORS[key] ?? DEFAULT_SKILL_COLOR;
+}
+
+interface BountyTagProps {
+  type: TagType;
+  value: string;
+  label?: string;
+  onTagClick?: (type: TagType, value: string) => void;
+  className?: string;
+}
+
+export function BountyTag({ type, value, label, onTagClick, className = '' }: BountyTagProps) {
+  const colors = resolveColors(type, value);
+  const displayLabel = label ?? value;
+  const clickable = typeof onTagClick === 'function';
+
+  const baseStyle: React.CSSProperties = {
+    backgroundColor: colors.bg + '22', // ~13% alpha tint, GitHub-label style
+    color: colors.bg,
+    borderColor: colors.bg + '55',
+  };
+
+  const hoverClass = clickable
+    ? 'cursor-pointer hover:opacity-80 focus-visible:ring-2 focus-visible:ring-offset-1'
+    : '';
+
+  if (clickable) {
+    return (
+      <button
+        type="button"
+        onClick={() => onTagClick(type, value)}
+        style={baseStyle}
+        className={
+          `inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium transition-opacity ${hoverClass} ${className}`
+        }
+        data-testid={`bounty-tag-${type}-${value}`}
+        aria-label={`Filter by ${type}: ${displayLabel}`}
+      >
+        {displayLabel}
+      </button>
+    );
+  }
+
+  return (
+    <span
+      style={baseStyle}
+      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${className}`}
+      data-testid={`bounty-tag-${type}-${value}`}
+    >
+      {displayLabel}
+    </span>
+  );
+}

--- a/frontend/src/components/bounties/BountyTagList.tsx
+++ b/frontend/src/components/bounties/BountyTagList.tsx
@@ -1,0 +1,101 @@
+import type { TagType } from './BountyTag';
+import { BountyTag } from './BountyTag';
+import type { BountyCategory, BountyTier } from '../../types/bounty';
+
+const CATEGORY_LABELS: Record<string, string> = {
+  'smart-contract': 'Smart Contract',
+  frontend: 'Frontend',
+  backend: 'Backend',
+  design: 'Design',
+  content: 'Content',
+  security: 'Security',
+  devops: 'DevOps',
+  documentation: 'Docs',
+};
+
+interface BountyTagListProps {
+  skills?: string[];
+  category?: BountyCategory | string;
+  tier?: BountyTier;
+  maxSkills?: number;
+  onTagClick?: (type: TagType, value: string) => void;
+  showTier?: boolean;
+}
+
+export function BountyTagList({
+  skills = [],
+  category,
+  tier,
+  maxSkills,
+  onTagClick,
+  showTier = false,
+}: BountyTagListProps) {
+  const visibleSkills = maxSkills != null ? skills.slice(0, maxSkills) : skills;
+  const overflow = maxSkills != null ? skills.length - maxSkills : 0;
+
+  return (
+    <div className="flex flex-wrap items-center gap-1" data-testid="bounty-tag-list">
+      {/* Tier badge rendered as a styled tag */}
+      {showTier && tier && (
+        <TierTag tier={tier} onTagClick={onTagClick} />
+      )}
+
+      {/* Category tag */}
+      {category && category !== 'all' && (
+        <BountyTag
+          type="category"
+          value={category}
+          label={CATEGORY_LABELS[category] ?? category}
+          onTagClick={onTagClick}
+        />
+      )}
+
+      {/* Skill tags */}
+      {visibleSkills.map(s => (
+        <BountyTag key={s} type="skill" value={s} onTagClick={onTagClick} />
+      ))}
+
+      {overflow > 0 && (
+        <span className="rounded-full border border-surface-300 bg-surface-200 px-2 py-0.5 text-xs text-gray-500">
+          +{overflow}
+        </span>
+      )}
+    </div>
+  );
+}
+
+// Tier-specific tag with fixed color mapping matching TierBadge conventions
+const TIER_COLORS: Record<BountyTier, React.CSSProperties> = {
+  T1: { backgroundColor: '#14F19522', color: '#14F195', borderColor: '#14F19555' },
+  T2: { backgroundColor: '#FFD70022', color: '#FFD700', borderColor: '#FFD70055' },
+  T3: { backgroundColor: '#FF6B6B22', color: '#FF6B6B', borderColor: '#FF6B6B55' },
+};
+
+function TierTag({ tier, onTagClick }: { tier: BountyTier; onTagClick?: (type: TagType, value: string) => void }) {
+  const style = TIER_COLORS[tier];
+
+  if (typeof onTagClick === 'function') {
+    return (
+      <button
+        type="button"
+        onClick={() => onTagClick('category', tier)}
+        style={style}
+        className="inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-bold cursor-pointer hover:opacity-80 transition-opacity focus-visible:ring-2"
+        data-testid={`bounty-tag-tier-${tier}`}
+        aria-label={`Filter by tier: ${tier}`}
+      >
+        {tier}
+      </button>
+    );
+  }
+
+  return (
+    <span
+      style={style}
+      className="inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-bold"
+      data-testid={`bounty-tag-tier-${tier}`}
+    >
+      {tier}
+    </span>
+  );
+}

--- a/frontend/src/components/bounties/SkillTags.tsx
+++ b/frontend/src/components/bounties/SkillTags.tsx
@@ -1,4 +1,26 @@
-export function SkillTags({ skills, maxVisible = 3 }: { skills: string[]; maxVisible?: number }) {
-  const v = skills.slice(0, maxVisible), o = skills.length - maxVisible;
-  return (<div className="flex flex-wrap gap-1" data-testid="skill-tags">{v.map(s => <span key={s} className="rounded-md bg-surface-200 px-2 py-0.5 text-xs text-gray-400">{s}</span>)}{o > 0 && <span className="rounded-md bg-surface-200 px-2 py-0.5 text-xs text-gray-500">+{o}</span>}</div>);
+import type { TagType } from './BountyTag';
+import { BountyTag } from './BountyTag';
+
+interface SkillTagsProps {
+  skills: string[];
+  maxVisible?: number;
+  onTagClick?: (type: TagType, value: string) => void;
+}
+
+export function SkillTags({ skills, maxVisible = 3, onTagClick }: SkillTagsProps) {
+  const visible = skills.slice(0, maxVisible);
+  const overflow = skills.length - maxVisible;
+
+  return (
+    <div className="flex flex-wrap gap-1" data-testid="skill-tags">
+      {visible.map(s => (
+        <BountyTag key={s} type="skill" value={s} onTagClick={onTagClick} />
+      ))}
+      {overflow > 0 && (
+        <span className="rounded-full border border-surface-300 bg-surface-200 px-2 py-0.5 text-xs text-gray-500">
+          +{overflow}
+        </span>
+      )}
+    </div>
+  );
 }

--- a/frontend/src/components/bounties/index.ts
+++ b/frontend/src/components/bounties/index.ts
@@ -8,3 +8,6 @@ export { TierBadge } from './TierBadge';
 export { StatusIndicator } from './StatusIndicator';
 export { SkillTags } from './SkillTags';
 export { EmptyState } from './EmptyState';
+export { BountyTag } from './BountyTag';
+export type { TagType } from './BountyTag';
+export { BountyTagList } from './BountyTagList';


### PR DESCRIPTION
Adds a reusable BountyTag component system for categories and tech stack labels:

- Color-coded category tags (Frontend=blue, Backend=purple, Smart Contract=orange, etc.)
- Tech stack tags (Python, TypeScript, Rust, Solidity, React, etc.)
- Tier badge integration (T1=green, T2=yellow, T3=red)
- Clickable tags that filter the bounty list
- Reusable across bounty cards and detail pages
- Colors match GitHub label convention

Closes #487

**Wallet:** GhUgLwY9ky48FechbmvN7XBHkNRJZRwBmw36g8r6KKpG