### PR TITLE
feat: contributor profile page (#483)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -133,6 +133,7 @@ function AppLayout() {
 
           {/* Contributor and Creator */}
           <Route path="/profile/:username" element={<ContributorProfilePage />} />
+          <Route path="/contributor/:username" element={<ContributorProfilePage />} />
           <Route path="/dashboard" element={<DashboardPage />} />
           <Route path="/creator" element={<CreatorDashboardPage />} />
 

--- a/frontend/src/components/ContributorProfile.test.tsx
+++ b/frontend/src/components/ContributorProfile.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { ContributorProfile } from './ContributorProfile';
 import type { ContributorBadgeStats } from '../types/badges';
 
@@ -24,9 +25,9 @@ describe('ContributorProfile', () => {
     expect(screen.getByText('testuser')).toBeInTheDocument();
   });
 
-  it('displays truncated wallet address', () => {
+  it('displays truncated wallet address (first 4 + last 4)', () => {
     render(<ContributorProfile {...defaultProps} />);
-    expect(screen.getByText(/Amu1YJ.*71o7/)).toBeInTheDocument();
+    expect(screen.getByText('Amu1...o7')).toBeInTheDocument();
   });
 
   it('displays total earned', () => {
@@ -70,5 +71,64 @@ describe('ContributorProfile', () => {
     render(<ContributorProfile {...defaultProps} />);
     expect(screen.queryByTestId('badge-grid')).not.toBeInTheDocument();
     expect(screen.queryByTestId('header-badge-count')).not.toBeInTheDocument();
+  });
+
+  it('renders tier progress bar section', () => {
+    render(<ContributorProfile {...defaultProps} completedT1={2} completedT2={0} completedT3={0} />);
+    expect(screen.getByTestId('tier-progress-section')).toBeInTheDocument();
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  it('renders T1/T2/T3 breakdown in stats', () => {
+    render(
+      <ContributorProfile
+        {...defaultProps}
+        completedT1={3}
+        completedT2={1}
+        completedT3={0}
+      />,
+    );
+    const breakdown = screen.getByTestId('bounty-tier-breakdown');
+    expect(breakdown).toBeInTheDocument();
+    expect(breakdown).toHaveTextContent('T1:');
+    expect(breakdown).toHaveTextContent('T2:');
+    expect(breakdown).toHaveTextContent('T3:');
+  });
+
+  it('shows copy button for wallet address', () => {
+    render(<ContributorProfile {...defaultProps} />);
+    expect(screen.getByTestId('copy-wallet-btn')).toBeInTheDocument();
+  });
+
+  it('copy button copies the full wallet address to clipboard', async () => {
+    const user = userEvent.setup();
+    Object.assign(navigator, {
+      clipboard: { writeText: jest.fn().mockResolvedValue(undefined) },
+    });
+    render(<ContributorProfile {...defaultProps} />);
+    await user.click(screen.getByTestId('copy-wallet-btn'));
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      'Amu1YJjcKWKL6xuMTo2dx511kfzXAjxgpetJrZp7N71o7',
+    );
+  });
+
+  it('renders join date when provided', () => {
+    render(<ContributorProfile {...defaultProps} joinDate="2025-06-01T00:00:00Z" />);
+    expect(screen.getByText(/Joined/)).toBeInTheDocument();
+  });
+
+  it('renders recent activity section', () => {
+    const recentBounties = [
+      { id: 'b1', title: 'Fix login bug', tier: 'T1' as const, reward: 5000, completedAt: '2026-03-01T00:00:00Z' },
+    ];
+    render(<ContributorProfile {...defaultProps} recentBounties={recentBounties} />);
+    expect(screen.getByTestId('recent-activity-section')).toBeInTheDocument();
+    expect(screen.getByTestId('recent-activity-list')).toBeInTheDocument();
+    expect(screen.getByText('Fix login bug')).toBeInTheDocument();
+  });
+
+  it('renders empty activity message when no recent bounties', () => {
+    render(<ContributorProfile {...defaultProps} recentBounties={[]} />);
+    expect(screen.getByText(/No completed bounties yet/)).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/ContributorProfile.tsx
+++ b/frontend/src/components/ContributorProfile.tsx
@@ -1,51 +1,162 @@
 'use client';
 
-import React from 'react';
+import React, { useState } from 'react';
 import type { ContributorBadgeStats } from '../types/badges';
 import { computeBadges } from '../types/badges';
 import { BadgeGrid } from './badges';
+import { TierProgressBar } from './common/TierProgressBar';
+import { TierBadge } from './bounties/TierBadge';
+import type { BountyTier } from '../types/bounty';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface RecentBounty {
+  id: string;
+  title: string;
+  tier: BountyTier;
+  reward: number;
+  completedAt: string;
+}
 
 interface ContributorProfileProps {
   username: string;
   avatarUrl?: string;
   walletAddress?: string;
+  joinDate?: string;
   totalEarned?: number;
   bountiesCompleted?: number;
+  completedT1?: number;
+  completedT2?: number;
+  completedT3?: number;
   reputationScore?: number;
+  recentBounties?: RecentBounty[];
   /** Badge stats — if omitted, badge section is hidden. */
   badgeStats?: ContributorBadgeStats;
 }
+
+// ── Wallet copy button ────────────────────────────────────────────────────────
+
+function WalletAddressRow({ walletAddress }: { walletAddress: string }) {
+  const [copied, setCopied] = useState(false);
+
+  if (!walletAddress) {
+    return <p className="text-gray-400 text-xs sm:text-sm font-mono">Not connected</p>;
+  }
+
+  const truncated = `${walletAddress.slice(0, 4)}...${walletAddress.slice(-4)}`;
+
+  function handleCopy() {
+    navigator.clipboard.writeText(walletAddress).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-gray-400 text-xs sm:text-sm font-mono" title={walletAddress}>
+        {truncated}
+      </span>
+      <button
+        onClick={handleCopy}
+        aria-label="Copy wallet address"
+        className="text-gray-500 hover:text-gray-300 transition-colors focus:outline-none focus:ring-2 focus:ring-[#9945FF]/50 rounded"
+        data-testid="copy-wallet-btn"
+      >
+        {copied ? (
+          <svg className="w-3.5 h-3.5 text-[#14F195]" fill="none" viewBox="0 0 24 24" strokeWidth={2.5} stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+          </svg>
+        ) : (
+          <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 01-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 011.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 00-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 01-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 00-3.375-3.375h-1.5a1.125 1.125 0 01-1.125-1.125v-1.5a3.375 3.375 0 00-3.375-3.375H9.75" />
+          </svg>
+        )}
+      </button>
+    </div>
+  );
+}
+
+// ── Recent bounties list ──────────────────────────────────────────────────────
+
+function RecentActivity({ bounties }: { bounties: RecentBounty[] }) {
+  if (bounties.length === 0) {
+    return (
+      <div className="bg-gray-800 rounded-lg p-4 text-center text-gray-500 text-sm">
+        No completed bounties yet.
+      </div>
+    );
+  }
+
+  return (
+    <ul className="space-y-2" data-testid="recent-activity-list">
+      {bounties.map((b) => (
+        <li key={b.id} className="flex items-center justify-between bg-gray-800 rounded-lg px-4 py-3 gap-3 min-w-0">
+          <div className="flex items-center gap-2 min-w-0">
+            <TierBadge tier={b.tier} />
+            <a
+              href={`/bounties/${b.id}`}
+              className="text-sm text-gray-200 hover:text-white truncate transition-colors"
+            >
+              {b.title}
+            </a>
+          </div>
+          <div className="flex items-center gap-3 shrink-0">
+            <span className="text-xs text-green-400 font-mono font-semibold">
+              +{b.reward.toLocaleString()} FNDRY
+            </span>
+            <span className="text-xs text-gray-500 hidden sm:block">
+              {new Date(b.completedAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+            </span>
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
 
 export const ContributorProfile: React.FC<ContributorProfileProps> = ({
   username,
   avatarUrl,
   walletAddress = '',
+  joinDate,
   totalEarned = 0,
   bountiesCompleted = 0,
+  completedT1 = 0,
+  completedT2 = 0,
+  completedT3 = 0,
   reputationScore = 0,
+  recentBounties = [],
   badgeStats,
 }) => {
-  const truncatedWallet = walletAddress
-    ? `${walletAddress.slice(0, 6)}...${walletAddress.slice(-4)}`
-    : 'Not connected';
-
   const badges = badgeStats ? computeBadges(badgeStats) : [];
   const earnedCount = badges.filter((b) => b.earned).length;
+
+  const joinDateFormatted = joinDate
+    ? new Date(joinDate).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })
+    : null;
 
   return (
     <div className="bg-gray-900 rounded-lg p-4 sm:p-6 text-white space-y-6">
       {/* Profile Header */}
       <div className="flex flex-col sm:flex-row sm:items-center gap-4">
-        <div className="w-16 h-16 sm:w-20 sm:h-20 rounded-full bg-purple-500 flex items-center justify-center shrink-0 mx-auto sm:mx-0">
+        <div className="w-16 h-16 sm:w-20 sm:h-20 rounded-full bg-purple-500 flex items-center justify-center shrink-0 mx-auto sm:mx-0 overflow-hidden">
           {avatarUrl ? (
-            <img src={avatarUrl} alt={username} className="w-full h-full rounded-full" />
+            <img src={avatarUrl} alt={username} className="w-full h-full rounded-full object-cover" />
           ) : (
             <span className="text-2xl sm:text-3xl">{username.charAt(0).toUpperCase()}</span>
           )}
         </div>
-        <div className="text-center sm:text-left flex-1">
+        <div className="text-center sm:text-left flex-1 min-w-0">
           <h1 className="text-xl sm:text-2xl font-bold break-words">{username}</h1>
-          <p className="text-gray-400 text-xs sm:text-sm font-mono">{truncatedWallet}</p>
+          <div className="flex items-center justify-center sm:justify-start gap-2 mt-1">
+            <WalletAddressRow walletAddress={walletAddress} />
+          </div>
+          {joinDateFormatted && (
+            <p className="text-gray-500 text-xs mt-1">Joined {joinDateFormatted}</p>
+          )}
         </div>
 
         {/* Badge count pill in header */}
@@ -64,19 +175,55 @@ export const ContributorProfile: React.FC<ContributorProfileProps> = ({
       </div>
 
       {/* Stats Cards */}
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 sm:gap-4">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 sm:gap-4">
         <div className="bg-gray-800 rounded-lg p-3 sm:p-4">
           <p className="text-gray-400 text-xs sm:text-sm">Total Earned</p>
           <p className="text-lg sm:text-xl font-bold text-green-400">{totalEarned.toLocaleString()} FNDRY</p>
         </div>
         <div className="bg-gray-800 rounded-lg p-3 sm:p-4">
-          <p className="text-gray-400 text-xs sm:text-sm">Bounties</p>
-          <p className="text-lg sm:text-xl font-bold text-purple-400">{bountiesCompleted}</p>
-        </div>
-        <div className="bg-gray-800 rounded-lg p-3 sm:p-4">
           <p className="text-gray-400 text-xs sm:text-sm">Reputation</p>
           <p className="text-lg sm:text-xl font-bold text-yellow-400">{reputationScore}</p>
         </div>
+        {/* T1/T2/T3 breakdown */}
+        <div className="bg-gray-800 rounded-lg p-3 sm:p-4 col-span-2 sm:col-span-2" data-testid="bounty-tier-breakdown">
+          <p className="text-gray-400 text-xs sm:text-sm mb-2">Bounties Completed</p>
+          <div className="flex items-center gap-3">
+            <span className="text-lg sm:text-xl font-bold text-purple-400">{bountiesCompleted}</span>
+            <div className="flex gap-2 text-xs font-mono">
+              <span className="flex items-center gap-1">
+                <span className="inline-block w-2 h-2 rounded-full bg-[#14F195]" />
+                <span className="text-gray-400">T1:</span>
+                <span className="text-gray-200 font-semibold">{completedT1}</span>
+              </span>
+              <span className="flex items-center gap-1">
+                <span className="inline-block w-2 h-2 rounded-full bg-[#FFD700]" />
+                <span className="text-gray-400">T2:</span>
+                <span className="text-gray-200 font-semibold">{completedT2}</span>
+              </span>
+              <span className="flex items-center gap-1">
+                <span className="inline-block w-2 h-2 rounded-full bg-[#FF6B6B]" />
+                <span className="text-gray-400">T3:</span>
+                <span className="text-gray-200 font-semibold">{completedT3}</span>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Tier Progress Bar */}
+      <div className="bg-gray-800 rounded-lg p-4 sm:p-5" data-testid="tier-progress-section">
+        <h2 className="text-sm font-semibold text-gray-300 mb-4">Tier Progress</h2>
+        <TierProgressBar
+          completedT1={completedT1}
+          completedT2={completedT2}
+          completedT3={completedT3}
+        />
+      </div>
+
+      {/* Recent Activity */}
+      <div data-testid="recent-activity-section">
+        <h2 className="text-sm font-semibold text-gray-300 mb-3">Recent Activity</h2>
+        <RecentActivity bounties={recentBounties} />
       </div>
 
       {/* Achievements / Badge Grid */}

--- a/frontend/src/pages/ContributorProfilePage.tsx
+++ b/frontend/src/pages/ContributorProfilePage.tsx
@@ -1,12 +1,13 @@
 /**
- * Route for /profile/:username -- exact lookup via apiClient + React Query.
- * Shows contributor stats fetched from the backend, with loading skeleton
- * and proper error display on failure.
+ * Route for /profile/:username and /contributor/:username — exact lookup via
+ * apiClient + React Query.  Shows contributor stats fetched from the backend,
+ * with loading skeleton and proper error display on failure.
  * @module pages/ContributorProfilePage
  */
 import { useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import ContributorProfile from '../components/ContributorProfile';
+import type { RecentBounty } from '../components/ContributorProfile';
 import { SkeletonCard } from '../components/common/Skeleton';
 import { apiClient } from '../services/apiClient';
 import type { ContributorBadgeStats } from '../types/badges';
@@ -32,9 +33,14 @@ interface ContributorApiResponse {
   username: string;
   avatar_url?: string;
   wallet_address?: string;
+  join_date?: string;
   total_earned?: number;
   bounties_completed?: number;
+  completed_t1?: number;
+  completed_t2?: number;
+  completed_t3?: number;
   reputation_score?: number;
+  recent_bounties?: RecentBounty[];
 }
 
 /**
@@ -91,21 +97,40 @@ export default function ContributorProfilePage() {
 
   if (!contributor) {
     return (
-      <div className="p-6 max-w-3xl mx-auto text-center text-gray-400">
-        Contributor not found.
+      <div className="p-6 max-w-3xl mx-auto text-center" role="alert" data-testid="not-found-state">
+        <div className="bg-gray-800 rounded-xl p-8">
+          <p className="text-2xl mb-2">404</p>
+          <p className="text-gray-300 font-semibold mb-1">Contributor not found</p>
+          <p className="text-gray-500 text-sm">
+            No contributor with username <span className="font-mono text-gray-400">{username}</span> exists.
+          </p>
+        </div>
       </div>
     );
   }
 
+  const completedT1 = contributor.completed_t1 ?? 0;
+  const completedT2 = contributor.completed_t2 ?? 0;
+  const completedT3 = contributor.completed_t3 ?? 0;
+  const bountiesCompleted =
+    contributor.bounties_completed ?? completedT1 + completedT2 + completedT3;
+
   return (
-    <ContributorProfile
-      username={contributor.username}
-      avatarUrl={contributor.avatar_url ?? `https://avatars.githubusercontent.com/${username}`}
-      walletAddress={contributor.wallet_address ?? ''}
-      totalEarned={contributor.total_earned ?? 0}
-      bountiesCompleted={contributor.bounties_completed ?? 0}
-      reputationScore={contributor.reputation_score ?? 0}
-      badgeStats={MOCK_BADGE_STATS}
-    />
+    <div className="p-4 sm:p-6 max-w-3xl mx-auto">
+      <ContributorProfile
+        username={contributor.username}
+        avatarUrl={contributor.avatar_url ?? `https://avatars.githubusercontent.com/${username}`}
+        walletAddress={contributor.wallet_address ?? ''}
+        joinDate={contributor.join_date}
+        totalEarned={contributor.total_earned ?? 0}
+        bountiesCompleted={bountiesCompleted}
+        completedT1={completedT1}
+        completedT2={completedT2}
+        completedT3={completedT3}
+        reputationScore={contributor.reputation_score ?? 0}
+        recentBounties={contributor.recent_bounties ?? []}
+        badgeStats={MOCK_BADGE_STATS}
+      />
+    </div>
   );
 }


### PR DESCRIPTION
Enhances the contributor profile page to meet bounty #483 requirements:

- Tier progress bar showing progress toward next tier (e.g., "3/5 T1s toward T2")
- Wallet address displayed with truncation and copy-to-clipboard button
- T1/T2/T3 bounty completion breakdown in stats
- Full contributor profile with avatar, username, join date, tier badge
- Recent activity list with bounty links
- Loading skeleton and 404 state for unknown contributors

Closes #483

**Wallet:** GhUgLwY9ky48FechbmvN7XBHkNRJZRwBmw36g8r6KKpG

## Changes

- `ContributorProfile.tsx` — added `TierProgressBar`, wallet copy button, T1/T2/T3 stats breakdown, join date, recent activity list, `RecentBounty` type export
- `ContributorProfilePage.tsx` — passes new props (`completedT1/T2/T3`, `joinDate`, `recentBounties`), improved 404 state, updated `ContributorApiResponse` shape
- `App.tsx` — added `/contributor/:username` route alias alongside existing `/profile/:username`
- `ContributorProfile.test.tsx` — added tests for tier progress bar, copy button, T1/T2/T3 breakdown, join date, recent activity