### PR TITLE
feat: add reusable Tooltip component and apply to dashboard stat cards

### DIFF
--- a/frontend/src/__tests__/Tooltip.test.tsx
+++ b/frontend/src/__tests__/Tooltip.test.tsx
@@ -1,0 +1,254 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Tooltip } from '../components/ui/Tooltip';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderTooltip(
+  content = 'Tooltip text',
+  position: 'top' | 'bottom' | 'left' | 'right' = 'top'
+) {
+  return render(
+    <Tooltip content={content} position={position}>
+      <button type="button">Trigger</button>
+    </Tooltip>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Tooltip', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders children', () => {
+    renderTooltip();
+    expect(screen.getByRole('button', { name: 'Trigger' })).toBeInTheDocument();
+  });
+
+  it('tooltip bubble is hidden by default (opacity-0)', () => {
+    renderTooltip('Hello tooltip');
+    const bubble = screen.getByRole('tooltip', { hidden: true });
+    expect(bubble).toHaveClass('opacity-0');
+    expect(bubble).not.toHaveClass('opacity-100');
+  });
+
+  it('shows tooltip on mouse enter', async () => {
+    renderTooltip('Hover content');
+    const trigger = screen.getByRole('button', { name: 'Trigger' }).parentElement!;
+    fireEvent.mouseEnter(trigger);
+    const bubble = screen.getByRole('tooltip');
+    expect(bubble).toHaveClass('opacity-100');
+    expect(bubble).toHaveTextContent('Hover content');
+  });
+
+  it('hides tooltip on mouse leave (after brief delay)', async () => {
+    renderTooltip('Hover content');
+    const trigger = screen.getByRole('button', { name: 'Trigger' }).parentElement!;
+
+    fireEvent.mouseEnter(trigger);
+    expect(screen.getByRole('tooltip')).toHaveClass('opacity-100');
+
+    fireEvent.mouseLeave(trigger);
+    // Before the 80ms timer fires the bubble is still rendered
+    expect(screen.getByRole('tooltip', { hidden: true })).toBeInTheDocument();
+
+    // Advance timer past hide delay
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    await waitFor(() =>
+      expect(screen.getByRole('tooltip', { hidden: true })).toHaveClass('opacity-0')
+    );
+  });
+
+  it('shows tooltip on focus', () => {
+    renderTooltip('Focus content');
+    const trigger = screen.getByRole('button', { name: 'Trigger' }).parentElement!;
+    fireEvent.focus(trigger);
+    expect(screen.getByRole('tooltip')).toHaveClass('opacity-100');
+  });
+
+  it('hides tooltip on blur', async () => {
+    renderTooltip('Focus content');
+    const trigger = screen.getByRole('button', { name: 'Trigger' }).parentElement!;
+
+    fireEvent.focus(trigger);
+    fireEvent.blur(trigger);
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    await waitFor(() =>
+      expect(screen.getByRole('tooltip', { hidden: true })).toHaveClass('opacity-0')
+    );
+  });
+
+  it('toggles on click (tap to show)', async () => {
+    renderTooltip('Tap content');
+    const trigger = screen.getByRole('button', { name: 'Trigger' }).parentElement!;
+
+    // First tap: show
+    fireEvent.click(trigger);
+    expect(screen.getByRole('tooltip')).toHaveClass('opacity-100');
+
+    // Second tap: hide
+    fireEvent.click(trigger);
+    expect(screen.getByRole('tooltip', { hidden: true })).toHaveClass('opacity-0');
+  });
+
+  it('closes on outside click when visible', async () => {
+    renderTooltip('Outside click');
+    const trigger = screen.getByRole('button', { name: 'Trigger' }).parentElement!;
+
+    fireEvent.click(trigger);
+    expect(screen.getByRole('tooltip')).toHaveClass('opacity-100');
+
+    // Simulate outside click by firing on document
+    fireEvent.click(document);
+
+    await waitFor(() =>
+      expect(screen.getByRole('tooltip', { hidden: true })).toHaveClass('opacity-0')
+    );
+  });
+
+  it('renders content string correctly', () => {
+    renderTooltip('My tooltip text');
+    const trigger = screen.getByRole('button', { name: 'Trigger' }).parentElement!;
+    fireEvent.mouseEnter(trigger);
+    expect(screen.getByRole('tooltip')).toHaveTextContent('My tooltip text');
+  });
+
+  it('defaults to top position when position is omitted', () => {
+    render(
+      <Tooltip content="Default position">
+        <span>child</span>
+      </Tooltip>
+    );
+    const wrapper = screen.getByText('child').parentElement!;
+    const bubble = wrapper.querySelector('[role="tooltip"]');
+    // top position adds bottom-full class
+    expect(bubble).toHaveClass('bottom-full');
+  });
+
+  it('applies bottom position classes', () => {
+    render(
+      <Tooltip content="Bottom tip" position="bottom">
+        <span>child</span>
+      </Tooltip>
+    );
+    const wrapper = screen.getByText('child').parentElement!;
+    const bubble = wrapper.querySelector('[role="tooltip"]');
+    expect(bubble).toHaveClass('top-full');
+  });
+
+  it('applies left position classes', () => {
+    render(
+      <Tooltip content="Left tip" position="left">
+        <span>child</span>
+      </Tooltip>
+    );
+    const wrapper = screen.getByText('child').parentElement!;
+    const bubble = wrapper.querySelector('[role="tooltip"]');
+    expect(bubble).toHaveClass('right-full');
+  });
+
+  it('applies right position classes', () => {
+    render(
+      <Tooltip content="Right tip" position="right">
+        <span>child</span>
+      </Tooltip>
+    );
+    const wrapper = screen.getByText('child').parentElement!;
+    const bubble = wrapper.querySelector('[role="tooltip"]');
+    expect(bubble).toHaveClass('left-full');
+  });
+
+  it('applies optional className to wrapper', () => {
+    render(
+      <Tooltip content="cls" className="my-custom-class">
+        <span>child</span>
+      </Tooltip>
+    );
+    const wrapper = screen.getByText('child').parentElement!;
+    expect(wrapper).toHaveClass('my-custom-class');
+  });
+
+  it('has aria-hidden=true when not visible', () => {
+    renderTooltip();
+    const bubble = screen.getByRole('tooltip', { hidden: true });
+    expect(bubble).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('has aria-hidden=false when visible', () => {
+    renderTooltip();
+    const trigger = screen.getByRole('button', { name: 'Trigger' }).parentElement!;
+    fireEvent.mouseEnter(trigger);
+    const bubble = screen.getByRole('tooltip');
+    expect(bubble).toHaveAttribute('aria-hidden', 'false');
+  });
+
+  it('does not flicker when mouse re-enters before hide delay', async () => {
+    renderTooltip('No flicker');
+    const trigger = screen.getByRole('button', { name: 'Trigger' }).parentElement!;
+
+    fireEvent.mouseEnter(trigger);
+    fireEvent.mouseLeave(trigger);
+    // Re-enter before the 80ms delay fires
+    fireEvent.mouseEnter(trigger);
+
+    // Advance past the original hide delay — tooltip should still be visible
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(screen.getByRole('tooltip')).toHaveClass('opacity-100');
+  });
+
+  it('renders children other than buttons', () => {
+    render(
+      <Tooltip content="div child">
+        <div data-testid="inner-div">content</div>
+      </Tooltip>
+    );
+    expect(screen.getByTestId('inner-div')).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: Tooltip applied to dashboard-style stat card
+// ---------------------------------------------------------------------------
+
+describe('Tooltip on stat card', () => {
+  it('wraps a stat card label and shows tooltip on hover', () => {
+    render(
+      <div>
+        <Tooltip content="Total number of bounties posted across all tiers" position="top">
+          <span data-testid="stat-label">Total Bounties</span>
+        </Tooltip>
+        <p data-testid="stat-value">42</p>
+      </div>
+    );
+
+    const label = screen.getByTestId('stat-label');
+    expect(label).toHaveTextContent('Total Bounties');
+
+    // Hover the wrapper
+    fireEvent.mouseEnter(label.parentElement!);
+    const bubble = screen.getByRole('tooltip');
+    expect(bubble).toHaveTextContent('Total number of bounties posted across all tiers');
+    expect(bubble).toHaveClass('opacity-100');
+  });
+});

--- a/frontend/src/components/ContributorDashboard.tsx
+++ b/frontend/src/components/ContributorDashboard.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useCallback } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { apiClient } from '../services/apiClient';
+import { Tooltip } from './ui/Tooltip';
 
 // ============================================================================
 // Types
@@ -236,13 +237,23 @@ interface SummaryCardProps {
   icon: React.ReactNode;
   trend?: 'up' | 'down' | 'neutral';
   trendValue?: string;
+  /** Optional tooltip text shown on hover/tap. */
+  tooltip?: string;
 }
 
-function SummaryCard({ label, value, suffix, icon, trend, trendValue }: SummaryCardProps) {
+function SummaryCard({ label, value, suffix, icon, trend, trendValue, tooltip }: SummaryCardProps) {
+  const labelNode = tooltip ? (
+    <Tooltip content={tooltip} position="top">
+      <span className="text-gray-400 text-sm cursor-help border-b border-dashed border-gray-600">{label}</span>
+    </Tooltip>
+  ) : (
+    <span className="text-gray-400 text-sm">{label}</span>
+  );
+
   return (
     <div className="bg-[#1a1a1a] rounded-xl p-5 border border-white/5 hover:border-white/10 transition-colors">
       <div className="flex items-center justify-between mb-3">
-        <span className="text-gray-400 text-sm">{label}</span>
+        {labelNode}
         <div className="w-10 h-10 rounded-lg bg-[#14F195]/10 flex items-center justify-center">
           {icon}
         </div>
@@ -749,6 +760,7 @@ export function ContributorDashboard({
                 suffix="$FNDRY"
                 trend="up"
                 trendValue="+15% this month"
+                tooltip="Total $FNDRY tokens distributed to contributors"
                 icon={
                   <svg className="w-5 h-5 text-[#14F195]" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 18.75a60.07 60.07 0 0115.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M3.75 4.5v.75A.75.75 0 013 6h-.75m0 0v-.375c0-.621.504-1.125 1.125-1.125H20.25M2.25 6v9m18-10.5v.75c0 .414.336.75.75.75h.75m-1.5-1.5h.375c.621 0 1.125.504 1.125 1.125v9.75c0 .621-.504 1.125-1.125 1.125h-.375m1.5-1.5H21a.75.75 0 00-.75.75v.75m0 0H3.75m0 0h-.375a1.125 1.125 0 01-1.125-1.125V15m1.5 1.5v-.75A.75.75 0 003 15h-.75M15 10.5a3 3 0 11-6 0 3 3 0 016 0zm3 0h.008v.008H18V10.5zm-12 0h.008v.008H6V10.5z" />
@@ -758,6 +770,7 @@ export function ContributorDashboard({
               <SummaryCard
                 label="Active Bounties"
                 value={stats.activeBounties}
+                tooltip="PRs currently under AI review or awaiting merge"
                 icon={
                   <svg className="w-5 h-5 text-[#9945FF]" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" d="M20.25 14.15v4.25c0 1.094-.787 2.036-1.872 2.18-2.087.277-4.216.42-6.378.42s-4.291-.143-6.378-.42c-1.085-.144-1.872-1.086-1.872-2.18v-4.25m16.5 0a2.18 2.18 0 00.75-1.661V8.706c0-1.081-.768-2.015-1.837-2.175a48.114 48.114 0 00-3.413-.387m4.5 8.006c-.194.165-.42.295-.673.38A23.978 23.978 0 0112 15.75c-2.648 0-5.195-.429-7.577-1.22a2.016 2.016 0 01-.673-.38m0 0A2.18 2.18 0 013 12.489V8.706c0-1.081.768-2.015 1.837-2.175a48.111 48.111 0 013.413-.387m7.5 0V5.25A2.25 2.25 0 0013.5 3h-3a2.25 2.25 0 00-2.25 2.25v.894m7.5 0a48.667 48.667 0 00-7.5 0M12 12.75h.008v.008H12v-.008z" />
@@ -768,6 +781,7 @@ export function ContributorDashboard({
                 label="Pending Payouts"
                 value={formatNumber(stats.pendingPayouts)}
                 suffix="$FNDRY"
+                tooltip="Unique contributors who have submitted PRs"
                 icon={
                   <svg className="w-5 h-5 text-yellow-400" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z" />
@@ -780,6 +794,7 @@ export function ContributorDashboard({
                 suffix={`of ${stats.totalContributors}`}
                 trend="up"
                 trendValue="Top 20%"
+                tooltip="Your accumulated reputation from merged bounties"
                 icon={
                   <svg className="w-5 h-5 text-yellow-400" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 18.75h-9m9 0a3 3 0 013 3h-15a3 3 0 013-3m9 0v-3.375c0-.621-.503-1.125-1.125-1.125h-.871M7.5 18.75v-3.375c0-.621.504-1.125 1.125-1.125h.872m5.007 0H9.497m5.007 0a7.454 7.454 0 01-.982-3.172M9.497 14.25a7.454 7.454 0 00.981-3.172M5.25 4.236c-.982.143-1.954.317-2.916.52A6.003 6.003 0 007.73 9.728M5.25 4.236V4.5c0 2.108.966 3.99 2.48 5.228M5.25 4.236V2.721C7.456 2.41 9.71 2.25 12 2.25c2.291 0 4.545.16 6.75.47v1.516M7.73 9.728a6.726 6.726 0 002.748 1.35m8.272-6.842V4.5c0 2.108-.966 3.99-2.48 5.228m2.48-5.492a46.32 46.32 0 012.916.52 6.003 6.003 0 01-5.395 4.972m0 0a6.726 6.726 0 01-2.749 1.35m0 0a6.772 6.772 0 01-3.044 0" />

--- a/frontend/src/components/ContributorProfile.tsx
+++ b/frontend/src/components/ContributorProfile.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import type { ContributorBadgeStats } from '../types/badges';
 import { computeBadges } from '../types/badges';
 import { BadgeGrid } from './badges';
+import { Tooltip } from './ui/Tooltip';
 
 interface ContributorProfileProps {
   username: string;
@@ -66,15 +67,21 @@ export const ContributorProfile: React.FC<ContributorProfileProps> = ({
       {/* Stats Cards */}
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 sm:gap-4">
         <div className="bg-gray-800 rounded-lg p-3 sm:p-4">
-          <p className="text-gray-400 text-xs sm:text-sm">Total Earned</p>
+          <Tooltip content="Total $FNDRY tokens distributed to contributors" position="top">
+            <p className="text-gray-400 text-xs sm:text-sm cursor-help border-b border-dashed border-gray-600 inline-block">Total Earned</p>
+          </Tooltip>
           <p className="text-lg sm:text-xl font-bold text-green-400">{totalEarned.toLocaleString()} FNDRY</p>
         </div>
         <div className="bg-gray-800 rounded-lg p-3 sm:p-4">
-          <p className="text-gray-400 text-xs sm:text-sm">Bounties</p>
+          <Tooltip content="Total number of bounties posted across all tiers" position="top">
+            <p className="text-gray-400 text-xs sm:text-sm cursor-help border-b border-dashed border-gray-600 inline-block">Bounties</p>
+          </Tooltip>
           <p className="text-lg sm:text-xl font-bold text-purple-400">{bountiesCompleted}</p>
         </div>
         <div className="bg-gray-800 rounded-lg p-3 sm:p-4">
-          <p className="text-gray-400 text-xs sm:text-sm">Reputation</p>
+          <Tooltip content="Your accumulated reputation from merged bounties" position="top">
+            <p className="text-gray-400 text-xs sm:text-sm cursor-help border-b border-dashed border-gray-600 inline-block">Reputation</p>
+          </Tooltip>
           <p className="text-lg sm:text-xl font-bold text-yellow-400">{reputationScore}</p>
         </div>
       </div>

--- a/frontend/src/components/ui/Tooltip.tsx
+++ b/frontend/src/components/ui/Tooltip.tsx
@@ -1,0 +1,174 @@
+/**
+ * Tooltip — A reusable tooltip component with no external dependencies.
+ * Supports hover (desktop) and tap (mobile), with configurable positioning.
+ * @module components/ui/Tooltip
+ */
+import React, { useState, useCallback, useRef, useEffect } from 'react';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type TooltipPosition = 'top' | 'bottom' | 'left' | 'right';
+
+export interface TooltipProps {
+  /** The text content to display inside the tooltip bubble. */
+  content: string;
+  /** The element(s) that trigger the tooltip on hover or tap. */
+  children: React.ReactNode;
+  /** Where to place the tooltip relative to the trigger element. Defaults to 'top'. */
+  position?: TooltipPosition;
+  /** Optional additional class names for the wrapper element. */
+  className?: string;
+}
+
+// ============================================================================
+// Position Styles
+// ============================================================================
+
+/**
+ * Returns Tailwind classes for positioning and transforming the tooltip bubble
+ * based on the requested direction.
+ */
+function getPositionClasses(position: TooltipPosition): {
+  tooltip: string;
+  arrow: string;
+} {
+  switch (position) {
+    case 'bottom':
+      return {
+        tooltip: 'top-full left-1/2 -translate-x-1/2 mt-2',
+        arrow:
+          'bottom-full left-1/2 -translate-x-1/2 border-b-[#2a2a2a] border-x-transparent border-t-transparent',
+      };
+    case 'left':
+      return {
+        tooltip: 'right-full top-1/2 -translate-y-1/2 mr-2',
+        arrow:
+          'left-full top-1/2 -translate-y-1/2 border-l-[#2a2a2a] border-y-transparent border-r-transparent',
+      };
+    case 'right':
+      return {
+        tooltip: 'left-full top-1/2 -translate-y-1/2 ml-2',
+        arrow:
+          'right-full top-1/2 -translate-y-1/2 border-r-[#2a2a2a] border-y-transparent border-l-transparent',
+      };
+    case 'top':
+    default:
+      return {
+        tooltip: 'bottom-full left-1/2 -translate-x-1/2 mb-2',
+        arrow:
+          'top-full left-1/2 -translate-x-1/2 border-t-[#2a2a2a] border-x-transparent border-b-transparent',
+      };
+  }
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+/**
+ * Tooltip wraps any child element and shows a text bubble on hover (desktop)
+ * or tap (mobile). No external libraries are required — positioning and
+ * animation are handled with Tailwind CSS utility classes.
+ *
+ * @example
+ * <Tooltip content="Total $FNDRY tokens distributed" position="top">
+ *   <StatCard label="Total Paid" value="1.2M" />
+ * </Tooltip>
+ */
+export function Tooltip({
+  content,
+  children,
+  position = 'top',
+  className = '',
+}: TooltipProps) {
+  const [visible, setVisible] = useState(false);
+  const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const { tooltip: tooltipClasses, arrow: arrowClasses } =
+    getPositionClasses(position);
+
+  // Clear any pending hide timer on unmount to avoid state updates on unmounted
+  // components.
+  useEffect(() => {
+    return () => {
+      if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
+    };
+  }, []);
+
+  const show = useCallback(() => {
+    if (hideTimerRef.current) {
+      clearTimeout(hideTimerRef.current);
+      hideTimerRef.current = null;
+    }
+    setVisible(true);
+  }, []);
+
+  const hide = useCallback(() => {
+    // Small delay so the tooltip does not flicker when moving between elements.
+    hideTimerRef.current = setTimeout(() => setVisible(false), 80);
+  }, []);
+
+  // Toggle on tap for mobile — prevent the tap from bubbling so it does not
+  // immediately re-close via a document click listener.
+  const handleTap = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      setVisible((prev) => !prev);
+    },
+    []
+  );
+
+  // Close on any outside click while visible.
+  useEffect(() => {
+    if (!visible) return;
+    const close = () => setVisible(false);
+    document.addEventListener('click', close);
+    return () => document.removeEventListener('click', close);
+  }, [visible]);
+
+  return (
+    <div
+      className={`relative inline-flex ${className}`}
+      onMouseEnter={show}
+      onMouseLeave={hide}
+      onFocus={show}
+      onBlur={hide}
+      onClick={handleTap}
+    >
+      {children}
+
+      {/* Tooltip bubble */}
+      <div
+        role="tooltip"
+        aria-hidden={!visible}
+        className={[
+          'absolute z-50 w-max max-w-[220px] px-3 py-1.5',
+          'bg-[#2a2a2a] border border-white/10 rounded-lg',
+          'text-xs text-white/90 leading-snug shadow-lg',
+          'pointer-events-none select-none',
+          'transition-opacity duration-150',
+          tooltipClasses,
+          visible ? 'opacity-100' : 'opacity-0',
+        ].join(' ')}
+      >
+        {content}
+
+        {/* Arrow */}
+        <span
+          className={[
+            'absolute w-0 h-0',
+            'border-4',
+            arrowClasses,
+          ].join(' ')}
+        />
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// Exports
+// ============================================================================
+
+export default Tooltip;


### PR DESCRIPTION
Creates a reusable `<Tooltip>` component with no external dependencies (pure Tailwind CSS + React) and applies it to the contributor dashboard stat cards.

**Component** — `frontend/src/components/ui/Tooltip.tsx`
- Props: `content: string`, `children: React.ReactNode`, `position?: 'top'|'bottom'|'left'|'right'` (default `'top'`)
- Works on hover (desktop) via `onMouseEnter`/`onMouseLeave`
- Works on tap (mobile) via click toggle with outside-click dismiss
- Proper `role="tooltip"` and `aria-hidden` toggling for accessibility
- Hide delay (80ms) prevents flickering when moving between elements
- No external libraries — positioning and animation handled with Tailwind utility classes

**Dashboard integration** — `frontend/src/components/ContributorDashboard.tsx`
- `SummaryCard` accepts new optional `tooltip` prop
- All four stat cards wired with tooltip text:
  - Total Earned: "Total $FNDRY tokens distributed to contributors"
  - Active Bounties: "PRs currently under AI review or awaiting merge"
  - Pending Payouts: "Unique contributors who have submitted PRs"
  - Reputation Rank: "Your accumulated reputation from merged bounties"

**Profile integration** — `frontend/src/components/ContributorProfile.tsx`
- Stat card labels wrapped with Tooltip for Total Earned, Bounties, and Reputation

**Tests** — `frontend/src/__tests__/Tooltip.test.tsx`
- 17 test cases covering: default hidden state, mouse enter/leave, focus/blur, tap toggle, outside-click dismiss, position classes (all 4 directions), aria-hidden state, flicker prevention, custom className, and stat card integration

Closes #484

**Wallet:** GhUgLwY9ky48FechbmvN7XBHkNRJZRwBmw36g8r6KKpG