### PR TITLE
docs: Add status badges to README (#488)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,37 @@
 </p>
 
 <p align="center">
+  <!-- Build Status -->
+  <a href="https://github.com/SolFoundry/solfoundry/actions">
+    <img src="https://img.shields.io/github/actions/workflow/status/SolFoundry/solfoundry/ci.yml?branch=main" alt="Build Status" />
+  </a>
+  <!-- Contributors -->
+  <a href="https://github.com/SolFoundry/solfoundry/graphs/contributors">
+    <img src="https://img.shields.io/github/contributors/SolFoundry/solfoundry" alt="Contributors" />
+  </a>
+  <!-- Open Bounties -->
+  <a href="https://github.com/SolFoundry/solfoundry/issues?q=is%3Aissue+is%3Aopen+label%3Abounty">
+    <img src="https://img.shields.io/github/issues/SolFoundry/solfoundry/bounty" alt="Open Bounties" />
+  </a>
+  <!-- License -->
+  <a href="https://github.com/SolFoundry/solfoundry/blob/main/LICENSE">
+    <img src="https://img.shields.io/github/license/SolFoundry/solfoundry" alt="License" />
+  </a>
+  <!-- $FNDRY Paid -->
+  <a href="https://github.com/SolFoundry/solfoundry/issues?q=is%3Aissue+is%3Aclosed+label%3Abounty">
+    <img src="https://img.shields.io/github/issues-closed/SolFoundry/solfoundry/bounty?color=success&label=$FNDRY%20Paid" alt="$FNDRY Paid" />
+  </a>
+  <!-- Stars -->
+  <a href="https://github.com/SolFoundry/solfoundry/stargazers">
+    <img src="https://img.shields.io/github/stars/SolFoundry/solfoundry" alt="Stars" />
+  </a>
+  <!-- Forks -->
+  <a href="https://github.com/SolFoundry/solfoundry/forks">
+    <img src="https://img.shields.io/github/forks/SolFoundry/solfoundry" alt="Forks" />
+  </a>
+</p>
+
+<p align="center">
   <a href="https://solfoundry.org">Website</a> ·
   <a href="https://x.com/foundrysol">Twitter</a> ·
   <a href="https://bags.fm/launch/C2TvY8E8B75EF2UP8cTpTp3EDUjTgjWmpaGnT74VBAGS">Buy $FNDRY</a> ·


### PR DESCRIPTION
## 🏭 Bounty #488 Submission - README Badges

### Summary
Added dynamic status badges to the README showing build status, contributors, open bounties, and key metrics.

### ✅ Acceptance Criteria Met
- [x] Build status badge (GitHub Actions workflow)
- [x] Contributors count badge
- [x] Open bounties count badge
- [x] License badge
- [x] $FNDRY paid badge (closed bounties count)
- [x] GitHub stars badge
- [x] Forks badge
- [x] All badges use shields.io for dynamic updates
- [x] Clean row layout at top of README
- [x] All badge links point to relevant pages

### Badge Details

| Badge | Source | Link |
|-------|--------|------|
| Build Status | GitHub Actions CI workflow | Actions page |
| Contributors | GitHub contributors API | Contributors graph |
| Open Bounties | GitHub issues with bounty label | Filtered issues |
| License | GitHub license API | LICENSE file |
| $FNDRY Paid | GitHub closed issues with bounty label | Closed bounties |
| Stars | GitHub stargazers API | Stargazers page |
| Forks | GitHub forks API | Forks page |

### Implementation

- All badges use shields.io dynamic endpoints
- Badges arranged in a clean row below the project description
- Each badge is clickable and links to the relevant page
- No static images - all badges update automatically

### Wallet Address for Reward
- **SOL**: `9xsvaaYbVrRuMu6JbXq5wVY9tDAz5S6BFzmjBkUaM865`
- **USDT TRC20**: `TMLkvEDrjvHEUbWYU1jfqyUKmbLNZkx6T1`

Fixes #488