### PR TITLE
Search bar for bounty listing

### DIFF
--- a/frontend/src/components/bounties/BountyFilters.tsx
+++ b/frontend/src/components/bounties/BountyFilters.tsx
@@ -10,21 +10,64 @@ interface Props {
   totalCount: number;
 }
 
+// Compact chip labels (shorter than full option labels)
+const TIER_CHIP_LABELS: Record<string, string> = {
+  all: 'All', T1: 'T1', T2: 'T2', T3: 'T3',
+};
+
+const STATUS_CHIP_LABELS: Record<string, string> = {
+  all: 'All', open: 'Open', 'in-progress': 'In Progress',
+  under_review: 'Under Review', completed: 'Completed',
+  disputed: 'Disputed', paid: 'Paid', cancelled: 'Cancelled',
+};
+
+const CATEGORY_CHIP_LABELS: Record<string, string> = {
+  all: 'All', 'smart-contract': 'Smart Contract', frontend: 'Frontend',
+  backend: 'Backend', design: 'Design', content: 'Content',
+  security: 'Security', devops: 'DevOps', documentation: 'Docs',
+};
+
+const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad|iPod/.test(navigator.platform);
+const SHORTCUT_LABEL = isMac ? '⌘K' : 'Ctrl+K';
+
 export function BountyFilters({ filters: f, onFilterChange, onReset, resultCount, totalCount }: Props) {
   const searchRef = useRef<HTMLInputElement>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [localQuery, setLocalQuery] = useState(f.searchQuery);
   const [suggestions, setSuggestions] = useState<AutocompleteItem[]>([]);
   const [showSuggestions, setShowSuggestions] = useState(false);
   const [showAdvanced, setShowAdvanced] = useState(false);
   const suggestionsRef = useRef<HTMLDivElement>(null);
 
+  // Sync local query when external reset clears searchQuery
+  useEffect(() => {
+    if (f.searchQuery === '' && localQuery !== '') {
+      setLocalQuery('');
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [f.searchQuery]);
+
   useEffect(() => () => { if (debounceRef.current) clearTimeout(debounceRef.current); }, []);
 
-  const handleSearch = useCallback((v: string) => {
-    if (debounceRef.current) clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => onFilterChange('searchQuery', v), 150);
+  // Cmd/Ctrl+K keyboard shortcut to focus search
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const modifier = isMac ? e.metaKey : e.ctrlKey;
+      if (modifier && e.key === 'k') {
+        e.preventDefault();
+        searchRef.current?.focus();
+        searchRef.current?.select();
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, []);
 
-    // Fetch autocomplete suggestions
+  const handleSearch = useCallback((v: string) => {
+    setLocalQuery(v);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => onFilterChange('searchQuery', v), 300);
+
     if (v.trim().length >= 2) {
       fetch(`/api/bounties/autocomplete?q=${encodeURIComponent(v.trim())}&limit=6`)
         .then(r => r.ok ? r.json() : null)
@@ -41,6 +84,15 @@ export function BountyFilters({ filters: f, onFilterChange, onReset, resultCount
     }
   }, [onFilterChange]);
 
+  const clearSearch = useCallback(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    setLocalQuery('');
+    setSuggestions([]);
+    setShowSuggestions(false);
+    onFilterChange('searchQuery', '');
+    searchRef.current?.focus();
+  }, [onFilterChange]);
+
   const selectSuggestion = useCallback((item: AutocompleteItem) => {
     if (item.type === 'skill') {
       const skills = f.skills;
@@ -48,8 +100,8 @@ export function BountyFilters({ filters: f, onFilterChange, onReset, resultCount
         onFilterChange('skills', [...skills, item.text]);
       }
     } else {
+      setLocalQuery(item.text);
       onFilterChange('searchQuery', item.text);
-      if (searchRef.current) searchRef.current.value = item.text;
     }
     setShowSuggestions(false);
   }, [f.skills, onFilterChange]);
@@ -74,25 +126,58 @@ export function BountyFilters({ filters: f, onFilterChange, onReset, resultCount
     f.searchQuery.trim() !== '' || f.rewardMin !== '' || f.rewardMax !== '' ||
     f.creatorType !== 'all' || f.category !== 'all' || f.deadlineBefore !== '';
 
+  const chipBase = 'rounded-full px-2.5 py-0.5 text-xs font-medium border transition-colors';
+  const chipActive = 'bg-solana-green/15 text-solana-green border-solana-green/30';
+  const chipInactive = 'bg-surface-50 text-gray-400 border-surface-300 hover:text-white hover:border-surface-200';
+
   return (
     <div className="space-y-3" data-testid="bounty-filters">
-      {/* Search bar with autocomplete */}
+
+      {/* Search bar */}
       <div className="relative" ref={suggestionsRef}>
-        <div className="relative">
-          <svg className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <div className="relative flex items-center">
+          {/* Search icon */}
+          <svg
+            className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500 pointer-events-none"
+            fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
+            aria-hidden="true"
+          >
             <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
           </svg>
+
           <input
             ref={searchRef}
             type="search"
-            placeholder="Search bounties by title, description, or skill..."
-            defaultValue={f.searchQuery}
+            placeholder="Search bounties by title, description, tags..."
+            value={localQuery}
             onChange={e => handleSearch(e.target.value)}
             onFocus={() => suggestions.length > 0 && setShowSuggestions(true)}
-            className="w-full rounded-lg border border-surface-300 bg-surface-50 pl-10 pr-4 py-2.5 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-solana-green/50 transition-colors"
+            className="w-full rounded-lg border border-surface-300 bg-surface-50 pl-10 pr-20 py-2.5 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-solana-green/50 transition-colors"
             aria-label="Search bounties"
             data-testid="bounty-search"
           />
+
+          {/* Keyboard shortcut hint (hidden when typing) */}
+          {!localQuery && (
+            <kbd className="absolute right-3 top-1/2 -translate-y-1/2 hidden sm:flex items-center gap-0.5 rounded border border-surface-300 bg-surface-100 px-1.5 py-0.5 text-[10px] text-gray-500 pointer-events-none select-none">
+              {SHORTCUT_LABEL}
+            </kbd>
+          )}
+
+          {/* Clear (X) button */}
+          {localQuery && (
+            <button
+              type="button"
+              onClick={clearSearch}
+              className="absolute right-3 top-1/2 -translate-y-1/2 rounded-full p-0.5 text-gray-500 hover:text-white transition-colors"
+              aria-label="Clear search"
+              data-testid="clear-search"
+            >
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          )}
         </div>
 
         {/* Autocomplete dropdown */}
@@ -118,28 +203,66 @@ export function BountyFilters({ filters: f, onFilterChange, onReset, resultCount
         )}
       </div>
 
-      {/* Primary filters row */}
+      {/* Filter chip groups: Tier, Status, Category */}
+      <div className="space-y-2">
+
+        {/* Tier chips */}
+        <div className="flex flex-wrap items-center gap-1.5" data-testid="tier-chips">
+          <span className="text-xs text-gray-500 shrink-0 w-14">Tier:</span>
+          {TIER_OPTIONS.map(o => (
+            <button
+              key={o.value}
+              type="button"
+              onClick={() => onFilterChange('tier', o.value)}
+              className={`${chipBase} ${f.tier === o.value ? chipActive : chipInactive}`}
+              aria-pressed={f.tier === o.value}
+              title={o.label}
+              data-testid={`tier-chip-${o.value}`}
+            >
+              {TIER_CHIP_LABELS[o.value] ?? o.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Status chips */}
+        <div className="flex flex-wrap items-center gap-1.5" data-testid="status-chips">
+          <span className="text-xs text-gray-500 shrink-0 w-14">Status:</span>
+          {STATUS_OPTIONS.map(o => (
+            <button
+              key={o.value}
+              type="button"
+              onClick={() => onFilterChange('status', o.value as BountyStatus | 'all')}
+              className={`${chipBase} ${f.status === o.value ? chipActive : chipInactive}`}
+              aria-pressed={f.status === o.value}
+              data-testid={`status-chip-${o.value}`}
+            >
+              {STATUS_CHIP_LABELS[o.value] ?? o.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Category chips */}
+        <div className="flex flex-wrap items-center gap-1.5" data-testid="category-chips">
+          <span className="text-xs text-gray-500 shrink-0 w-14">Category:</span>
+          {CATEGORY_OPTIONS.map(o => (
+            <button
+              key={o.value}
+              type="button"
+              onClick={() => onFilterChange('category', o.value as BountyCategory | 'all')}
+              className={`${chipBase} ${f.category === o.value ? chipActive : chipInactive}`}
+              aria-pressed={f.category === o.value}
+              title={o.label}
+              data-testid={`category-chip-${o.value}`}
+            >
+              {CATEGORY_CHIP_LABELS[o.value] ?? o.label}
+            </button>
+          ))}
+        </div>
+
+      </div>
+
+      {/* Controls row: creator type, more filters, clear all, result count */}
       <div className="flex flex-wrap items-center gap-2">
-        <select
-          value={f.tier}
-          onChange={e => onFilterChange('tier', e.target.value as BountyTier | 'all')}
-          className="rounded-lg border border-surface-300 bg-surface-50 px-3 py-1.5 text-sm text-white focus:outline-none focus:border-solana-green/50"
-          aria-label="Filter by tier"
-          data-testid="tier-filter"
-        >
-          {TIER_OPTIONS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-        </select>
-
-        <select
-          value={f.status}
-          onChange={e => onFilterChange('status', e.target.value as BountyStatus | 'all')}
-          className="rounded-lg border border-surface-300 bg-surface-50 px-3 py-1.5 text-sm text-white focus:outline-none focus:border-solana-green/50"
-          aria-label="Filter by status"
-          data-testid="status-filter"
-        >
-          {STATUS_OPTIONS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-        </select>
-
         <select
           value={f.creatorType}
           onChange={e => onFilterChange('creatorType', e.target.value as 'all' | 'platform' | 'community')}
@@ -148,16 +271,6 @@ export function BountyFilters({ filters: f, onFilterChange, onReset, resultCount
           data-testid="creator-type-filter"
         >
           {CREATOR_TYPE_OPTIONS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-        </select>
-
-        <select
-          value={f.category}
-          onChange={e => onFilterChange('category', e.target.value as BountyCategory | 'all')}
-          className="rounded-lg border border-surface-300 bg-surface-50 px-3 py-1.5 text-sm text-white focus:outline-none focus:border-solana-green/50"
-          aria-label="Filter by category"
-          data-testid="category-filter"
-        >
-          {CATEGORY_OPTIONS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
         </select>
 
         <button
@@ -173,8 +286,8 @@ export function BountyFilters({ filters: f, onFilterChange, onReset, resultCount
         {hasActive && (
           <button
             type="button"
-            onClick={() => { onReset(); if (searchRef.current) searchRef.current.value = ''; setSuggestions([]); }}
-            className="text-sm text-gray-400 hover:text-white"
+            onClick={() => { onReset(); setSuggestions([]); }}
+            className="rounded-lg border border-surface-300 px-3 py-1.5 text-sm text-gray-400 hover:text-white transition-colors"
             data-testid="reset-filters"
           >
             Clear all
@@ -182,11 +295,11 @@ export function BountyFilters({ filters: f, onFilterChange, onReset, resultCount
         )}
 
         <span className="ml-auto text-xs text-gray-500" data-testid="result-count">
-          {resultCount} of {totalCount} bounties
+          Showing {resultCount} of {totalCount} bounties
         </span>
       </div>
 
-      {/* Advanced filters (reward range + deadline) */}
+      {/* Advanced filters: reward range + deadline */}
       {showAdvanced && (
         <div className="flex flex-wrap items-center gap-3 p-3 rounded-lg border border-surface-300 bg-surface-50" data-testid="advanced-filters">
           <span className="text-xs text-gray-500">Reward:</span>
@@ -244,6 +357,7 @@ export function BountyFilters({ filters: f, onFilterChange, onReset, resultCount
           );
         })}
       </div>
+
     </div>
   );
 }

--- a/frontend/src/components/common/EmptyState.tsx
+++ b/frontend/src/components/common/EmptyState.tsx
@@ -207,10 +207,10 @@ export interface NoBountiesProps {
 export function NoBountiesFound({ onReset, hasFilters = false, className = '' }: NoBountiesProps) {
   return (
     <EmptyState
-      icon="📋"
-      title="No bounties found"
-      description={hasFilters ? "Try adjusting your filters to see more results" : "Check back soon for new opportunities"}
-      actionLabel={hasFilters ? "Clear all filters" : undefined}
+      icon="🔍"
+      title={hasFilters ? 'No bounties match your search' : 'No bounties found'}
+      description={hasFilters ? 'Try adjusting your filters or search terms' : 'Check back soon for new opportunities'}
+      actionLabel={hasFilters ? 'Clear all filters' : undefined}
       onAction={hasFilters ? onReset : undefined}
       className={className}
       testId="empty-bounties"

--- a/frontend/src/hooks/useBountyBoard.ts
+++ b/frontend/src/hooks/useBountyBoard.ts
@@ -1,15 +1,15 @@
 /**
- * Bounty fetching via apiClient + React Query with search and fallback.
+ * Bounty fetching via apiClient + React Query with search, URL sync, and fallback.
  * @module hooks/useBountyBoard
  */
-import { useState, useMemo, useCallback, useRef } from 'react';
+import { useState, useMemo, useCallback, useRef, useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
-import type { Bounty, BountyBoardFilters, BountySortBy, SearchResponse } from '../types/bounty';
+import type { Bounty, BountyBoardFilters, BountySortBy, SearchResponse, BountyTier, BountyStatus, BountyCategory } from '../types/bounty';
 import { DEFAULT_FILTERS } from '../types/bounty';
 import { apiClient } from '../services/apiClient';
 
 const TIER_MAP: Record<number, 'T1' | 'T2' | 'T3'> = { 1: 'T1', 2: 'T2', 3: 'T3' };
-import type { BountyStatus } from '../types/bounty';
 const STATUS_MAP: Record<string, BountyStatus> = {
   open: 'open',
   in_progress: 'in-progress',
@@ -70,6 +70,42 @@ function buildSearchParams(
 
 const SORT_COMPAT: Record<string, BountySortBy> = { reward: 'reward_high' };
 
+const VALID_TIERS = new Set<string>(['all', 'T1', 'T2', 'T3']);
+const VALID_STATUSES = new Set<string>(['all', 'open', 'in-progress', 'under_review', 'completed', 'disputed', 'paid', 'cancelled']);
+const VALID_CATEGORIES = new Set<string>(['all', 'smart-contract', 'frontend', 'backend', 'design', 'content', 'security', 'devops', 'documentation']);
+const VALID_SORTS = new Set<string>(['newest', 'reward_high', 'reward_low', 'deadline', 'submissions', 'best_match']);
+
+/** Parse URLSearchParams into partial filter + sort + page state. */
+function parseUrlParams(params: URLSearchParams): Partial<BountyBoardFilters> & { sortBy?: BountySortBy; page?: number } {
+  const result: Partial<BountyBoardFilters> & { sortBy?: BountySortBy; page?: number } = {};
+  const q = params.get('q');
+  if (q) result.searchQuery = q;
+  const tier = params.get('tier');
+  if (tier && VALID_TIERS.has(tier)) result.tier = tier as BountyTier | 'all';
+  const status = params.get('status');
+  if (status && VALID_STATUSES.has(status)) result.status = status as BountyStatus | 'all';
+  const category = params.get('category');
+  if (category && VALID_CATEGORIES.has(category)) result.category = category as BountyCategory | 'all';
+  const creatorType = params.get('creator_type');
+  if (creatorType && ['all', 'platform', 'community'].includes(creatorType)) {
+    result.creatorType = creatorType as 'all' | 'platform' | 'community';
+  }
+  const skills = params.get('skills');
+  if (skills) result.skills = skills.split(',').filter(Boolean);
+  const rewardMin = params.get('reward_min');
+  if (rewardMin) result.rewardMin = rewardMin;
+  const rewardMax = params.get('reward_max');
+  if (rewardMax) result.rewardMax = rewardMax;
+  const deadlineBefore = params.get('deadline_before');
+  if (deadlineBefore) result.deadlineBefore = deadlineBefore;
+  const sort = params.get('sort');
+  if (sort && VALID_SORTS.has(sort)) result.sortBy = sort as BountySortBy;
+  const page = params.get('page');
+  const pageNum = Number(page);
+  if (page && Number.isFinite(pageNum) && pageNum > 0) result.page = pageNum;
+  return result;
+}
+
 /** Sort bounties by the given field, returning a new sorted array. */
 function localSort(bounties: Bounty[], sortBy: BountySortBy): Bounty[] {
   const sorted = [...bounties];
@@ -92,7 +128,12 @@ function applyLocalFilters(allBounties: Bounty[], activeFilters: BountyBoardFilt
   if (activeFilters.skills.length) results = results.filter(bounty => activeFilters.skills.some(skill => bounty.skills.map(bountySkill => bountySkill.toLowerCase()).includes(skill.toLowerCase())));
   if (activeFilters.searchQuery.trim()) {
     const query = activeFilters.searchQuery.toLowerCase();
-    results = results.filter(bounty => bounty.title.toLowerCase().includes(query) || bounty.description.toLowerCase().includes(query) || bounty.projectName.toLowerCase().includes(query));
+    results = results.filter(bounty =>
+      bounty.title.toLowerCase().includes(query) ||
+      bounty.description.toLowerCase().includes(query) ||
+      bounty.projectName.toLowerCase().includes(query) ||
+      bounty.skills.some(skill => skill.toLowerCase().includes(query))
+    );
   }
   if (activeFilters.rewardMin) { const minReward = Number(activeFilters.rewardMin); if (!isNaN(minReward)) results = results.filter(bounty => bounty.rewardAmount >= minReward); }
   if (activeFilters.rewardMax) { const maxReward = Number(activeFilters.rewardMax); if (!isNaN(maxReward)) results = results.filter(bounty => bounty.rewardAmount <= maxReward); }
@@ -103,13 +144,45 @@ function applyLocalFilters(allBounties: Bounty[], activeFilters: BountyBoardFilt
   return localSort(results, sortBy);
 }
 
-/** Bounty board hook with React Query caching, server-side search, and client-side fallback. */
+/** Bounty board hook with React Query caching, server-side search, URL sync, and client-side fallback. */
 export function useBountyBoard() {
-  const [filters, setFilters] = useState<BountyBoardFilters>(DEFAULT_FILTERS);
-  const [sortBy, setSortByRaw] = useState<BountySortBy>('newest');
-  const [page, setPage] = useState(1);
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const [filters, setFilters] = useState<BountyBoardFilters>(() => {
+    const urlState = parseUrlParams(searchParams);
+    return { ...DEFAULT_FILTERS, ...urlState };
+  });
+
+  const [sortBy, setSortByRaw] = useState<BountySortBy>(() => {
+    const { sortBy: urlSort } = parseUrlParams(searchParams);
+    if (!urlSort) return 'newest';
+    return (SORT_COMPAT[urlSort] || urlSort) as BountySortBy;
+  });
+
+  const [page, setPage] = useState<number>(() => {
+    const { page: urlPage } = parseUrlParams(searchParams);
+    return urlPage ?? 1;
+  });
+
   const perPage = 20;
   const searchAvailableRef = useRef(true);
+
+  // Sync filters / sort / page → URL (replace history so back button works naturally)
+  useEffect(() => {
+    const params: Record<string, string> = {};
+    if (filters.searchQuery.trim()) params.q = filters.searchQuery.trim();
+    if (filters.tier !== 'all') params.tier = filters.tier;
+    if (filters.status !== 'all') params.status = filters.status;
+    if (filters.category !== 'all') params.category = filters.category;
+    if (filters.creatorType !== 'all') params.creator_type = filters.creatorType;
+    if (filters.skills.length) params.skills = filters.skills.join(',');
+    if (filters.rewardMin) params.reward_min = filters.rewardMin;
+    if (filters.rewardMax) params.reward_max = filters.rewardMax;
+    if (filters.deadlineBefore) params.deadline_before = filters.deadlineBefore;
+    if (sortBy !== 'newest') params.sort = sortBy;
+    if (page > 1) params.page = String(page);
+    setSearchParams(params, { replace: true });
+  }, [filters, sortBy, page, setSearchParams]);
 
   const setSortBy = useCallback((sortField: BountySortBy | string) => {
     setSortByRaw((SORT_COMPAT[sortField] || sortField) as BountySortBy);
@@ -122,7 +195,7 @@ export function useBountyBoard() {
     queryFn: async () => {
       const params = buildSearchParams(filters, sortBy, page, perPage);
       const data = await apiClient<SearchResponse>(`/api/bounties/search?${params}`);
-      return { items: data.items.map(mapApiBounty), total: data.total };
+      return { items: data.items.map(item => mapApiBounty(item as unknown as Record<string, unknown>)), total: data.total };
     },
     enabled: searchAvailableRef.current,
     retry: false,
@@ -137,7 +210,7 @@ export function useBountyBoard() {
     queryFn: async () => {
       const data = await apiClient<{ items?: unknown[] }>('/api/bounties?limit=100');
       const items = (data.items || data) as unknown[];
-      return Array.isArray(items) ? items.map(mapApiBounty) : [];
+      return Array.isArray(items) ? items.map(item => mapApiBounty(item as Record<string, unknown>)) : [];
     },
     enabled: !searchAvailableRef.current,
     staleTime: 60_000,
@@ -153,7 +226,7 @@ export function useBountyBoard() {
   // Hot bounties (fetched once)
   const hotBountiesQuery = useQuery({
     queryKey: ['bounties', 'hot'],
-    queryFn: async () => (await apiClient<unknown[]>('/api/bounties/hot?limit=6')).map(mapApiBounty),
+    queryFn: async () => (await apiClient<unknown[]>('/api/bounties/hot?limit=6')).map(item => mapApiBounty(item as Record<string, unknown>)),
     staleTime: 60_000,
     retry: false,
   });
@@ -162,7 +235,7 @@ export function useBountyBoard() {
   const skillsKey = filters.skills.length > 0 ? filters.skills : ['react', 'typescript', 'rust'];
   const recommendedQuery = useQuery({
     queryKey: ['bounties', 'recommended', skillsKey],
-    queryFn: async () => (await apiClient<unknown[]>(`/api/bounties/recommended?skills=${encodeURIComponent(skillsKey.join(','))}&limit=6`)).map(mapApiBounty),
+    queryFn: async () => (await apiClient<unknown[]>(`/api/bounties/recommended?skills=${encodeURIComponent(skillsKey.join(','))}&limit=6`)).map(item => mapApiBounty(item as Record<string, unknown>)),
     staleTime: 60_000,
     retry: false,
   });


### PR DESCRIPTION
## Description

Adds a fully-featured search and filter bar to the bounty listing page, enabling contributors to quickly find relevant bounties by title, description, tags, tier, status, and category. All filter state is reflected in the URL so searches are shareable.

Closes #481 

## Solana Wallet for Payout
**Wallet:** 4QhseKvBuaCQhdkP248iXoUxohPzVC5m8pE9hAv4nMYw

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [x] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test addition/update

## Checklist
- [x] Code is clean and follows the issue spec exactly
- [x] One PR per bounty (no multiple bounties in one PR)
- [ ] Tests included for new functionality
- [x] All existing tests pass
- [x] No `console.log` or debugging code left behind
- [x] No hardcoded secrets or API keys

## Testing
- [x] Manual testing performed
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated

## Screenshots (if applicable)
<!-- Add screenshots of the search bar, chip filters, clear button, and empty state -->

## Additional Notes

### Files changed
| File | Change |
|---|---|
| `frontend/src/hooks/useBountyBoard.ts` | URL query param sync, skills included in local search |
| `frontend/src/components/bounties/BountyFilters.tsx` | Full filter bar redesign |
| `frontend/src/components/common/EmptyState.tsx` | Better empty-state copy for search |

### Acceptance criteria coverage

| Criterion | Implementation |
|---|---|
| Search icon in input | SVG magnifier icon, `absolute left-3`, always visible |
| Debounced search (300ms) | `setTimeout(..., 300)` in `handleSearch`, cleared on each keystroke |
| Searches title, description, tags | `applyLocalFilters` now matches `bounty.skills` in addition to title/description/projectName |
| Filter chips — tier, status, category | Three chip-button rows replace the previous `<select>` dropdowns; `aria-pressed` for a11y |
| Clear search button (X) | Appears in the search input trailing edge when `localQuery !== ''`; clears immediately (no debounce) |
| Result count "Showing X of Y bounties" | `data-testid="result-count"` span updated to match exact copy |
| Cmd/Ctrl+K focuses search | Global `keydown` listener; platform-aware (`⌘K` on Mac, `Ctrl+K` elsewhere); keyboard hint shown in empty input |
| Empty state "No bounties match your search" | `NoBountiesFound` title changes based on `hasFilters` prop |
| URL query param sync | `useSearchParams` in `useBountyBoard`; state initialized from URL on mount; `useEffect` writes back on every change with `replace: true` |
