### PR TITLE
Feat/reputation display

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -78,6 +78,7 @@ const CreatorDashboardPage = lazy(() => import('./pages/CreatorDashboardPage'));
 const HowItWorksPage = lazy(() => import('./pages/HowItWorksPage'));
 const DisputeListPage = lazy(() => import('./pages/DisputeListPage'));
 const DisputePage = lazy(() => import('./pages/DisputePage'));
+const ReputationPage = lazy(() => import('./pages/ReputationPage'));
 const NotFoundPage = lazy(() => import('./pages/NotFoundPage'));
 
 // ── Loading spinner ──────────────────────────────────────────────────────────
@@ -133,6 +134,7 @@ function AppLayout() {
 
           {/* Contributor and Creator */}
           <Route path="/profile/:username" element={<ContributorProfilePage />} />
+          <Route path="/reputation/:username" element={<ReputationPage />} />
           <Route path="/dashboard" element={<DashboardPage />} />
           <Route path="/creator" element={<CreatorDashboardPage />} />
 

--- a/frontend/src/__tests__/reputation.test.tsx
+++ b/frontend/src/__tests__/reputation.test.tsx
@@ -1,0 +1,503 @@
+/**
+ * Reputation display test suite.
+ *
+ * Covers:
+ *   - ReputationScoreCard  — score, tier badge, rank badge, loading skeleton
+ *   - TierBadge            — T1 / T2 / T3 labels
+ *   - ReputationHistoryChart — loading skeleton, insufficient data, renders SVG region
+ *   - ReputationBreakdown  — rows, REP calculations, streak badge, star rating, loading skeleton
+ *   - TierProgressIndicator — next-tier messages, max-tier message, loading skeleton
+ *   - ReputationPanel      — integration: error state, loading state, successful render
+ *   - useReputation hook   — API hit, leaderboard fallback, ultimate fallback, disabled
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, act } from '@testing-library/react';
+import React from 'react';
+
+import { ReputationScoreCard, TierBadge } from '../components/reputation/ReputationScoreCard';
+import { ReputationHistoryChart } from '../components/reputation/ReputationHistoryChart';
+import { ReputationBreakdown } from '../components/reputation/ReputationBreakdown';
+import { TierProgressIndicator } from '../components/reputation/TierProgressIndicator';
+import { ReputationPanel } from '../components/reputation/ReputationPanel';
+import { useReputation } from '../hooks/useReputation';
+import type { ReputationData, ReputationBreakdown as BreakdownType, ReputationSnapshot, ReputationEvent } from '../types/reputation';
+
+// ── Global fetch mock ─────────────────────────────────────────────────────────
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+beforeEach(() => mockFetch.mockReset());
+
+// ── Test helpers ──────────────────────────────────────────────────────────────
+
+function okJson(data: unknown): Response {
+  return {
+    ok: true, status: 200, statusText: 'OK',
+    json: () => Promise.resolve(data),
+    headers: new Headers(), redirected: false, type: 'basic' as ResponseType, url: '',
+    clone: function () { return this; }, body: null, bodyUsed: false,
+    arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+    blob: () => Promise.resolve(new Blob()),
+    formData: () => Promise.resolve(new FormData()),
+    text: () => Promise.resolve(JSON.stringify(data)),
+    bytes: () => Promise.resolve(new Uint8Array()),
+  } as Response;
+}
+
+function errorResponse(status: number): Response {
+  return {
+    ok: false, status, statusText: 'Error',
+    json: () => Promise.resolve({ message: 'Error' }),
+    headers: new Headers(), redirected: false, type: 'basic' as ResponseType, url: '',
+    clone: function () { return this; }, body: null, bodyUsed: false,
+    arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+    blob: () => Promise.resolve(new Blob()),
+    formData: () => Promise.resolve(new FormData()),
+    text: () => Promise.resolve('{}'),
+    bytes: () => Promise.resolve(new Uint8Array()),
+  } as Response;
+}
+
+function makeQueryClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false, staleTime: 0 } } });
+}
+
+function renderWith(element: React.ReactElement) {
+  return render(
+    <QueryClientProvider client={makeQueryClient()}>
+      <MemoryRouter>{element}</MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+function wrapHook<T>(fn: () => T) {
+  const qc = makeQueryClient();
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={qc}><MemoryRouter>{children}</MemoryRouter></QueryClientProvider>
+  );
+  return renderHook(fn, { wrapper });
+}
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const BREAKDOWN: BreakdownType = {
+  t1Completions: 6,
+  t2Completions: 3,
+  t3Completions: 1,
+  avgReviewScore: 4.2,
+  reviewCount: 10,
+  streak: 7,
+};
+
+const HISTORY: ReputationSnapshot[] = [
+  { date: '2024-01-01', score: 100 },
+  { date: '2024-02-01', score: 250 },
+  { date: '2024-03-01', score: 450 },
+];
+
+const EVENTS: ReputationEvent[] = [
+  { id: 'ev-1', date: '2024-03-01', delta: 200, reason: 'Completed T3 bounty', tier: 'T3', bountyId: 'b-99' },
+  { id: 'ev-2', date: '2024-02-15', delta: 100, reason: 'Completed T2 bounty', tier: 'T2' },
+  { id: 'ev-3', date: '2024-01-20', delta: 50,  reason: 'Completed T1 bounty', tier: 'T1' },
+];
+
+const REP_DATA: ReputationData = {
+  score: 1450,
+  rank: 3,
+  totalContributors: 200,
+  tier: 'T3',
+  breakdown: BREAKDOWN,
+  history: HISTORY,
+  events: EVENTS,
+};
+
+// ── ReputationScoreCard ───────────────────────────────────────────────────────
+
+describe('ReputationScoreCard', () => {
+  it('renders score and tier', () => {
+    renderWith(<ReputationScoreCard score={1450} rank={3} totalContributors={200} tier="T3" />);
+    expect(screen.getByLabelText(/1,450 reputation points/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/current tier: tier 3/i)).toBeInTheDocument();
+  });
+
+  it('displays rank badge with medal for top 3', () => {
+    renderWith(<ReputationScoreCard score={500} rank={1} totalContributors={100} tier="T1" />);
+    expect(screen.getByText(/#1/)).toBeInTheDocument();
+    expect(screen.getByText(/of 100/)).toBeInTheDocument();
+  });
+
+  it('renders medal emoji for rank 2', () => {
+    renderWith(<ReputationScoreCard score={400} rank={2} totalContributors={50} tier="T2" />);
+    expect(screen.getByText(/#2/)).toBeInTheDocument();
+  });
+
+  it('renders medal emoji for rank 3', () => {
+    renderWith(<ReputationScoreCard score={300} rank={3} totalContributors={30} tier="T1" />);
+    expect(screen.getByText(/#3/)).toBeInTheDocument();
+  });
+
+  it('does not render rank badge when rank is 0', () => {
+    renderWith(<ReputationScoreCard score={0} rank={0} totalContributors={0} tier="T1" />);
+    expect(screen.queryByText(/#0/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/of 0/)).not.toBeInTheDocument();
+  });
+
+  it('shows loading skeleton with aria-busy when loading=true', () => {
+    renderWith(<ReputationScoreCard score={0} rank={0} totalContributors={0} tier="T1" loading />);
+    expect(screen.getByLabelText(/loading reputation score/i)).toHaveAttribute('aria-busy', 'true');
+    expect(screen.queryByLabelText(/reputation score/i, { selector: '[role="region"]' })).not.toBeInTheDocument();
+  });
+
+  it('has role=region on main content', () => {
+    renderWith(<ReputationScoreCard score={100} rank={5} totalContributors={50} tier="T1" />);
+    expect(screen.getByRole('region', { name: /reputation score/i })).toBeInTheDocument();
+  });
+
+  it('formats large scores with locale commas', () => {
+    renderWith(<ReputationScoreCard score={12500} rank={1} totalContributors={500} tier="T3" />);
+    expect(screen.getByLabelText(/12,500 reputation points/i)).toBeInTheDocument();
+  });
+});
+
+// ── TierBadge ─────────────────────────────────────────────────────────────────
+
+describe('TierBadge', () => {
+  it('renders T1 label', () => {
+    renderWith(<TierBadge tier="T1" />);
+    expect(screen.getByText('Tier 1')).toBeInTheDocument();
+  });
+
+  it('renders T2 label', () => {
+    renderWith(<TierBadge tier="T2" />);
+    expect(screen.getByText('Tier 2')).toBeInTheDocument();
+  });
+
+  it('renders T3 label with trophy emoji', () => {
+    renderWith(<TierBadge tier="T3" />);
+    expect(screen.getByText('Tier 3')).toBeInTheDocument();
+    expect(screen.getByText('🏆')).toBeInTheDocument();
+  });
+
+  it('has accessible aria-label on each tier badge', () => {
+    const { rerender } = renderWith(<TierBadge tier="T1" />);
+    expect(screen.getByLabelText('Current tier: Tier 1')).toBeInTheDocument();
+    rerender(
+      <QueryClientProvider client={makeQueryClient()}><MemoryRouter><TierBadge tier="T2" /></MemoryRouter></QueryClientProvider>,
+    );
+    expect(screen.getByLabelText('Current tier: Tier 2')).toBeInTheDocument();
+  });
+});
+
+// ── ReputationHistoryChart ────────────────────────────────────────────────────
+
+describe('ReputationHistoryChart', () => {
+  it('renders the chart region heading', () => {
+    renderWith(<ReputationHistoryChart history={HISTORY} events={EVENTS} />);
+    expect(screen.getByRole('region', { name: /reputation history chart/i })).toBeInTheDocument();
+    expect(screen.getByText(/score history/i)).toBeInTheDocument();
+  });
+
+  it('shows "not enough data" when fewer than 2 history points', () => {
+    renderWith(<ReputationHistoryChart history={[{ date: '2024-01-01', score: 100 }]} />);
+    expect(screen.getByText(/not enough data yet/i)).toBeInTheDocument();
+  });
+
+  it('shows "not enough data" when history is empty', () => {
+    renderWith(<ReputationHistoryChart history={[]} />);
+    expect(screen.getByText(/not enough data yet/i)).toBeInTheDocument();
+  });
+
+  it('renders loading skeleton with aria-busy when loading=true', () => {
+    renderWith(<ReputationHistoryChart history={[]} loading />);
+    expect(screen.getByLabelText(/loading reputation chart/i)).toHaveAttribute('aria-busy', 'true');
+    expect(screen.queryByRole('region', { name: /reputation history chart/i })).not.toBeInTheDocument();
+  });
+
+  it('renders SVG element when sufficient history exists', () => {
+    const { container } = renderWith(<ReputationHistoryChart history={HISTORY} />);
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('renders tooltip on mouse move over chart', () => {
+    const { container } = renderWith(<ReputationHistoryChart history={HISTORY} events={EVENTS} />);
+    const svg = container.querySelector('svg')!;
+    // getBoundingClientRect returns zeros in jsdom, so tooltip may not show,
+    // but we assert mouse handlers are present without crashing
+    fireEvent.mouseMove(svg, { clientX: 100, clientY: 50 });
+    fireEvent.mouseLeave(svg);
+  });
+});
+
+// ── ReputationBreakdown ───────────────────────────────────────────────────────
+
+describe('ReputationBreakdown', () => {
+  it('renders section heading', () => {
+    renderWith(<ReputationBreakdown breakdown={BREAKDOWN} />);
+    expect(screen.getByRole('region', { name: /reputation breakdown/i })).toBeInTheDocument();
+    expect(screen.getByText(/score breakdown/i)).toBeInTheDocument();
+  });
+
+  it('displays T1, T2, T3 completion labels', () => {
+    renderWith(<ReputationBreakdown breakdown={BREAKDOWN} />);
+    expect(screen.getByText('T1 Completions')).toBeInTheDocument();
+    expect(screen.getByText('T2 Completions')).toBeInTheDocument();
+    expect(screen.getByText('T3 Completions')).toBeInTheDocument();
+  });
+
+  it('displays REP earned sub-labels: T1×50, T2×100, T3×200', () => {
+    renderWith(<ReputationBreakdown breakdown={BREAKDOWN} />);
+    // T1: 6 × 50 = 300
+    expect(screen.getByText('300 REP earned')).toBeInTheDocument();
+    // T2: 3 × 100 = 300
+    expect(screen.getByText('300 REP earned')).toBeInTheDocument();
+    // T3: 1 × 200 = 200
+    expect(screen.getByText('200 REP earned')).toBeInTheDocument();
+  });
+
+  it('displays avg review score and review count', () => {
+    renderWith(<ReputationBreakdown breakdown={BREAKDOWN} />);
+    expect(screen.getByText('4.2 / 5.0')).toBeInTheDocument();
+    expect(screen.getByText('10 reviews')).toBeInTheDocument();
+  });
+
+  it('shows singular "review" when reviewCount is 1', () => {
+    renderWith(<ReputationBreakdown breakdown={{ ...BREAKDOWN, reviewCount: 1 }} />);
+    expect(screen.getByText('1 review')).toBeInTheDocument();
+  });
+
+  it('shows streak badge when streak > 0', () => {
+    renderWith(<ReputationBreakdown breakdown={BREAKDOWN} />);
+    expect(screen.getByText(/7d streak/)).toBeInTheDocument();
+  });
+
+  it('does not show streak badge when streak is 0', () => {
+    renderWith(<ReputationBreakdown breakdown={{ ...BREAKDOWN, streak: 0 }} />);
+    expect(screen.queryByText(/streak/)).not.toBeInTheDocument();
+  });
+
+  it('renders star rating accessible label', () => {
+    renderWith(<ReputationBreakdown breakdown={BREAKDOWN} />);
+    // rounded(4.2) = 4 filled stars
+    expect(screen.getByLabelText(/4 out of 5 stars/i)).toBeInTheDocument();
+  });
+
+  it('renders tier point legend (T1=50, T2=100, T3=200)', () => {
+    renderWith(<ReputationBreakdown breakdown={BREAKDOWN} />);
+    expect(screen.getByText('T1 = +50 REP')).toBeInTheDocument();
+    expect(screen.getByText('T2 = +100 REP')).toBeInTheDocument();
+    expect(screen.getByText('T3 = +200 REP')).toBeInTheDocument();
+  });
+
+  it('shows loading skeleton with aria content when loading=true', () => {
+    renderWith(<ReputationBreakdown breakdown={BREAKDOWN} loading />);
+    // Loading renders BreakdownSkeleton, no region role
+    expect(screen.queryByRole('region', { name: /reputation breakdown/i })).not.toBeInTheDocument();
+  });
+});
+
+// ── TierProgressIndicator ─────────────────────────────────────────────────────
+
+describe('TierProgressIndicator', () => {
+  it('renders tier progress region', () => {
+    renderWith(
+      <TierProgressIndicator tier="T1" t1Completions={2} t2Completions={0} t3Completions={0} />,
+    );
+    expect(screen.getByRole('region', { name: /tier progress/i })).toBeInTheDocument();
+    expect(screen.getByText(/tier progress/i)).toBeInTheDocument();
+  });
+
+  it('T1 with 2 completions: shows 2 more T1 merges needed', () => {
+    renderWith(
+      <TierProgressIndicator tier="T1" t1Completions={2} t2Completions={0} t3Completions={0} />,
+    );
+    expect(screen.getByText(/2 more T1 merges needed to unlock T2/i)).toBeInTheDocument();
+  });
+
+  it('T1 with exactly 1 completion remaining: singular "merge"', () => {
+    renderWith(
+      <TierProgressIndicator tier="T1" t1Completions={3} t2Completions={0} t3Completions={0} />,
+    );
+    expect(screen.getByText(/1 more T1 merge needed to unlock T2/i)).toBeInTheDocument();
+  });
+
+  it('T1 with 4+ completions: shows T2 requirements met', () => {
+    renderWith(
+      <TierProgressIndicator tier="T1" t1Completions={4} t2Completions={0} t3Completions={0} />,
+    );
+    expect(screen.getByText(/T2 requirements met/i)).toBeInTheDocument();
+  });
+
+  it('T2 on path to T3 (needs 2 more T2 merges)', () => {
+    renderWith(
+      <TierProgressIndicator tier="T2" t1Completions={4} t2Completions={1} t3Completions={0} />,
+    );
+    expect(screen.getByText(/To unlock T3/i)).toBeInTheDocument();
+  });
+
+  it('T2 with requirements met: shows T3 requirements met', () => {
+    renderWith(
+      <TierProgressIndicator tier="T2" t1Completions={5} t2Completions={3} t3Completions={0} />,
+    );
+    expect(screen.getByText(/T3 requirements met/i)).toBeInTheDocument();
+  });
+
+  it('T3 tier: shows maximum tier reached message', () => {
+    renderWith(
+      <TierProgressIndicator tier="T3" t1Completions={6} t2Completions={3} t3Completions={1} />,
+    );
+    expect(screen.getByText(/maximum tier reached/i)).toBeInTheDocument();
+  });
+
+  it('shows loading skeleton when loading=true', () => {
+    renderWith(
+      <TierProgressIndicator tier="T1" t1Completions={0} t2Completions={0} t3Completions={0} loading />,
+    );
+    expect(screen.queryByRole('region', { name: /tier progress/i })).not.toBeInTheDocument();
+  });
+
+  it('renders tier point legend (T1/T2/T3)', () => {
+    renderWith(
+      <TierProgressIndicator tier="T2" t1Completions={4} t2Completions={1} t3Completions={0} />,
+    );
+    expect(screen.getByText('T1')).toBeInTheDocument();
+    expect(screen.getByText('T2')).toBeInTheDocument();
+    expect(screen.getByText('T3')).toBeInTheDocument();
+    expect(screen.getByText('+50 REP')).toBeInTheDocument();
+    expect(screen.getByText('+100 REP')).toBeInTheDocument();
+    expect(screen.getByText('+200 REP')).toBeInTheDocument();
+  });
+});
+
+// ── ReputationPanel ───────────────────────────────────────────────────────────
+
+describe('ReputationPanel', () => {
+  it('shows error alert when API returns 401', async () => {
+    mockFetch.mockResolvedValue(errorResponse(401));
+    renderWith(<ReputationPanel username="alice" />);
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+  });
+
+  it('shows loading skeletons while fetching', () => {
+    // Never resolves so loading state stays
+    mockFetch.mockReturnValue(new Promise(() => {}));
+    renderWith(<ReputationPanel username="alice" />);
+    // Loading skeleton: aria-busy on score card
+    expect(screen.getByLabelText(/loading reputation score/i)).toBeInTheDocument();
+  });
+
+  it('renders all subcomponents after successful fetch', async () => {
+    mockFetch.mockResolvedValue(okJson(REP_DATA));
+    renderWith(<ReputationPanel username="alice" />);
+
+    await waitFor(() =>
+      expect(screen.getByRole('region', { name: /reputation score/i })).toBeInTheDocument(),
+    );
+    expect(screen.getByRole('region', { name: /reputation breakdown/i })).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: /tier progress/i })).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: /reputation history chart/i })).toBeInTheDocument();
+  });
+
+  it('shows leaderboard link for top-3 ranked user', async () => {
+    mockFetch.mockResolvedValue(okJson(REP_DATA));
+    renderWith(<ReputationPanel username="alice" />);
+    await waitFor(() =>
+      expect(screen.getByRole('link', { name: /view alice on the leaderboard/i })).toBeInTheDocument(),
+    );
+  });
+
+  it('shows recent activity events feed', async () => {
+    mockFetch.mockResolvedValue(okJson(REP_DATA));
+    renderWith(<ReputationPanel username="alice" />);
+    await waitFor(() =>
+      expect(screen.getByRole('list', { name: /reputation events/i })).toBeInTheDocument(),
+    );
+    expect(screen.getByText('Completed T3 bounty')).toBeInTheDocument();
+    expect(screen.getByText('Completed T2 bounty')).toBeInTheDocument();
+  });
+
+  it('shows "No activity yet" when events array is empty', async () => {
+    mockFetch.mockResolvedValue(okJson({ ...REP_DATA, events: [] }));
+    renderWith(<ReputationPanel username="alice" />);
+    await waitFor(() => expect(screen.getByText(/no activity yet/i)).toBeInTheDocument());
+  });
+
+  it('shows tooltip detail on event row hover', async () => {
+    mockFetch.mockResolvedValue(okJson(REP_DATA));
+    renderWith(<ReputationPanel username="alice" />);
+    await waitFor(() =>
+      expect(screen.getByText('Completed T3 bounty')).toBeInTheDocument(),
+    );
+    const eventItem = screen.getByLabelText(/completed t3 bounty/i);
+    fireEvent.mouseEnter(eventItem);
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+    fireEvent.mouseLeave(eventItem);
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+
+  it('falls back to leaderboard data when reputation endpoint returns 404', async () => {
+    const leaderboardRow = [{ username: 'alice', points: 500, bountiesCompleted: 5 }];
+    mockFetch
+      .mockResolvedValueOnce(errorResponse(404))   // reputation endpoint → 404
+      .mockResolvedValueOnce(okJson(leaderboardRow)); // leaderboard fallback
+    renderWith(<ReputationPanel username="alice" />);
+    await waitFor(() =>
+      expect(screen.getByRole('region', { name: /reputation score/i })).toBeInTheDocument(),
+    );
+  });
+});
+
+// ── useReputation hook ────────────────────────────────────────────────────────
+
+describe('useReputation hook', () => {
+  it('returns reputation data from API on success', async () => {
+    mockFetch.mockResolvedValue(okJson(REP_DATA));
+    const { result } = wrapHook(() => useReputation('alice'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.reputation?.score).toBe(1450);
+    expect(result.current.reputation?.tier).toBe('T3');
+    expect(result.current.error).toBeNull();
+  });
+
+  it('falls back to leaderboard when reputation endpoint is 404', async () => {
+    mockFetch
+      .mockResolvedValueOnce(errorResponse(404))
+      .mockResolvedValueOnce(okJson([{ username: 'alice', points: 300, bountiesCompleted: 4 }]));
+    const { result } = wrapHook(() => useReputation('alice'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.reputation).not.toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it('returns ultimate fallback (score 0) when both endpoints fail', async () => {
+    mockFetch.mockResolvedValue(errorResponse(500));
+    const { result } = wrapHook(() => useReputation('nobody'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.reputation?.score).toBe(0);
+    expect(result.current.reputation?.rank).toBe(0);
+  });
+
+  it('throws and sets error when API returns 403', async () => {
+    mockFetch.mockResolvedValue(errorResponse(403));
+    const { result } = wrapHook(() => useReputation('alice'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).not.toBeNull();
+    expect(result.current.reputation).toBeNull();
+  });
+
+  it('stays in loading state when username is empty string (disabled)', () => {
+    mockFetch.mockResolvedValue(okJson(REP_DATA));
+    const { result } = wrapHook(() => useReputation(''));
+    // Query is disabled — no fetch fires, stays in idle/loading
+    expect(result.current.reputation).toBeNull();
+  });
+
+  it('is initially loading when username is provided', () => {
+    mockFetch.mockReturnValue(new Promise(() => {}));
+    const { result } = wrapHook(() => useReputation('alice'));
+    expect(result.current.loading).toBe(true);
+  });
+});

--- a/frontend/src/components/leaderboard/LeaderboardPage.tsx
+++ b/frontend/src/components/leaderboard/LeaderboardPage.tsx
@@ -5,6 +5,7 @@
  * pages/LeaderboardPage.tsx re-export.
  * @module components/leaderboard/LeaderboardPage
  */
+import { Link } from 'react-router-dom';
 import { useLeaderboard } from '../../hooks/useLeaderboard';
 import { Skeleton, SkeletonTable } from '../common/Skeleton';
 import { NoDataAvailable } from '../common/EmptyState';
@@ -132,8 +133,20 @@ export function LeaderboardPage() {
                 <td className="py-3">
                   <div className="flex items-center gap-2 flex-wrap">
                     <img src={c.avatarUrl} alt={c.username} className="h-6 w-6 rounded-full shrink-0" width={24} height={24} />
-                    <span className="font-medium text-gray-900 dark:text-white">{c.username}</span>
+                    <Link
+                      to={`/profile/${c.username}`}
+                      className="font-medium text-gray-900 hover:text-solana-purple dark:text-white dark:hover:text-solana-purple transition-colors"
+                    >
+                      {c.username}
+                    </Link>
                     <span className="text-xs text-gray-600 dark:text-gray-500">{c.topSkills.slice(0, 2).join(', ')}</span>
+                    <Link
+                      to={`/reputation/${c.username}`}
+                      className="text-xs text-gray-500 hover:text-solana-green dark:hover:text-solana-green transition-colors hidden sm:inline"
+                      aria-label={`View ${c.username} reputation`}
+                    >
+                      REP ↗
+                    </Link>
                   </div>
                 </td>
                 <td className="py-3 text-right text-emerald-700 dark:text-solana-green font-semibold tabular-nums">

--- a/frontend/src/components/reputation/ReputationBreakdown.tsx
+++ b/frontend/src/components/reputation/ReputationBreakdown.tsx
@@ -1,0 +1,185 @@
+/**
+ * ReputationBreakdown — shows how the reputation score is composed:
+ *   T1 completions, T2 completions, T3 completions, review score.
+ *
+ * Each row has a labelled stat + a proportional fill bar.
+ * @module components/reputation/ReputationBreakdown
+ */
+import React from 'react';
+import { Skeleton } from '../common/Skeleton';
+import type { ReputationBreakdown as Breakdown } from '../../types/reputation';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Star rating display (filled + empty up to 5). */
+function StarRating({ value, max = 5 }: { value: number; max?: number }) {
+  const full = Math.round(value);
+  return (
+    <span aria-label={`${value.toFixed(1)} out of ${max} stars`} className="inline-flex gap-0.5">
+      {Array.from({ length: max }, (_, i) => (
+        <svg
+          key={i}
+          className={`w-3.5 h-3.5 ${i < full ? 'text-amber-400' : 'text-gray-600'}`}
+          fill="currentColor"
+          viewBox="0 0 20 20"
+          aria-hidden="true"
+        >
+          <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+        </svg>
+      ))}
+    </span>
+  );
+}
+
+// ── Row types ─────────────────────────────────────────────────────────────────
+
+interface BreakdownRow {
+  label: string;
+  value: string;
+  subLabel?: string;
+  /** 0–1 fill fraction for the bar */
+  fill: number;
+  barColor: string;
+  extra?: React.ReactNode;
+}
+
+function buildRows(b: Breakdown): BreakdownRow[] {
+  const maxCompletions = Math.max(b.t1Completions, b.t2Completions, b.t3Completions, 1);
+  return [
+    {
+      label: 'T1 Completions',
+      value: String(b.t1Completions),
+      subLabel: `${b.t1Completions * 50} REP earned`,
+      fill: b.t1Completions / maxCompletions,
+      barColor: 'bg-sky-400',
+    },
+    {
+      label: 'T2 Completions',
+      value: String(b.t2Completions),
+      subLabel: `${b.t2Completions * 100} REP earned`,
+      fill: b.t2Completions / maxCompletions,
+      barColor: 'bg-solana-purple',
+    },
+    {
+      label: 'T3 Completions',
+      value: String(b.t3Completions),
+      subLabel: `${b.t3Completions * 200} REP earned`,
+      fill: b.t3Completions / maxCompletions,
+      barColor: 'bg-solana-green',
+    },
+    {
+      label: 'Avg Review Score',
+      value: `${b.avgReviewScore.toFixed(1)} / 5.0`,
+      subLabel: `${b.reviewCount} review${b.reviewCount === 1 ? '' : 's'}`,
+      fill: b.avgReviewScore / 5,
+      barColor: 'bg-amber-400',
+      extra: <StarRating value={b.avgReviewScore} />,
+    },
+  ];
+}
+
+// ── Row component ─────────────────────────────────────────────────────────────
+
+function BreakdownRowItem({ row }: { row: BreakdownRow }) {
+  return (
+    <li className="flex flex-col gap-1.5">
+      <div className="flex items-center justify-between gap-2 flex-wrap">
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="text-sm text-gray-300 font-medium truncate">{row.label}</span>
+          {row.extra}
+        </div>
+        <div className="text-right shrink-0">
+          <span className="text-sm font-mono font-bold text-gray-100">{row.value}</span>
+          {row.subLabel && (
+            <span className="ml-2 text-xs text-gray-600">{row.subLabel}</span>
+          )}
+        </div>
+      </div>
+      {/* Progress bar */}
+      <div className="h-1.5 rounded-full bg-white/5 overflow-hidden" aria-hidden="true">
+        <div
+          className={`h-full rounded-full transition-all duration-700 ${row.barColor}`}
+          style={{ width: `${Math.max(row.fill * 100, row.fill > 0 ? 2 : 0)}%` }}
+        />
+      </div>
+    </li>
+  );
+}
+
+// ── Loading skeleton ──────────────────────────────────────────────────────────
+
+function BreakdownSkeleton() {
+  return (
+    <div className="rounded-2xl border border-white/10 bg-surface-50 p-5 space-y-4">
+      <Skeleton height="1rem" width="8rem" rounded="md" />
+      {Array.from({ length: 4 }, (_, i) => (
+        <div key={i} className="space-y-1.5">
+          <div className="flex justify-between">
+            <Skeleton height="0.875rem" width="9rem" rounded="sm" />
+            <Skeleton height="0.875rem" width="5rem" rounded="sm" />
+          </div>
+          <Skeleton height="0.375rem" width="100%" rounded="full" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+export interface ReputationBreakdownProps {
+  breakdown: Breakdown;
+  loading?: boolean;
+  className?: string;
+}
+
+export function ReputationBreakdown({
+  breakdown,
+  loading = false,
+  className = '',
+}: ReputationBreakdownProps) {
+  if (loading) return <BreakdownSkeleton />;
+
+  const rows = buildRows(breakdown);
+
+  return (
+    <div
+      className={`rounded-2xl border border-white/10 bg-surface-50 p-5 ${className}`}
+      role="region"
+      aria-label="Reputation breakdown"
+    >
+      <div className="flex items-center justify-between mb-4 flex-wrap gap-2">
+        <h3 className="text-sm font-semibold text-gray-400 uppercase tracking-wider">
+          Score Breakdown
+        </h3>
+        {breakdown.streak > 0 && (
+          <span className="flex items-center gap-1 text-xs font-mono text-amber-400 bg-amber-400/10 px-2 py-0.5 rounded-full">
+            🔥 {breakdown.streak}d streak
+          </span>
+        )}
+      </div>
+
+      <ul className="space-y-4" aria-label="Reputation components">
+        {rows.map(row => (
+          <BreakdownRowItem key={row.label} row={row} />
+        ))}
+      </ul>
+
+      {/* Point multiplier legend */}
+      <div className="mt-4 pt-4 border-t border-white/5 flex flex-wrap gap-3">
+        {[
+          { tier: 'T1', pts: 50, color: 'bg-sky-400' },
+          { tier: 'T2', pts: 100, color: 'bg-solana-purple' },
+          { tier: 'T3', pts: 200, color: 'bg-solana-green' },
+        ].map(({ tier, pts, color }) => (
+          <span key={tier} className="flex items-center gap-1.5 text-xs text-gray-500">
+            <span className={`w-2 h-2 rounded-full ${color}`} aria-hidden="true" />
+            {tier} = +{pts} REP
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default ReputationBreakdown;

--- a/frontend/src/components/reputation/ReputationHistoryChart.tsx
+++ b/frontend/src/components/reputation/ReputationHistoryChart.tsx
@@ -1,0 +1,336 @@
+/**
+ * ReputationHistoryChart — SVG line chart showing reputation score over time.
+ *
+ * No external chart library required. Pure SVG with:
+ *   - Smooth cubic-bezier line and gradient fill
+ *   - Hover tooltip showing score and nearest event
+ *   - Responsive via preserveAspectRatio
+ *   - Loading skeleton
+ *
+ * @module components/reputation/ReputationHistoryChart
+ */
+import React, { useState, useRef, useCallback } from 'react';
+import { Skeleton } from '../common/Skeleton';
+import type { ReputationSnapshot, ReputationEvent } from '../../types/reputation';
+
+// ── Chart dimensions (viewBox space) ─────────────────────────────────────────
+
+const VB_W = 560;
+const VB_H = 180;
+const PAD = { top: 16, right: 16, bottom: 32, left: 44 };
+const CHART_W = VB_W - PAD.left - PAD.right;
+const CHART_H = VB_H - PAD.top - PAD.bottom;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Convert history snapshots to SVG coordinate pairs. */
+function toPoints(
+  history: ReputationSnapshot[],
+  minScore: number,
+  maxScore: number,
+): Array<{ x: number; y: number; snapshot: ReputationSnapshot }> {
+  if (history.length === 0) return [];
+  const range = maxScore - minScore || 1;
+  return history.map((s, i) => ({
+    x: PAD.left + (i / Math.max(history.length - 1, 1)) * CHART_W,
+    y: PAD.top + CHART_H - ((s.score - minScore) / range) * CHART_H,
+    snapshot: s,
+  }));
+}
+
+/**
+ * Build a smooth SVG path through points using cubic bezier curves.
+ * Each segment's control points are at the horizontal midpoint,
+ * creating a flowing S-curve through consecutive data points.
+ */
+function buildLinePath(pts: Array<{ x: number; y: number }>): string {
+  if (pts.length < 2) return pts.length === 1 ? `M ${pts[0].x},${pts[0].y}` : '';
+  let d = `M ${pts[0].x.toFixed(1)},${pts[0].y.toFixed(1)}`;
+  for (let i = 1; i < pts.length; i++) {
+    const prev = pts[i - 1];
+    const curr = pts[i];
+    const cpx = ((prev.x + curr.x) / 2).toFixed(1);
+    d += ` C ${cpx},${prev.y.toFixed(1)} ${cpx},${curr.y.toFixed(1)} ${curr.x.toFixed(1)},${curr.y.toFixed(1)}`;
+  }
+  return d;
+}
+
+/** Build the closed area path (same curve + baseline back). */
+function buildAreaPath(pts: Array<{ x: number; y: number }>): string {
+  if (pts.length < 2) return '';
+  const baseline = PAD.top + CHART_H;
+  const line = buildLinePath(pts);
+  return `${line} L ${pts[pts.length - 1].x.toFixed(1)},${baseline} L ${pts[0].x.toFixed(1)},${baseline} Z`;
+}
+
+/** Format ISO date to short label, e.g. "Mar 15". */
+function fmtDate(iso: string): string {
+  const d = new Date(iso + 'T00:00:00');
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+// ── Tooltip state ─────────────────────────────────────────────────────────────
+
+interface TooltipState {
+  pointIndex: number;
+  svgX: number; // fractional 0–1 (for CSS left)
+  svgY: number; // fractional 0–1 (for CSS top)
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export interface ReputationHistoryChartProps {
+  history: ReputationSnapshot[];
+  events?: ReputationEvent[];
+  loading?: boolean;
+  className?: string;
+}
+
+export function ReputationHistoryChart({
+  history,
+  events = [],
+  loading = false,
+  className = '',
+}: ReputationHistoryChartProps) {
+  const [tooltip, setTooltip] = useState<TooltipState | null>(null);
+  const svgRef = useRef<SVGSVGElement>(null);
+
+  // Derived values
+  const scores = history.map(h => h.score);
+  const minScore = Math.max(0, Math.min(...scores) - 20);
+  const maxScore = Math.max(...scores) + 20 || 100;
+  const points = toPoints(history, minScore, maxScore);
+
+  // Y-axis grid lines (4 steps)
+  const ySteps = 4;
+  const yGridLines = Array.from({ length: ySteps + 1 }, (_, i) => {
+    const fraction = i / ySteps;
+    return {
+      y: PAD.top + CHART_H * (1 - fraction),
+      label: Math.round(minScore + (maxScore - minScore) * fraction).toLocaleString(),
+    };
+  });
+
+  // X-axis labels: show first, middle, last
+  const xLabels: Array<{ x: number; label: string }> = [];
+  if (history.length > 0) {
+    const indices = [0, Math.floor(history.length / 2), history.length - 1];
+    for (const idx of [...new Set(indices)]) {
+      xLabels.push({ x: points[idx].x, label: fmtDate(history[idx].date) });
+    }
+  }
+
+  // Find event matching a given date
+  function eventForDate(date: string): ReputationEvent | undefined {
+    return events.find(e => e.date === date);
+  }
+
+  // Mouse hover: find nearest point
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent<SVGSVGElement>) => {
+      if (!svgRef.current || points.length === 0) return;
+      const rect = svgRef.current.getBoundingClientRect();
+      const relX = e.clientX - rect.left;
+      const scaleX = VB_W / rect.width;
+      const svgX = relX * scaleX;
+
+      let closestIdx = 0;
+      let minDist = Infinity;
+      for (let i = 0; i < points.length; i++) {
+        const dist = Math.abs(points[i].x - svgX);
+        if (dist < minDist) { minDist = dist; closestIdx = i; }
+      }
+
+      setTooltip({
+        pointIndex: closestIdx,
+        svgX: (points[closestIdx].x - PAD.left) / CHART_W,
+        svgY: (points[closestIdx].y - PAD.top) / CHART_H,
+      });
+    },
+    [points],
+  );
+
+  const handleMouseLeave = useCallback(() => setTooltip(null), []);
+
+  // Build paths
+  const linePath = buildLinePath(points);
+  const areaPath = buildAreaPath(points);
+
+  // ── Loading skeleton ────────────────────────────────────────────────────────
+  if (loading) {
+    return (
+      <div
+        className={`rounded-2xl border border-white/10 bg-surface-50 p-5 ${className}`}
+        aria-busy="true"
+        aria-label="Loading reputation chart"
+      >
+        <Skeleton height="1rem" width="10rem" rounded="md" className="mb-4" />
+        <Skeleton height="9rem" width="100%" rounded="lg" />
+        <div className="flex justify-between mt-2">
+          {Array.from({ length: 3 }, (_, i) => (
+            <Skeleton key={i} height="0.75rem" width="3.5rem" rounded="sm" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  const hoveredPoint = tooltip !== null ? points[tooltip.pointIndex] : null;
+  const hoveredSnapshot = hoveredPoint?.snapshot ?? null;
+  const hoveredEvent = hoveredSnapshot ? eventForDate(hoveredSnapshot.date) : null;
+
+  // Tooltip position: flip to left side if past midpoint
+  const tooltipOnLeft = tooltip !== null && tooltip.svgX > 0.55;
+
+  return (
+    <div
+      className={`rounded-2xl border border-white/10 bg-surface-50 p-5 ${className}`}
+      role="region"
+      aria-label="Reputation history chart"
+    >
+      <h3 className="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-4">
+        Score History
+      </h3>
+
+      {history.length < 2 ? (
+        <div className="flex items-center justify-center h-32 text-gray-600 text-sm">
+          Not enough data yet
+        </div>
+      ) : (
+        <div className="relative">
+          <svg
+            ref={svgRef}
+            viewBox={`0 0 ${VB_W} ${VB_H}`}
+            preserveAspectRatio="xMidYMid meet"
+            className="w-full h-auto cursor-crosshair select-none"
+            onMouseMove={handleMouseMove}
+            onMouseLeave={handleMouseLeave}
+            aria-hidden="true"
+          >
+            <defs>
+              <linearGradient id="rep-area-fill" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor="#9945FF" stopOpacity="0.25" />
+                <stop offset="100%" stopColor="#9945FF" stopOpacity="0.02" />
+              </linearGradient>
+            </defs>
+
+            {/* Y-axis grid lines */}
+            {yGridLines.map((g, i) => (
+              <g key={i}>
+                <line
+                  x1={PAD.left}
+                  y1={g.y}
+                  x2={VB_W - PAD.right}
+                  y2={g.y}
+                  stroke="white"
+                  strokeOpacity="0.05"
+                  strokeWidth="1"
+                />
+                <text
+                  x={PAD.left - 6}
+                  y={g.y + 4}
+                  textAnchor="end"
+                  fontSize="9"
+                  fill="rgba(156,163,175,0.7)"
+                  fontFamily="monospace"
+                >
+                  {g.label}
+                </text>
+              </g>
+            ))}
+
+            {/* Area fill */}
+            <path d={areaPath} fill="url(#rep-area-fill)" />
+
+            {/* Line */}
+            <path
+              d={linePath}
+              fill="none"
+              stroke="#9945FF"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+
+            {/* Data point dots — visible on all, highlighted on hover */}
+            {points.map((p, i) => (
+              <circle
+                key={i}
+                cx={p.x}
+                cy={p.y}
+                r={tooltip?.pointIndex === i ? 5 : 3}
+                fill={tooltip?.pointIndex === i ? '#14F195' : '#9945FF'}
+                stroke={tooltip?.pointIndex === i ? '#14F195' : 'transparent'}
+                strokeWidth="2"
+                strokeOpacity="0.4"
+                style={{ transition: 'r 0.1s, fill 0.1s' }}
+              />
+            ))}
+
+            {/* Vertical hover line */}
+            {hoveredPoint && (
+              <line
+                x1={hoveredPoint.x}
+                y1={PAD.top}
+                x2={hoveredPoint.x}
+                y2={PAD.top + CHART_H}
+                stroke="white"
+                strokeOpacity="0.15"
+                strokeWidth="1"
+                strokeDasharray="4 3"
+              />
+            )}
+
+            {/* X-axis labels */}
+            {xLabels.map((xl, i) => (
+              <text
+                key={i}
+                x={xl.x}
+                y={VB_H - 4}
+                textAnchor="middle"
+                fontSize="9"
+                fill="rgba(156,163,175,0.6)"
+                fontFamily="monospace"
+              >
+                {xl.label}
+              </text>
+            ))}
+          </svg>
+
+          {/* Floating tooltip */}
+          {tooltip !== null && hoveredSnapshot && (
+            <div
+              className={`absolute pointer-events-none z-10
+                bg-surface-100 border border-white/10 rounded-xl px-3 py-2
+                text-xs shadow-xl whitespace-nowrap
+                -translate-y-full -mt-2`}
+              style={{
+                left: tooltipOnLeft
+                  ? `calc(${tooltip.svgX * 100}% - 8px)`
+                  : `calc(${tooltip.svgX * 100}% + 8px)`,
+                top: `${Math.max(0, tooltip.svgY) * 100}%`,
+                transform: tooltipOnLeft
+                  ? 'translateX(-100%) translateY(-100%)'
+                  : 'translateY(-100%)',
+              }}
+              role="tooltip"
+            >
+              <div className="font-semibold text-solana-green tabular-nums mb-0.5">
+                {hoveredSnapshot.score.toLocaleString()} REP
+              </div>
+              <div className="text-gray-400">{fmtDate(hoveredSnapshot.date)}</div>
+              {hoveredEvent && (
+                <div className="text-gray-300 mt-1 border-t border-white/10 pt-1">
+                  <span className="text-solana-green font-mono">+{hoveredEvent.delta}</span>
+                  {' '}· {hoveredEvent.reason}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default ReputationHistoryChart;

--- a/frontend/src/components/reputation/ReputationPanel.tsx
+++ b/frontend/src/components/reputation/ReputationPanel.tsx
@@ -1,0 +1,248 @@
+/**
+ * ReputationPanel — composite layout assembling all reputation widgets:
+ *   - ReputationScoreCard
+ *   - TierProgressIndicator
+ *   - ReputationHistoryChart
+ *   - ReputationBreakdown
+ *   - Recent Events feed (with hover detail tooltips)
+ *
+ * Responsive: single column on mobile, two columns on md+.
+ * @module components/reputation/ReputationPanel
+ */
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useReputation } from '../../hooks/useReputation';
+import { ReputationScoreCard } from './ReputationScoreCard';
+import { ReputationHistoryChart } from './ReputationHistoryChart';
+import { ReputationBreakdown } from './ReputationBreakdown';
+import { TierProgressIndicator } from './TierProgressIndicator';
+import type { ReputationEvent } from '../../types/reputation';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Format ISO date to human-readable. */
+function fmtDate(iso: string): string {
+  return new Date(iso + 'T00:00:00').toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+// ── Events feed ───────────────────────────────────────────────────────────────
+
+const TIER_DOT: Record<string, string> = {
+  T1: 'bg-sky-400',
+  T2: 'bg-solana-purple',
+  T3: 'bg-solana-green',
+};
+
+function EventRow({ event }: { event: ReputationEvent }) {
+  const [showDetail, setShowDetail] = useState(false);
+
+  return (
+    <li
+      className="relative flex items-start gap-3 py-2.5 border-b border-white/5 last:border-0
+        cursor-default group"
+      onMouseEnter={() => setShowDetail(true)}
+      onMouseLeave={() => setShowDetail(false)}
+      onFocus={() => setShowDetail(true)}
+      onBlur={() => setShowDetail(false)}
+      tabIndex={0}
+      aria-label={`${event.reason} on ${fmtDate(event.date)}: +${event.delta} reputation`}
+    >
+      {/* Tier colour dot */}
+      <span
+        className={`mt-1 w-2 h-2 rounded-full shrink-0 ${TIER_DOT[event.tier] ?? 'bg-gray-500'}`}
+        aria-hidden="true"
+      />
+
+      <div className="flex-1 min-w-0">
+        <p className="text-sm text-gray-300 truncate">{event.reason}</p>
+        <p className="text-xs text-gray-600 mt-0.5 font-mono">{fmtDate(event.date)}</p>
+      </div>
+
+      {/* Delta badge */}
+      <span className="text-sm font-mono font-bold text-solana-green shrink-0">
+        +{event.delta}
+      </span>
+
+      {/* Hover tooltip */}
+      {showDetail && (
+        <div
+          className="absolute right-0 top-full mt-1 z-20
+            bg-surface-100 border border-white/10 rounded-xl px-3 py-2
+            text-xs shadow-xl whitespace-nowrap pointer-events-none"
+          role="tooltip"
+        >
+          <div className="font-semibold text-gray-200 mb-1">{event.reason}</div>
+          <div className="text-gray-400">
+            <span className="text-solana-green font-mono">+{event.delta} REP</span>
+            {' '}· {event.tier} bounty · {fmtDate(event.date)}
+          </div>
+          {event.bountyId && (
+            <div className="text-gray-600 mt-0.5">ID: {event.bountyId}</div>
+          )}
+        </div>
+      )}
+    </li>
+  );
+}
+
+function EventsFeed({
+  events,
+  loading,
+}: {
+  events: ReputationEvent[];
+  loading: boolean;
+}) {
+  const shown = events.slice(0, 10);
+
+  return (
+    <div className="rounded-2xl border border-white/10 bg-surface-50 p-5">
+      <h3 className="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-3">
+        Recent Activity
+      </h3>
+
+      {loading ? (
+        <ul className="space-y-2.5" aria-busy="true" aria-label="Loading recent activity">
+          {Array.from({ length: 6 }, (_, i) => (
+            <li key={i} className="flex items-center gap-3 py-1">
+              <span className="w-2 h-2 rounded-full bg-white/10 shrink-0" />
+              <div className="flex-1 h-3 rounded bg-white/5 animate-pulse" />
+              <div className="w-8 h-3 rounded bg-white/5 animate-pulse" />
+            </li>
+          ))}
+        </ul>
+      ) : shown.length === 0 ? (
+        <p className="text-sm text-gray-600 py-4 text-center">No activity yet</p>
+      ) : (
+        <ul aria-label="Reputation events">
+          {shown.map(ev => (
+            <EventRow key={ev.id} event={ev} />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+// ── Leaderboard rank teaser ───────────────────────────────────────────────────
+
+function LeaderboardTeaser({
+  rank,
+  total,
+  username,
+}: {
+  rank: number;
+  total: number;
+  username: string;
+}) {
+  if (rank === 0) return null;
+  const medal = rank === 1 ? '🥇' : rank === 2 ? '🥈' : rank === 3 ? '🥉' : null;
+  return (
+    <div className="rounded-2xl border border-white/10 bg-surface-50 p-4 flex items-center justify-between gap-4 flex-wrap">
+      <div className="flex items-center gap-2">
+        {medal && <span className="text-2xl" aria-hidden="true">{medal}</span>}
+        <div>
+          <p className="text-xs text-gray-500 font-mono uppercase tracking-wider">
+            Leaderboard Rank
+          </p>
+          <p className="text-xl font-black tabular-nums text-gray-100">
+            #{rank}
+            <span className="text-sm font-normal text-gray-500 ml-1.5">
+              of {total.toLocaleString()}
+            </span>
+          </p>
+        </div>
+      </div>
+      <Link
+        to="/leaderboard"
+        className="text-xs font-medium text-solana-purple hover:text-solana-green transition-colors
+          px-3 py-1.5 rounded-lg border border-solana-purple/20 hover:border-solana-green/30"
+        aria-label={`View ${username} on the leaderboard`}
+      >
+        View leaderboard →
+      </Link>
+    </div>
+  );
+}
+
+// ── Main ReputationPanel ──────────────────────────────────────────────────────
+
+export interface ReputationPanelProps {
+  username: string;
+  className?: string;
+}
+
+export function ReputationPanel({ username, className = '' }: ReputationPanelProps) {
+  const { reputation: rep, loading, error } = useReputation(username);
+
+  if (error) {
+    return (
+      <div className="rounded-2xl border border-red-500/20 bg-red-500/5 p-6 text-center" role="alert">
+        <p className="text-sm text-red-400">{error}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`space-y-4 ${className}`}>
+      {/* Top row: score card + leaderboard teaser */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <ReputationScoreCard
+          score={rep?.score ?? 0}
+          rank={rep?.rank ?? 0}
+          totalContributors={rep?.totalContributors ?? 0}
+          tier={rep?.tier ?? 'T1'}
+          loading={loading}
+        />
+        <div className="flex flex-col gap-4">
+          {loading ? (
+            <div className="rounded-2xl border border-white/10 bg-surface-50 h-full animate-pulse" />
+          ) : rep && (
+            <LeaderboardTeaser
+              rank={rep.rank}
+              total={rep.totalContributors}
+              username={username}
+            />
+          )}
+        </div>
+      </div>
+
+      {/* History chart — full width */}
+      <ReputationHistoryChart
+        history={rep?.history ?? []}
+        events={rep?.events ?? []}
+        loading={loading}
+      />
+
+      {/* Two-column: breakdown + tier progress */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <ReputationBreakdown
+          breakdown={rep?.breakdown ?? {
+            t1Completions: 0,
+            t2Completions: 0,
+            t3Completions: 0,
+            avgReviewScore: 0,
+            reviewCount: 0,
+            streak: 0,
+          }}
+          loading={loading}
+        />
+        <TierProgressIndicator
+          tier={rep?.tier ?? 'T1'}
+          t1Completions={rep?.breakdown.t1Completions ?? 0}
+          t2Completions={rep?.breakdown.t2Completions ?? 0}
+          t3Completions={rep?.breakdown.t3Completions ?? 0}
+          loading={loading}
+        />
+      </div>
+
+      {/* Events feed — full width */}
+      <EventsFeed events={rep?.events ?? []} loading={loading} />
+    </div>
+  );
+}
+
+export default ReputationPanel;

--- a/frontend/src/components/reputation/ReputationScoreCard.tsx
+++ b/frontend/src/components/reputation/ReputationScoreCard.tsx
@@ -1,0 +1,143 @@
+/**
+ * ReputationScoreCard — displays the headline reputation score, tier badge,
+ * and global leaderboard rank.
+ * @module components/reputation/ReputationScoreCard
+ */
+import React from 'react';
+import { Skeleton } from '../common/Skeleton';
+import type { Tier } from '../../types/reputation';
+
+// ── Tier config ───────────────────────────────────────────────────────────────
+
+const TIER_CONFIG: Record<Tier, { label: string; color: string; bg: string; ring: string; glow: string }> = {
+  T1: {
+    label: 'Tier 1',
+    color: 'text-sky-400',
+    bg: 'bg-sky-500/10',
+    ring: 'ring-sky-500/30',
+    glow: 'shadow-sky-500/20',
+  },
+  T2: {
+    label: 'Tier 2',
+    color: 'text-solana-purple',
+    bg: 'bg-solana-purple/10',
+    ring: 'ring-solana-purple/30',
+    glow: 'shadow-solana-purple/20',
+  },
+  T3: {
+    label: 'Tier 3',
+    color: 'text-solana-green',
+    bg: 'bg-solana-green/10',
+    ring: 'ring-solana-green/30',
+    glow: 'shadow-solana-green/20',
+  },
+};
+
+// ── Rank badge ────────────────────────────────────────────────────────────────
+
+function RankBadge({ rank, total }: { rank: number; total: number }) {
+  const medal = rank === 1 ? '🥇' : rank === 2 ? '🥈' : rank === 3 ? '🥉' : null;
+  if (rank === 0 || total === 0) return null;
+  return (
+    <div className="flex items-center gap-1.5 text-sm text-gray-400 dark:text-gray-500">
+      {medal && <span aria-hidden="true">{medal}</span>}
+      <span className="font-mono">
+        <span className="text-gray-700 dark:text-gray-200 font-semibold">#{rank}</span>
+        {' '}of {total.toLocaleString()}
+      </span>
+    </div>
+  );
+}
+
+// ── Tier badge ────────────────────────────────────────────────────────────────
+
+export function TierBadge({ tier }: { tier: Tier }) {
+  const cfg = TIER_CONFIG[tier];
+  return (
+    <span
+      className={`inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-bold
+        ring-1 ${cfg.bg} ${cfg.color} ${cfg.ring}`}
+      aria-label={`Current tier: ${cfg.label}`}
+    >
+      {tier === 'T3' && <span aria-hidden="true">🏆</span>}
+      {cfg.label}
+    </span>
+  );
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+export interface ReputationScoreCardProps {
+  score: number;
+  rank: number;
+  totalContributors: number;
+  tier: Tier;
+  loading?: boolean;
+  className?: string;
+}
+
+export function ReputationScoreCard({
+  score,
+  rank,
+  totalContributors,
+  tier,
+  loading = false,
+  className = '',
+}: ReputationScoreCardProps) {
+  const cfg = TIER_CONFIG[tier];
+
+  if (loading) {
+    return (
+      <div
+        className={`rounded-2xl border border-white/10 bg-surface-50 p-6 flex flex-col gap-4 ${className}`}
+        aria-busy="true"
+        aria-label="Loading reputation score"
+      >
+        <div className="flex items-start justify-between">
+          <Skeleton height="3.5rem" width="10rem" rounded="lg" />
+          <Skeleton height="1.5rem" width="5rem" rounded="full" />
+        </div>
+        <Skeleton height="1rem" width="8rem" rounded="md" />
+        <Skeleton height="0.875rem" width="6rem" rounded="md" />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`rounded-2xl border border-white/10 bg-surface-50 p-6 flex flex-col gap-3
+        shadow-lg ${cfg.glow} ${className}`}
+      role="region"
+      aria-label="Reputation score"
+    >
+      {/* Score + tier row */}
+      <div className="flex items-start justify-between gap-4 flex-wrap">
+        <div>
+          <p className="text-xs font-mono uppercase tracking-widest text-gray-500 mb-1">
+            Reputation Score
+          </p>
+          <p
+            className={`text-5xl font-black tabular-nums leading-none ${cfg.color}`}
+            aria-label={`${score.toLocaleString()} reputation points`}
+          >
+            {score.toLocaleString()}
+          </p>
+        </div>
+        <TierBadge tier={tier} />
+      </div>
+
+      {/* Rank */}
+      <RankBadge rank={rank} total={totalContributors} />
+
+      {/* Divider */}
+      <div className="h-px bg-white/5" />
+
+      {/* Label row */}
+      <p className="text-xs text-gray-600 dark:text-gray-500 font-mono">
+        REP · SolFoundry Contributor
+      </p>
+    </div>
+  );
+}
+
+export default ReputationScoreCard;

--- a/frontend/src/components/reputation/TierProgressIndicator.tsx
+++ b/frontend/src/components/reputation/TierProgressIndicator.tsx
@@ -1,0 +1,143 @@
+/**
+ * TierProgressIndicator — visual progress bar towards the next tier,
+ * with a plain-text "N completions to unlock TierX" label below.
+ *
+ * Composes the existing TierProgressBar and adds:
+ *   - "Progress to next tier" header
+ *   - Requirement callout ("3 more T1 merges to unlock T2")
+ *   - Points-per-tier legend
+ *   - Loading skeleton
+ *
+ * @module components/reputation/TierProgressIndicator
+ */
+import React from 'react';
+import { TierProgressBar } from '../common/TierProgressBar';
+import { Skeleton } from '../common/Skeleton';
+import type { Tier } from '../../types/reputation';
+
+// ── Next-tier requirement message ─────────────────────────────────────────────
+
+function nextTierMessage(
+  tier: Tier,
+  t1: number,
+  t2: number,
+  t3: number,
+): string {
+  if (tier === 'T3') return '🏆 Maximum tier reached — nothing higher to unlock.';
+  if (tier === 'T1') {
+    const needed = Math.max(0, 4 - t1);
+    return needed === 0
+      ? 'T2 requirements met — keep completing bounties!'
+      : `${needed} more T1 merge${needed === 1 ? '' : 's'} needed to unlock T2`;
+  }
+  // T2 → T3
+  const path1 = Math.max(0, 3 - t2);
+  const path2t1 = Math.max(0, 5 - t1);
+  const path2t2 = Math.max(0, 1 - t2);
+  if (path1 === 0 || (path2t1 === 0 && path2t2 === 0)) {
+    return 'T3 requirements met — keep completing bounties!';
+  }
+  const msgA = path1 > 0 ? `${path1} more T2 merge${path1 === 1 ? '' : 's'}` : null;
+  const msgB = path2t1 > 0 || path2t2 > 0
+    ? [path2t1 > 0 && `${path2t1} T1`, path2t2 > 0 && `${path2t2} T2`]
+        .filter(Boolean).join(' + ') + ' merge' + (path2t1 + path2t2 > 1 ? 's' : '')
+    : null;
+  const parts = [msgA, msgB].filter(Boolean);
+  return parts.length === 2
+    ? `To unlock T3: ${parts[0]} (or ${parts[1]})`
+    : `To unlock T3: ${parts[0]}`;
+}
+
+// ── Skeleton ──────────────────────────────────────────────────────────────────
+
+function TierProgressSkeleton({ className }: { className?: string }) {
+  return (
+    <div className={`rounded-2xl border border-white/10 bg-surface-50 p-5 space-y-4 ${className}`}>
+      <Skeleton height="1rem" width="10rem" rounded="md" />
+      <div className="space-y-2">
+        <div className="flex justify-between">
+          {Array.from({ length: 3 }, (_, i) => (
+            <Skeleton key={i} height="0.75rem" width="4rem" rounded="sm" />
+          ))}
+        </div>
+        <Skeleton height="0.375rem" width="100%" rounded="full" />
+      </div>
+      <Skeleton height="0.875rem" width="14rem" rounded="sm" />
+    </div>
+  );
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+export interface TierProgressIndicatorProps {
+  tier: Tier;
+  t1Completions: number;
+  t2Completions: number;
+  t3Completions: number;
+  loading?: boolean;
+  className?: string;
+}
+
+export function TierProgressIndicator({
+  tier,
+  t1Completions,
+  t2Completions,
+  t3Completions,
+  loading = false,
+  className = '',
+}: TierProgressIndicatorProps) {
+  if (loading) return <TierProgressSkeleton className={className} />;
+
+  const message = nextTierMessage(tier, t1Completions, t2Completions, t3Completions);
+  const isMaxTier = tier === 'T3';
+
+  return (
+    <div
+      className={`rounded-2xl border border-white/10 bg-surface-50 p-5 ${className}`}
+      role="region"
+      aria-label="Tier progress"
+    >
+      <h3 className="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-4">
+        Tier Progress
+      </h3>
+
+      {/* Existing TierProgressBar handles the visual track */}
+      <TierProgressBar
+        completedT1={t1Completions}
+        completedT2={t2Completions}
+        completedT3={t3Completions}
+      />
+
+      {/* Next-tier callout */}
+      <div
+        className={`mt-4 rounded-lg px-3 py-2 text-xs font-mono
+          ${isMaxTier
+            ? 'bg-solana-green/10 text-solana-green border border-solana-green/20'
+            : 'bg-white/5 text-gray-400 border border-white/5'}`}
+        aria-live="polite"
+      >
+        {message}
+      </div>
+
+      {/* Per-tier point legend */}
+      <div className="mt-3 grid grid-cols-3 gap-2 text-xs text-center">
+        {[
+          { tier: 'T1', pts: 50, active: tier === 'T1', color: 'text-sky-400', border: 'border-sky-500/20' },
+          { tier: 'T2', pts: 100, active: tier === 'T2', color: 'text-solana-purple', border: 'border-solana-purple/20' },
+          { tier: 'T3', pts: 200, active: tier === 'T3', color: 'text-solana-green', border: 'border-solana-green/20' },
+        ].map(row => (
+          <div
+            key={row.tier}
+            className={`rounded-lg border py-1.5 font-mono ${row.border}
+              ${row.active ? 'bg-white/5' : 'bg-transparent opacity-60'}`}
+          >
+            <div className={`font-bold ${row.color}`}>{row.tier}</div>
+            <div className="text-gray-500">+{row.pts} REP</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default TierProgressIndicator;

--- a/frontend/src/hooks/useReputation.ts
+++ b/frontend/src/hooks/useReputation.ts
@@ -1,0 +1,131 @@
+/**
+ * useReputation — fetches reputation data for a contributor.
+ *
+ * Tries GET /api/users/{username}/reputation first.
+ * Falls back to computing from leaderboard data + synthetic history when
+ * the dedicated endpoint is unavailable (e.g. during development).
+ *
+ * @module hooks/useReputation
+ */
+import { useQuery } from '@tanstack/react-query';
+import { apiClient, isApiError } from '../services/apiClient';
+import type { ReputationData, ReputationEvent, ReputationSnapshot, Tier } from '../types/reputation';
+
+// Point weights per tier completion
+const TIER_POINTS: Record<Tier, number> = { T1: 50, T2: 100, T3: 200 };
+
+function tierFromCounts(t1: number, t2: number, t3: number): Tier {
+  if (t3 > 0 || t2 >= 3 || (t1 >= 5 && t2 >= 1)) return 'T3';
+  if (t1 >= 4) return 'T2';
+  return 'T1';
+}
+
+/**
+ * Build a plausible ReputationData from minimal leaderboard fields when
+ * the dedicated API endpoint is not yet available.
+ */
+function buildFallback(
+  bountiesCompleted: number,
+  rank: number,
+  totalContributors: number,
+): ReputationData {
+  // Spread bounties across tiers: ~50% T1, 35% T2, 15% T3
+  const t1 = Math.max(0, Math.round(bountiesCompleted * 0.5));
+  const t2 = Math.max(0, Math.round(bountiesCompleted * 0.35));
+  const t3 = Math.max(0, bountiesCompleted - t1 - t2);
+  const score = t1 * TIER_POINTS.T1 + t2 * TIER_POINTS.T2 + t3 * TIER_POINTS.T3;
+
+  // Deterministic 12-week history
+  const history: ReputationSnapshot[] = [];
+  const now = new Date();
+  const weeklyStep = Math.max(1, Math.floor(score / 12));
+  let running = 0;
+  for (let w = 11; w >= 0; w--) {
+    const d = new Date(now);
+    d.setDate(d.getDate() - w * 7);
+    running = Math.min(score, running + weeklyStep + (w % 4 === 0 ? 15 : 0));
+    history.push({ date: d.toISOString().split('T')[0], score: running });
+  }
+  history[history.length - 1].score = score;
+
+  // Synthetic events, newest first
+  const events: ReputationEvent[] = [];
+  const tierList: Tier[] = ['T1', 'T2', 'T3'];
+  for (let i = 0; i < Math.min(bountiesCompleted, 12); i++) {
+    const d = new Date(now);
+    d.setDate(d.getDate() - i * 6);
+    const tier = tierList[Math.min(Math.floor(i / 5), 2)];
+    events.push({
+      id: `ev-${i}`,
+      date: d.toISOString().split('T')[0],
+      delta: TIER_POINTS[tier],
+      reason: `Completed ${tier} bounty`,
+      tier,
+    });
+  }
+
+  return {
+    score,
+    rank,
+    totalContributors,
+    tier: tierFromCounts(t1, t2, t3),
+    breakdown: {
+      t1Completions: t1,
+      t2Completions: t2,
+      t3Completions: t3,
+      avgReviewScore: 4.2,
+      reviewCount: bountiesCompleted,
+      streak: Math.max(1, Math.floor(bountiesCompleted / 2)),
+    },
+    history,
+    events,
+  };
+}
+
+async function fetchReputation(username: string): Promise<ReputationData> {
+  // 1. Try dedicated reputation endpoint
+  try {
+    const data = await apiClient<ReputationData>(
+      `/api/users/${encodeURIComponent(username)}/reputation`,
+      { retries: 1 },
+    );
+    if (data && typeof data.score === 'number') return data;
+  } catch (err) {
+    // Rethrow hard client errors (401, 403); let 404 fall through to leaderboard
+    if (isApiError(err) && err.status >= 400 && err.status < 500 && err.status !== 404) throw err;
+  }
+
+  // 2. Fall back: compute from leaderboard
+  try {
+    type Row = { username: string; points: number; bountiesCompleted: number };
+    const rows = await apiClient<Row[]>('/api/leaderboard', {
+      params: { range: 'all' },
+      retries: 1,
+    });
+    if (Array.isArray(rows)) {
+      const sorted = [...rows]
+        .sort((a, b) => b.points - a.points)
+        .map((c, i) => ({ ...c, rank: i + 1 }));
+      const user = sorted.find(c => c.username === username);
+      if (user) return buildFallback(user.bountiesCompleted, user.rank, sorted.length);
+    }
+  } catch { /* ignore */ }
+
+  // 3. Ultimate fallback — empty profile
+  return buildFallback(0, 0, 0);
+}
+
+export function useReputation(username: string) {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['reputation', username],
+    queryFn: () => fetchReputation(username),
+    staleTime: 60_000,
+    enabled: Boolean(username),
+  });
+
+  return {
+    reputation: data ?? null,
+    loading: isLoading,
+    error: error instanceof Error ? error.message : null,
+  };
+}

--- a/frontend/src/pages/ReputationPage.tsx
+++ b/frontend/src/pages/ReputationPage.tsx
@@ -1,0 +1,57 @@
+/**
+ * ReputationPage — route target for /reputation/:username
+ *
+ * Renders the full ReputationPanel for the given contributor.
+ * @module pages/ReputationPage
+ */
+import React from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { ReputationPanel } from '../components/reputation/ReputationPanel';
+
+export default function ReputationPage() {
+  const { username } = useParams<{ username: string }>();
+
+  if (!username) {
+    return (
+      <div className="p-8 text-center text-gray-500" role="alert">
+        No username specified.
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-8 space-y-6">
+      {/* Breadcrumb */}
+      <nav className="flex items-center gap-2 text-sm text-gray-500 font-mono" aria-label="Breadcrumb">
+        <Link
+          to="/leaderboard"
+          className="hover:text-gray-300 transition-colors"
+        >
+          Leaderboard
+        </Link>
+        <span aria-hidden="true">/</span>
+        <Link
+          to={`/profile/${username}`}
+          className="hover:text-gray-300 transition-colors"
+        >
+          {username}
+        </Link>
+        <span aria-hidden="true">/</span>
+        <span className="text-gray-300">Reputation</span>
+      </nav>
+
+      {/* Page heading */}
+      <div>
+        <h1 className="text-2xl font-bold text-white">
+          {username}&apos;s Reputation
+        </h1>
+        <p className="text-sm text-gray-500 mt-1">
+          On-chain reputation data, tier progress, and contribution history.
+        </p>
+      </div>
+
+      {/* All reputation widgets */}
+      <ReputationPanel username={username} />
+    </div>
+  );
+}

--- a/frontend/src/types/reputation.ts
+++ b/frontend/src/types/reputation.ts
@@ -1,0 +1,43 @@
+/**
+ * Reputation domain types shared by hook and components.
+ * @module types/reputation
+ */
+
+export type Tier = 'T1' | 'T2' | 'T3';
+
+/** A single reputation event (bounty completion, review score, etc). */
+export interface ReputationEvent {
+  id: string;
+  date: string;     // ISO date string "2024-03-15"
+  delta: number;    // signed point change, e.g. +50 or -10
+  reason: string;   // human-readable, e.g. "Completed T2 bounty: Fix pagination bug"
+  tier: Tier;
+  bountyId?: string;
+}
+
+/** Score at a point in time (for the history chart). */
+export interface ReputationSnapshot {
+  date: string;   // ISO date string
+  score: number;
+}
+
+/** Breakdown of how the score is composed. */
+export interface ReputationBreakdown {
+  t1Completions: number;
+  t2Completions: number;
+  t3Completions: number;
+  avgReviewScore: number; // 0–5
+  reviewCount: number;
+  streak: number;         // active day streak
+}
+
+/** Full reputation profile for a contributor. */
+export interface ReputationData {
+  score: number;
+  rank: number;
+  totalContributors: number;
+  tier: Tier;
+  breakdown: ReputationBreakdown;
+  history: ReputationSnapshot[];  // oldest → newest
+  events: ReputationEvent[];      // newest → oldest
+}


### PR DESCRIPTION
## Description

Builds the full reputation UI layer for SolFoundry contributors — score display, history chart, tier progress, breakdown by contribution type, and a recent events feed with hover tooltips. All components work with both live API data and a computed fallback derived from leaderboard data when the dedicated endpoint is not yet available. Route: `/reputation/:username`.

Closes #499 

## Solana Wallet for Payout
**Wallet:** 4QhseKvBuaCQhdkP248iXoUxohPzVC5m8pE9hAv4nMYw

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [x] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test addition/update

## Checklist
- [x] Code is clean and follows the issue spec exactly
- [x] One PR per bounty (no multiple bounties in one PR)
- [ ] Tests included for new functionality
- [x] All existing tests pass
- [x] No `console.log` or debugging code left behind
- [x] No hardcoded secrets or API keys

## Testing
- [x] Manual testing performed
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated

`tsc --noEmit` passes with zero errors across all new files.

## Screenshots (if applicable)

N/A — frontend-only feature; components render in browser at `/reputation/:username`.

## Additional Notes

**New files:**

- `frontend/src/types/reputation.ts` — `ReputationData`, `ReputationEvent`, `ReputationSnapshot`, `ReputationBreakdown`, `Tier` types shared across all components
- `frontend/src/hooks/useReputation.ts` — React Query hook; tries `GET /api/users/:username/reputation`, falls back to leaderboard data + deterministic synthetic history when the endpoint is unavailable
- `frontend/src/components/reputation/ReputationScoreCard.tsx` — large score number, colour-coded tier badge (T1 = sky, T2 = purple, T3 = green + trophy), global rank with medal emoji for top 3
- `frontend/src/components/reputation/ReputationHistoryChart.tsx` — pure SVG line chart (no external library); smooth cubic-bezier curve, gradient area fill, hover crosshair + floating tooltip showing score and nearest reputation event
- `frontend/src/components/reputation/ReputationBreakdown.tsx` — T1 / T2 / T3 completion counts with proportional fill bars, average review score with star rating, streak badge, per-tier REP multiplier legend
- `frontend/src/components/reputation/TierProgressIndicator.tsx` — composes the existing `TierProgressBar` with a plain-text next-tier requirement callout ("3 more T1 merges to unlock T2") and a per-tier REP legend
- `frontend/src/components/reputation/ReputationPanel.tsx` — responsive composite layout (1-col mobile / 2-col md+): score card, leaderboard rank teaser with link, history chart, breakdown + tier progress side-by-side, recent events feed with per-row hover tooltips ("Completed T2 bounty · +100 REP · Mar 15 2024")
- `frontend/src/pages/ReputationPage.tsx` — lazy-loaded route target with breadcrumb (`Leaderboard / username / Reputation`)

**Modified files:**

- `frontend/src/App.tsx` — added lazy `ReputationPage` import and `/reputation/:username` route
- `frontend/src/components/leaderboard/LeaderboardPage.tsx` — username is now a `<Link>` to `/profile/:username`; added `REP ↗` link per row navigating to `/reputation/:username` for leaderboard rank integration

**Design decisions:**

- No chart library added — the SVG chart is ~120 lines of pure React/SVG and covers all required interactions (hover tooltip, area fill, grid lines, axis labels)
- Data fallback is deterministic (no `Math.random()`), so SSR and snapshot tests would produce stable output
- All components accept a `loading` prop and render fully-formed skeletons using the existing `Skeleton` primitives — no layout shift on load
- `require_wallet_auth` dependency is not used here (read-only public data); no auth gating needed on the reputation page
