### PR TITLE
feat: Implement multi-llm review dashboard

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ const ProfilePage = React.lazy(() => import('./pages/ProfilePage').then((m) => (
 const GitHubCallbackPage = React.lazy(() => import('./pages/GitHubCallbackPage').then((m) => ({ default: m.GitHubCallbackPage })));
 const BountiesPage = React.lazy(() => import('./pages/BountiesPage').then((m) => ({ default: m.BountiesPage })));
 const NotFoundPage = React.lazy(() => import('./pages/NotFoundPage').then((m) => ({ default: m.NotFoundPage })));
+const ReviewDashboardPage = React.lazy(() => import('./pages/ReviewDashboardPage').then((m) => ({ default: m.ReviewDashboardPage })));
 
 function PageLoader() {
   return (
@@ -46,6 +47,7 @@ export default function App() {
         />
         <Route path="/bounties" element={<BountiesPage />} />
         <Route path="/bounties/:id" element={<BountyDetailPage />} />
+        <Route path="/submissions/:submissionId/review" element={<ReviewDashboardPage />} />
         <Route path="/auth/github/callback" element={<GitHubCallbackPage />} />
         <Route path="*" element={<NotFoundPage />} />
       </Routes>

--- a/frontend/src/__tests__/review-scores.test.tsx
+++ b/frontend/src/__tests__/review-scores.test.tsx
@@ -1,0 +1,252 @@
+/**
+ * Tests for the multi-LLM review score dashboard.
+ *
+ * Covers ReviewScorePanel (score visualization, consensus, disagreement),
+ * AppealWorkflow (file + assign), and AppealHistory (resolution tracking).
+ *
+ * @module __tests__/review-scores.test
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import React from 'react';
+
+vi.mock('../hooks/useReviewScores', () => ({
+  useReviewScores: vi.fn(),
+  useAppeal: vi.fn(),
+}));
+
+import { ReviewScorePanel } from '../components/reviews/ReviewScorePanel';
+import { AppealWorkflow } from '../components/reviews/AppealWorkflow';
+import { AppealHistory } from '../components/reviews/AppealHistory';
+import { useReviewScores, useAppeal } from '../hooks/useReviewScores';
+import type { ReviewScore, Appeal } from '../hooks/useReviewScores';
+
+const mockUseReviewScores = useReviewScores as ReturnType<typeof vi.fn>;
+const mockUseAppeal = useAppeal as ReturnType<typeof vi.fn>;
+
+function wrap() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <MemoryRouter>
+        <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+      </MemoryRouter>
+    );
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const SCORES_CONSENSUS: ReviewScore[] = [
+  { reviewer: 'claude',  score: 8.5, reasoning: 'Well-structured solution with good test coverage.', model_id: 'claude-sonnet-4-6',   reviewed_at: '2026-04-04T10:00:00Z' },
+  { reviewer: 'codex',   score: 8.2, reasoning: 'Clean implementation, minor style issues.',         model_id: 'gpt-4o',              reviewed_at: '2026-04-04T10:01:00Z' },
+  { reviewer: 'gemini',  score: 8.7, reasoning: 'Meets all acceptance criteria.',                    model_id: 'gemini-1.5-pro',      reviewed_at: '2026-04-04T10:02:00Z' },
+];
+
+const SCORES_DISAGREEMENT: ReviewScore[] = [
+  { reviewer: 'claude',  score: 9.0, reasoning: 'Excellent solution, exceeds requirements.', model_id: 'claude-sonnet-4-6', reviewed_at: '2026-04-04T10:00:00Z' },
+  { reviewer: 'codex',   score: 4.5, reasoning: 'Missing key functionality.',                model_id: 'gpt-4o',            reviewed_at: '2026-04-04T10:01:00Z' },
+  { reviewer: 'gemini',  score: 8.0, reasoning: 'Mostly complete.',                          model_id: 'gemini-1.5-pro',    reviewed_at: '2026-04-04T10:02:00Z' },
+];
+
+const OPEN_APPEAL: Appeal = {
+  id: 'appeal-001',
+  submission_id: 'sub-001',
+  status: 'pending',
+  reason: 'Scores do not reflect the full solution.',
+  filed_at: '2026-04-04T11:00:00Z',
+  reviewer_id: null,
+  reviewer_name: null,
+  resolution: null,
+  resolved_at: null,
+  history: [],
+};
+
+const ASSIGNED_APPEAL: Appeal = {
+  ...OPEN_APPEAL,
+  id: 'appeal-002',
+  status: 'assigned',
+  reviewer_id: 'reviewer-001',
+  reviewer_name: 'Jane Doe',
+  history: [
+    { id: 'ah1', action: 'filed',    actor: 'Contributor', note: 'Appeal filed',         created_at: '2026-04-04T11:00:00Z' },
+    { id: 'ah2', action: 'assigned', actor: 'Admin',       note: 'Assigned to Jane Doe', created_at: '2026-04-04T11:30:00Z' },
+  ],
+};
+
+const RESOLVED_APPEAL: Appeal = {
+  ...ASSIGNED_APPEAL,
+  id: 'appeal-003',
+  status: 'resolved',
+  resolution: 'Score revised upward to 8.5 after human review.',
+  resolved_at: '2026-04-04T14:00:00Z',
+  history: [
+    ...ASSIGNED_APPEAL.history,
+    { id: 'ah3', action: 'resolved', actor: 'Jane Doe', note: 'Revised score accepted', created_at: '2026-04-04T14:00:00Z' },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// ReviewScorePanel
+// ---------------------------------------------------------------------------
+
+describe('ReviewScorePanel', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders heading and all three reviewers', () => {
+    mockUseReviewScores.mockReturnValue({ scores: SCORES_CONSENSUS, isLoading: false, error: null });
+    render(<ReviewScorePanel submissionId="sub-001" />, { wrapper: wrap() });
+    expect(screen.getByText('Review Scores')).toBeDefined();
+    expect(screen.getByText('Claude')).toBeDefined();
+    expect(screen.getByText('Codex')).toBeDefined();
+    expect(screen.getByText('Gemini')).toBeDefined();
+  });
+
+  it('shows score for each reviewer', () => {
+    mockUseReviewScores.mockReturnValue({ scores: SCORES_CONSENSUS, isLoading: false, error: null });
+    render(<ReviewScorePanel submissionId="sub-001" />, { wrapper: wrap() });
+    expect(screen.getByTestId('score-claude')).toHaveTextContent('8.5');
+    expect(screen.getByTestId('score-codex')).toHaveTextContent('8.2');
+    expect(screen.getByTestId('score-gemini')).toHaveTextContent('8.7');
+  });
+
+  it('shows reasoning for each reviewer', () => {
+    mockUseReviewScores.mockReturnValue({ scores: SCORES_CONSENSUS, isLoading: false, error: null });
+    render(<ReviewScorePanel submissionId="sub-001" />, { wrapper: wrap() });
+    expect(screen.getByText('Well-structured solution with good test coverage.')).toBeDefined();
+    expect(screen.getByText('Clean implementation, minor style issues.')).toBeDefined();
+  });
+
+  it('shows consensus indicator when scores agree (spread ≤ 1.5)', () => {
+    mockUseReviewScores.mockReturnValue({ scores: SCORES_CONSENSUS, isLoading: false, error: null });
+    render(<ReviewScorePanel submissionId="sub-001" />, { wrapper: wrap() });
+    expect(screen.getByTestId('consensus-indicator')).toHaveTextContent(/consensus/i);
+  });
+
+  it('shows disagreement indicator when scores diverge (spread > 1.5)', () => {
+    mockUseReviewScores.mockReturnValue({ scores: SCORES_DISAGREEMENT, isLoading: false, error: null });
+    render(<ReviewScorePanel submissionId="sub-001" />, { wrapper: wrap() });
+    expect(screen.getByTestId('consensus-indicator')).toHaveTextContent(/disagreement/i);
+  });
+
+  it('shows average score', () => {
+    mockUseReviewScores.mockReturnValue({ scores: SCORES_CONSENSUS, isLoading: false, error: null });
+    render(<ReviewScorePanel submissionId="sub-001" />, { wrapper: wrap() });
+    // avg of 8.5, 8.2, 8.7 = 8.47
+    expect(screen.getByTestId('average-score')).toBeDefined();
+  });
+
+  it('shows model ID for each reviewer', () => {
+    mockUseReviewScores.mockReturnValue({ scores: SCORES_CONSENSUS, isLoading: false, error: null });
+    render(<ReviewScorePanel submissionId="sub-001" />, { wrapper: wrap() });
+    expect(screen.getByText('claude-sonnet-4-6')).toBeDefined();
+    expect(screen.getByText('gpt-4o')).toBeDefined();
+  });
+
+  it('shows loading skeleton when loading', () => {
+    mockUseReviewScores.mockReturnValue({ scores: [], isLoading: true, error: null });
+    const { container } = render(<ReviewScorePanel submissionId="sub-001" />, { wrapper: wrap() });
+    expect(container.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0);
+  });
+
+  it('shows error state', () => {
+    mockUseReviewScores.mockReturnValue({ scores: [], isLoading: false, error: new Error('Failed') });
+    render(<ReviewScorePanel submissionId="sub-001" />, { wrapper: wrap() });
+    expect(screen.getByRole('alert')).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AppealWorkflow
+// ---------------------------------------------------------------------------
+
+describe('AppealWorkflow', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders File Appeal button when no appeal exists', () => {
+    mockUseAppeal.mockReturnValue({ appeal: null, fileAppeal: vi.fn(), isLoading: false });
+    render(<AppealWorkflow submissionId="sub-001" />, { wrapper: wrap() });
+    expect(screen.getByRole('button', { name: /file appeal/i })).toBeDefined();
+  });
+
+  it('opens appeal form on File Appeal click', async () => {
+    mockUseAppeal.mockReturnValue({ appeal: null, fileAppeal: vi.fn(), isLoading: false });
+    const u = userEvent.setup();
+    render(<AppealWorkflow submissionId="sub-001" />, { wrapper: wrap() });
+    await u.click(screen.getByRole('button', { name: /file appeal/i }));
+    expect(screen.getByTestId('appeal-form')).toBeDefined();
+  });
+
+  it('submit is disabled until reason is entered', async () => {
+    mockUseAppeal.mockReturnValue({ appeal: null, fileAppeal: vi.fn(), isLoading: false });
+    const u = userEvent.setup();
+    render(<AppealWorkflow submissionId="sub-001" />, { wrapper: wrap() });
+    await u.click(screen.getByRole('button', { name: /file appeal/i }));
+    expect(screen.getByTestId('submit-appeal')).toBeDisabled();
+  });
+
+  it('calls fileAppeal with reason when submitted', async () => {
+    const fileAppeal = vi.fn();
+    mockUseAppeal.mockReturnValue({ appeal: null, fileAppeal, isLoading: false });
+    const u = userEvent.setup();
+    render(<AppealWorkflow submissionId="sub-001" />, { wrapper: wrap() });
+    await u.click(screen.getByRole('button', { name: /file appeal/i }));
+    await u.type(screen.getByTestId('appeal-reason-input'), 'Scores are incorrect');
+    await u.click(screen.getByTestId('submit-appeal'));
+    expect(fileAppeal).toHaveBeenCalledWith({ reason: 'Scores are incorrect' });
+  });
+
+  it('shows pending status badge when appeal is pending', () => {
+    mockUseAppeal.mockReturnValue({ appeal: OPEN_APPEAL, fileAppeal: vi.fn(), isLoading: false });
+    render(<AppealWorkflow submissionId="sub-001" />, { wrapper: wrap() });
+    expect(screen.getByTestId('appeal-status')).toHaveTextContent(/pending/i);
+  });
+
+  it('shows assigned reviewer name when appeal is assigned', () => {
+    mockUseAppeal.mockReturnValue({ appeal: ASSIGNED_APPEAL, fileAppeal: vi.fn(), isLoading: false });
+    render(<AppealWorkflow submissionId="sub-001" />, { wrapper: wrap() });
+    expect(screen.getByTestId('assigned-reviewer')).toHaveTextContent('Jane Doe');
+  });
+
+  it('shows resolution when appeal is resolved', () => {
+    mockUseAppeal.mockReturnValue({ appeal: RESOLVED_APPEAL, fileAppeal: vi.fn(), isLoading: false });
+    render(<AppealWorkflow submissionId="sub-001" />, { wrapper: wrap() });
+    expect(screen.getByTestId('appeal-resolution')).toHaveTextContent('Score revised upward');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AppealHistory
+// ---------------------------------------------------------------------------
+
+describe('AppealHistory', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('shows empty state when no history', () => {
+    render(<AppealHistory history={[]} />, { wrapper: wrap() });
+    expect(screen.getByText('No appeal history yet.')).toBeDefined();
+  });
+
+  it('renders all history entries', () => {
+    render(<AppealHistory history={ASSIGNED_APPEAL.history} />, { wrapper: wrap() });
+    expect(screen.getByTestId('appeal-history-entry-ah1')).toBeDefined();
+    expect(screen.getByTestId('appeal-history-entry-ah2')).toBeDefined();
+  });
+
+  it('shows actor and note for each entry', () => {
+    render(<AppealHistory history={ASSIGNED_APPEAL.history} />, { wrapper: wrap() });
+    expect(screen.getByText('Appeal filed')).toBeDefined();
+    expect(screen.getByText('Assigned to Jane Doe')).toBeDefined();
+  });
+
+  it('highlights resolved entry', () => {
+    render(<AppealHistory history={RESOLVED_APPEAL.history} />, { wrapper: wrap() });
+    expect(screen.getByTestId('appeal-history-entry-ah3')).toBeDefined();
+    expect(screen.getByText('Revised score accepted')).toBeDefined();
+  });
+});

--- a/frontend/src/components/disputes/DisputeCard.tsx
+++ b/frontend/src/components/disputes/DisputeCard.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import type { DisputeListItem } from '../../types/dispute';
+
+// ---------------------------------------------------------------------------
+// Formatters
+// ---------------------------------------------------------------------------
+
+function formatReason(reason: string): string {
+  return reason
+    .split('_')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
+function formatOutcome(outcome: string): string {
+  const MAP: Record<string, string> = {
+    release_to_contributor: 'Released to Contributor',
+    return_to_poster: 'Returned to Poster',
+    partial_release: 'Partial Release',
+    dismissed: 'Dismissed',
+  };
+  return MAP[outcome] ?? formatReason(outcome);
+}
+
+const STATUS_STYLES: Record<string, string> = {
+  opened:    'bg-yellow-500/20 text-yellow-400',
+  evidence:  'bg-blue-500/20 text-blue-400',
+  mediation: 'bg-purple-500/20 text-purple-400',
+  resolved:  'bg-[#14F195]/20 text-[#14F195]',
+  closed:    'bg-white/10 text-white/40',
+};
+
+function fmtDate(iso: string) {
+  return new Date(iso).toLocaleDateString('en-US', {
+    month: 'short', day: 'numeric', year: 'numeric',
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+interface Props {
+  dispute: DisputeListItem;
+}
+
+export function DisputeCard({ dispute }: Props) {
+  const statusLabel = dispute.status.charAt(0).toUpperCase() + dispute.status.slice(1);
+
+  return (
+    <Link
+      data-testid={`dispute-card-${dispute.id}`}
+      to={`/disputes/${dispute.id}`}
+      href={`/disputes/${dispute.id}`}
+      className="block bg-[#0d0d1a] border border-white/10 rounded-xl p-4 hover:border-white/20 transition-colors"
+    >
+      {/* Header */}
+      <div className="flex items-start justify-between gap-3 mb-3">
+        <span
+          data-testid="dispute-status-badge"
+          className={`text-xs font-medium px-2 py-0.5 rounded-full ${STATUS_STYLES[dispute.status] ?? 'bg-white/10 text-white/50'}`}
+        >
+          {statusLabel}
+        </span>
+        <span className="text-xs text-white/30">{fmtDate(dispute.created_at)}</span>
+      </div>
+
+      {/* Reason */}
+      <p className="text-sm font-semibold text-white mb-1">{formatReason(dispute.reason)}</p>
+
+      {/* Bounty ID */}
+      <p className="text-xs text-white/40 font-mono truncate mb-2">{dispute.bounty_id}</p>
+
+      {/* Meta */}
+      <p className="text-xs text-white/40">Filed: {fmtDate(dispute.created_at)}</p>
+
+      {/* Outcome */}
+      {dispute.outcome && (
+        <p className="text-xs text-[#14F195] mt-2 font-medium">{formatOutcome(dispute.outcome)}</p>
+      )}
+    </Link>
+  );
+}

--- a/frontend/src/components/disputes/DisputeEvidenceForm.tsx
+++ b/frontend/src/components/disputes/DisputeEvidenceForm.tsx
@@ -1,0 +1,121 @@
+import React, { useState } from 'react';
+import type { EvidenceSubmission } from '../../types/dispute';
+
+interface EvidenceItem {
+  evidence_type: string;
+  url: string;
+  description: string;
+}
+
+const BLANK_ITEM: EvidenceItem = { evidence_type: 'link', url: '', description: '' };
+
+interface Props {
+  onSubmit: (payload: EvidenceSubmission) => Promise<void> | void;
+  loading: boolean;
+}
+
+export function DisputeEvidenceForm({ onSubmit, loading }: Props) {
+  const [items, setItems] = useState<EvidenceItem[]>([{ ...BLANK_ITEM }]);
+  const [error, setError] = useState<string | null>(null);
+
+  function updateItem(index: number, field: keyof EvidenceItem, value: string) {
+    setItems((prev) => prev.map((item, i) => (i === index ? { ...item, [field]: value } : item)));
+  }
+
+  function addItem() {
+    setItems((prev) => [...prev, { ...BLANK_ITEM }]);
+  }
+
+  function removeItem(index: number) {
+    setItems((prev) => prev.filter((_, i) => i !== index));
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+
+    const hasDescription = items.some((item) => item.description.trim().length > 0);
+    if (!hasDescription) {
+      setError('Please provide at least one evidence item with a description.');
+      return;
+    }
+
+    await onSubmit({ evidence_links: items });
+  }
+
+  return (
+    <form data-testid="evidence-form" onSubmit={handleSubmit} className="space-y-4">
+      {error && (
+        <div role="alert" className="bg-red-500/10 border border-red-500/20 rounded-lg p-3 text-red-400 text-sm">
+          {error}
+        </div>
+      )}
+
+      {items.map((item, index) => (
+        <div
+          key={index}
+          data-testid={`evidence-item-${index}`}
+          className="bg-white/5 border border-white/10 rounded-xl p-4 space-y-3"
+        >
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-white/50 font-medium">Evidence #{index + 1}</span>
+            {items.length > 1 && (
+              <button
+                type="button"
+                onClick={() => removeItem(index)}
+                className="text-xs text-red-400 hover:text-red-300"
+              >
+                Remove
+              </button>
+            )}
+          </div>
+
+          <select
+            value={item.evidence_type}
+            onChange={(e) => updateItem(index, 'evidence_type', e.target.value)}
+            className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-white text-sm focus:outline-none"
+          >
+            <option value="link">Link</option>
+            <option value="screenshot">Screenshot</option>
+            <option value="code">Code Snippet</option>
+            <option value="other">Other</option>
+          </select>
+
+          <input
+            type="url"
+            value={item.url}
+            onChange={(e) => updateItem(index, 'url', e.target.value)}
+            placeholder="https://..."
+            className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-white text-sm focus:outline-none"
+          />
+
+          <textarea
+            value={item.description}
+            onChange={(e) => updateItem(index, 'description', e.target.value)}
+            placeholder="Describe this evidence..."
+            rows={3}
+            className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-white text-sm focus:outline-none resize-none"
+          />
+        </div>
+      ))}
+
+      <button
+        type="button"
+        onClick={addItem}
+        className="text-sm text-[#14F195] hover:underline"
+      >
+        + Add Another Evidence Item
+      </button>
+
+      <div>
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full py-2.5 bg-[#14F195] text-black font-semibold rounded-xl text-sm disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          {loading ? 'Submitting...' : 'Submit Evidence'}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/components/disputes/DisputeTimeline.tsx
+++ b/frontend/src/components/disputes/DisputeTimeline.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import type { DisputeHistoryItem } from '../../types/dispute';
+
+function formatAction(action: string): string {
+  return action
+    .split('_')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
+function fmtDate(iso: string) {
+  return new Date(iso).toLocaleString('en-US', {
+    month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
+  });
+}
+
+const ACTION_COLORS: Record<string, string> = {
+  dispute_opened:      'bg-yellow-500',
+  evidence_submitted:  'bg-blue-500',
+  moved_to_mediation:  'bg-purple-500',
+  resolved:            'bg-[#14F195]',
+  closed:              'bg-white/20',
+};
+
+interface Props {
+  history: DisputeHistoryItem[];
+}
+
+export function DisputeTimeline({ history }: Props) {
+  if (history.length === 0) {
+    return <p className="text-sm text-white/40 text-center py-6">No history entries yet.</p>;
+  }
+
+  return (
+    <ol data-testid="dispute-timeline" className="relative border-l border-white/10 space-y-6 pl-6">
+      {history.map((entry) => (
+        <li
+          key={entry.id}
+          data-testid={`timeline-entry-${entry.action}`}
+          className="relative"
+        >
+          {/* Dot */}
+          <span
+            className={`absolute -left-[1.625rem] top-1 w-3 h-3 rounded-full ${
+              ACTION_COLORS[entry.action] ?? 'bg-white/20'
+            }`}
+          />
+
+          {/* Content */}
+          <div>
+            <div className="flex items-center gap-2 mb-0.5">
+              <p className="text-sm font-semibold text-white">{formatAction(entry.action)}</p>
+              <span className="text-xs text-white/30">{fmtDate(entry.created_at)}</span>
+            </div>
+
+            {/* Status transition */}
+            {entry.previous_status && (
+              <p className="text-xs text-white/40 mb-1">
+                <span className="text-white/30">{entry.previous_status}</span>
+                {' → '}
+                <span className="text-white/70">{entry.new_status}</span>
+              </p>
+            )}
+            {!entry.previous_status && (
+              <p className="text-xs text-white/40 mb-1">{entry.new_status}</p>
+            )}
+
+            {entry.notes && (
+              <p className="text-xs text-white/50">{entry.notes}</p>
+            )}
+          </div>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/frontend/src/components/reviews/AppealHistory.tsx
+++ b/frontend/src/components/reviews/AppealHistory.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import type { AppealHistoryEntry } from '../../hooks/useReviewScores';
+
+const ACTION_COLORS: Record<string, string> = {
+  filed:    'bg-yellow-500',
+  assigned: 'bg-blue-500',
+  reviewing:'bg-purple-500',
+  resolved: 'bg-[#14F195]',
+  dismissed:'bg-white/20',
+};
+
+function fmtDate(iso: string) {
+  return new Date(iso).toLocaleString('en-US', {
+    month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
+  });
+}
+
+interface Props {
+  history: AppealHistoryEntry[];
+}
+
+export function AppealHistory({ history }: Props) {
+  if (!history.length) {
+    return <p className="text-sm text-white/40 text-center py-4">No appeal history yet.</p>;
+  }
+
+  return (
+    <ol className="relative border-l border-white/10 space-y-5 pl-6">
+      {history.map((entry) => (
+        <li
+          key={entry.id}
+          data-testid={`appeal-history-entry-${entry.id}`}
+          className="relative"
+        >
+          <span
+            className={`absolute -left-[1.625rem] top-1 w-3 h-3 rounded-full ${
+              ACTION_COLORS[entry.action] ?? 'bg-white/20'
+            }`}
+          />
+          <div>
+            <div className="flex items-center gap-2 mb-0.5">
+              <p className="text-xs font-semibold text-white capitalize">{entry.action}</p>
+              <span className="text-xs text-white/30">{fmtDate(entry.created_at)}</span>
+            </div>
+            <p className="text-xs text-white/50">{entry.actor}</p>
+            {entry.note && (
+              <p className="text-xs text-white/70 mt-0.5">{entry.note}</p>
+            )}
+          </div>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/frontend/src/components/reviews/AppealWorkflow.tsx
+++ b/frontend/src/components/reviews/AppealWorkflow.tsx
@@ -1,0 +1,120 @@
+/**
+ * AppealWorkflow — file, track, and resolve score appeals.
+ */
+import React, { useState } from 'react';
+import { useAppeal } from '../../hooks/useReviewScores';
+
+const STATUS_STYLES: Record<string, string> = {
+  pending:    'bg-yellow-500/20 text-yellow-400',
+  assigned:   'bg-blue-500/20 text-blue-400',
+  reviewing:  'bg-purple-500/20 text-purple-400',
+  resolved:   'bg-[#14F195]/20 text-[#14F195]',
+  dismissed:  'bg-white/10 text-white/40',
+};
+
+interface Props {
+  submissionId: string;
+}
+
+export function AppealWorkflow({ submissionId }: Props) {
+  const { appeal, fileAppeal, isLoading } = useAppeal(submissionId);
+  const [formOpen, setFormOpen] = useState(false);
+  const [reason, setReason] = useState('');
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!reason.trim()) return;
+    fileAppeal({ reason: reason.trim() });
+    setFormOpen(false);
+    setReason('');
+  }
+
+  // ── No appeal yet ──────────────────────────────────────────────────────────
+  if (!appeal) {
+    return (
+      <div className="bg-[#0d0d1a] border border-white/10 rounded-xl p-5">
+        <h3 className="text-sm font-semibold text-white mb-1">Appeal Scores</h3>
+        <p className="text-xs text-white/50 mb-4">
+          Dispute the AI-generated scores and request a human review.
+        </p>
+
+        {!formOpen ? (
+          <button
+            onClick={() => setFormOpen(true)}
+            className="px-4 py-2 bg-yellow-500/20 text-yellow-400 border border-yellow-500/30 rounded-lg text-sm font-medium hover:bg-yellow-500/30"
+          >
+            File Appeal
+          </button>
+        ) : (
+          <form data-testid="appeal-form" onSubmit={handleSubmit} className="space-y-3">
+            <textarea
+              data-testid="appeal-reason-input"
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              placeholder="Explain why you are appealing these scores…"
+              rows={4}
+              className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-white text-sm focus:outline-none resize-none"
+            />
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => { setFormOpen(false); setReason(''); }}
+                className="flex-1 py-2 border border-white/10 rounded-lg text-white/50 text-sm hover:bg-white/5"
+              >
+                Cancel
+              </button>
+              <button
+                data-testid="submit-appeal"
+                type="submit"
+                disabled={!reason.trim() || isLoading}
+                className="flex-1 py-2 bg-yellow-500 text-black font-semibold rounded-lg text-sm disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                {isLoading ? 'Submitting…' : 'Submit Appeal'}
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
+    );
+  }
+
+  // ── Existing appeal ────────────────────────────────────────────────────────
+  return (
+    <div className="bg-[#0d0d1a] border border-white/10 rounded-xl p-5 space-y-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-semibold text-white mb-1">Appeal</h3>
+          <p className="text-xs text-white/50 leading-relaxed">{appeal.reason}</p>
+        </div>
+        <span
+          data-testid="appeal-status"
+          className={`shrink-0 text-xs px-2.5 py-1 rounded-full font-medium capitalize ${
+            STATUS_STYLES[appeal.status] ?? 'bg-white/10 text-white/50'
+          }`}
+        >
+          {appeal.status}
+        </span>
+      </div>
+
+      {/* Assigned reviewer */}
+      {appeal.reviewer_name && (
+        <div className="flex items-center gap-2 text-sm">
+          <span className="text-white/40">Assigned to:</span>
+          <span data-testid="assigned-reviewer" className="text-white font-medium">
+            {appeal.reviewer_name}
+          </span>
+        </div>
+      )}
+
+      {/* Resolution */}
+      {appeal.resolution && (
+        <div
+          data-testid="appeal-resolution"
+          className="bg-[#14F195]/10 border border-[#14F195]/20 rounded-lg p-3 text-sm text-white/80 leading-relaxed"
+        >
+          {appeal.resolution}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/reviews/ReviewScorePanel.tsx
+++ b/frontend/src/components/reviews/ReviewScorePanel.tsx
@@ -1,0 +1,142 @@
+/**
+ * ReviewScorePanel — visualises multi-LLM review scores with consensus indicator.
+ */
+import React from 'react';
+import { useReviewScores } from '../../hooks/useReviewScores';
+import type { ReviewScore } from '../../hooks/useReviewScores';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const REVIEWER_META: Record<string, { label: string; color: string; bg: string }> = {
+  claude: { label: 'Claude',  color: '#14F195', bg: 'bg-[#14F195]/10 border-[#14F195]/20' },
+  codex:  { label: 'Codex',   color: '#60a5fa', bg: 'bg-blue-500/10 border-blue-500/20' },
+  gemini: { label: 'Gemini',  color: '#f59e0b', bg: 'bg-yellow-500/10 border-yellow-500/20' },
+};
+
+function scoreColor(score: number): string {
+  if (score >= 8) return 'text-[#14F195]';
+  if (score >= 6) return 'text-yellow-400';
+  return 'text-red-400';
+}
+
+function consensus(scores: ReviewScore[]): { isConsensus: boolean; spread: number; avg: number } {
+  if (!scores.length) return { isConsensus: true, spread: 0, avg: 0 };
+  const vals = scores.map((s) => s.score);
+  const avg = vals.reduce((a, b) => a + b, 0) / vals.length;
+  const spread = Math.max(...vals) - Math.min(...vals);
+  return { isConsensus: spread <= 1.5, spread, avg };
+}
+
+// ---------------------------------------------------------------------------
+// ScoreCard
+// ---------------------------------------------------------------------------
+
+function ScoreCard({ score }: { score: ReviewScore }) {
+  const meta = REVIEWER_META[score.reviewer] ?? { label: score.reviewer, color: '#ffffff', bg: 'bg-white/5 border-white/10' };
+
+  return (
+    <div className={`border rounded-xl p-4 ${meta.bg}`}>
+      <div className="flex items-center justify-between mb-3">
+        <div>
+          <p className="text-sm font-semibold text-white">{meta.label}</p>
+          <p className="text-xs text-white/40 font-mono mt-0.5">{score.model_id}</p>
+        </div>
+        <span
+          data-testid={`score-${score.reviewer}`}
+          className={`text-2xl font-bold ${scoreColor(score.score)}`}
+        >
+          {score.score}
+        </span>
+      </div>
+
+      {/* Score bar */}
+      <div className="w-full h-1.5 bg-white/10 rounded-full overflow-hidden mb-3">
+        <div
+          className="h-full rounded-full transition-all"
+          style={{ width: `${score.score * 10}%`, backgroundColor: meta.color }}
+        />
+      </div>
+
+      {/* Reasoning */}
+      <p className="text-xs text-white/60 leading-relaxed">{score.reasoning}</p>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ReviewScorePanel
+// ---------------------------------------------------------------------------
+
+interface Props {
+  submissionId: string;
+}
+
+export function ReviewScorePanel({ submissionId }: Props) {
+  const { scores, isLoading, error } = useReviewScores(submissionId);
+  const { isConsensus, spread, avg } = consensus(scores);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <div className="animate-pulse bg-white/5 rounded-xl h-6 w-40" />
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          {[0, 1, 2].map((i) => (
+            <div key={i} className="animate-pulse bg-white/5 rounded-xl h-36" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div role="alert" className="bg-red-500/10 border border-red-500/20 rounded-xl p-4 text-red-400 text-sm">
+        {error.message}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h2 className="text-lg font-semibold text-white">Review Scores</h2>
+
+        <div className="flex items-center gap-3">
+          {/* Average */}
+          {scores.length > 0 && (
+            <span
+              data-testid="average-score"
+              className={`text-sm font-bold ${scoreColor(avg)}`}
+            >
+              Avg {avg.toFixed(2)}
+            </span>
+          )}
+
+          {/* Consensus indicator */}
+          {scores.length > 0 && (
+            <span
+              data-testid="consensus-indicator"
+              className={`text-xs px-2.5 py-1 rounded-full font-medium ${
+                isConsensus
+                  ? 'bg-[#14F195]/20 text-[#14F195]'
+                  : 'bg-red-500/20 text-red-400'
+              }`}
+            >
+              {isConsensus ? 'Consensus' : `Disagreement (Δ${spread.toFixed(1)})`}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Score cards */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        {scores.map((s) => (
+          <ScoreCard key={s.reviewer} score={s} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useReviewScores.ts
+++ b/frontend/src/hooks/useReviewScores.ts
@@ -1,0 +1,98 @@
+/**
+ * useReviewScores / useAppeal — hooks for the multi-LLM review dashboard.
+ */
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+// ---------------------------------------------------------------------------
+// Types (exported for tests + components)
+// ---------------------------------------------------------------------------
+
+export interface ReviewScore {
+  reviewer: string;           // 'claude' | 'codex' | 'gemini'
+  score: number;              // 0–10
+  reasoning: string;
+  model_id: string;
+  reviewed_at: string;
+}
+
+export interface AppealHistoryEntry {
+  id: string;
+  action: string;
+  actor: string;
+  note: string;
+  created_at: string;
+}
+
+export interface Appeal {
+  id: string;
+  submission_id: string;
+  status: 'pending' | 'assigned' | 'reviewing' | 'resolved' | 'dismissed';
+  reason: string;
+  filed_at: string;
+  reviewer_id: string | null;
+  reviewer_name: string | null;
+  resolution: string | null;
+  resolved_at: string | null;
+  history: AppealHistoryEntry[];
+}
+
+// ---------------------------------------------------------------------------
+// useReviewScores
+// ---------------------------------------------------------------------------
+
+async function fetchReviewScores(submissionId: string): Promise<ReviewScore[]> {
+  const res = await fetch(`/api/submissions/${submissionId}/review-scores`);
+  if (!res.ok) throw new Error('Failed to load review scores');
+  return res.json();
+}
+
+export function useReviewScores(submissionId: string) {
+  const { data, isLoading, error } = useQuery<ReviewScore[], Error>({
+    queryKey: ['review-scores', submissionId],
+    queryFn: () => fetchReviewScores(submissionId),
+    staleTime: 60_000,
+  });
+  return { scores: data ?? [], isLoading, error: error ?? null };
+}
+
+// ---------------------------------------------------------------------------
+// useAppeal
+// ---------------------------------------------------------------------------
+
+async function fetchAppeal(submissionId: string): Promise<Appeal | null> {
+  const res = await fetch(`/api/submissions/${submissionId}/appeal`);
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error('Failed to load appeal');
+  return res.json();
+}
+
+async function postAppeal(submissionId: string, payload: { reason: string }): Promise<Appeal> {
+  const res = await fetch(`/api/submissions/${submissionId}/appeal`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) throw new Error('Failed to file appeal');
+  return res.json();
+}
+
+export function useAppeal(submissionId: string) {
+  const qc = useQueryClient();
+
+  const { data: appeal, isLoading } = useQuery<Appeal | null, Error>({
+    queryKey: ['appeal', submissionId],
+    queryFn: () => fetchAppeal(submissionId),
+    staleTime: 30_000,
+  });
+
+  const mutation = useMutation({
+    mutationFn: (payload: { reason: string }) => postAppeal(submissionId, payload),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['appeal', submissionId] }),
+  });
+
+  return {
+    appeal: appeal ?? null,
+    fileAppeal: mutation.mutate,
+    isLoading: isLoading || mutation.isPending,
+  };
+}

--- a/frontend/src/pages/ReviewDashboardPage.tsx
+++ b/frontend/src/pages/ReviewDashboardPage.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { ReviewScorePanel } from '../components/reviews/ReviewScorePanel';
+import { AppealWorkflow } from '../components/reviews/AppealWorkflow';
+import { AppealHistory } from '../components/reviews/AppealHistory';
+import { useAppeal } from '../hooks/useReviewScores';
+
+function ReviewDashboard({ submissionId }: { submissionId: string }) {
+  const { appeal } = useAppeal(submissionId);
+
+  return (
+    <div className="min-h-screen bg-[#0a0a14] text-white px-6 py-16 max-w-4xl mx-auto space-y-8">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <Link to="/bounties" className="text-white/40 hover:text-white text-sm">← Bounties</Link>
+        <span className="text-white/20">/</span>
+        <span className="text-white/60 text-sm font-mono truncate">{submissionId}</span>
+      </div>
+
+      <div>
+        <h1 className="text-2xl font-bold mb-1">Review Dashboard</h1>
+        <p className="text-white/50 text-sm">
+          Multi-LLM review scores with consensus analysis and appeal workflow.
+        </p>
+      </div>
+
+      {/* Scores */}
+      <ReviewScorePanel submissionId={submissionId} />
+
+      {/* Appeal */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <AppealWorkflow submissionId={submissionId} />
+
+        {appeal && appeal.history.length > 0 && (
+          <div className="bg-[#0d0d1a] border border-white/10 rounded-xl p-5">
+            <h3 className="text-sm font-semibold text-white/70 mb-4">Appeal History</h3>
+            <AppealHistory history={appeal.history} />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function ReviewDashboardPage() {
+  const { submissionId } = useParams<{ submissionId: string }>();
+  if (!submissionId) return null;
+  return <ReviewDashboard submissionId={submissionId} />;
+}

--- a/frontend/src/types/dispute.ts
+++ b/frontend/src/types/dispute.ts
@@ -1,0 +1,31 @@
+export interface DisputeListItem {
+  id: string;
+  bounty_id: string;
+  contributor_id: string;
+  reason: string;
+  status: 'opened' | 'evidence' | 'mediation' | 'resolved' | 'closed';
+  outcome?: 'release_to_contributor' | 'return_to_poster' | 'partial_release' | 'dismissed';
+  created_at: string;
+  resolved_at?: string;
+}
+
+export interface DisputeHistoryItem {
+  id: string;
+  dispute_id: string;
+  action: string;
+  previous_status?: string;
+  new_status: string;
+  actor_id: string;
+  notes?: string;
+  created_at: string;
+}
+
+export interface EvidenceLink {
+  evidence_type: string;
+  url: string;
+  description: string;
+}
+
+export interface EvidenceSubmission {
+  evidence_links: EvidenceLink[];
+}


### PR DESCRIPTION

## Description

Closes #858 

Builds a multi-LLM review score dashboard at `/submissions/:submissionId/review` showing scores from Claude, Codex, and Gemini with reasoning, a consensus/disagreement indicator, and a full appeal workflow with human reviewer assignment and resolution tracking. Also implements the dispute resolution components required by the existing test suite.

## Solana Wallet for Payout
**Wallet:** 4QhseKvBuaCQhdkP248iXoUxohPzVC5m8pE9hAv4nMYw

## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement
- [x] ✅ Test addition/update

## Checklist
- [x] Code is clean and follows the issue spec exactly
- [x] One PR per bounty (no multiple bounties in one PR)
- [x] Tests included for new functionality
- [x] All existing tests pass
- [x] No `console.log` or debugging code left behind
- [x] No hardcoded secrets or API keys


## Additional Notes
New files (frontend only):
- `src/types/dispute.ts` — `DisputeListItem`, `DisputeHistoryItem`, `EvidenceLink`, `EvidenceSubmission`
- `src/components/disputes/DisputeCard.tsx` — status badge, reason/outcome formatting, Link with `href`
- `src/components/disputes/DisputeTimeline.tsx` — timeline with `data-testid` per action
- `src/components/disputes/DisputeEvidenceForm.tsx` — dynamic evidence items, validation, submission
- `src/hooks/useReviewScores.ts` — `useReviewScores` (React Query), `useAppeal` (query + mutation), exported types
- `src/components/reviews/ReviewScorePanel.tsx` — 3-column score cards, consensus spread logic, average
- `src/components/reviews/AppealWorkflow.tsx` — file form, status display, reviewer assignment, resolution
- `src/components/reviews/AppealHistory.tsx` — timeline of appeal actions
- `src/pages/ReviewDashboardPage.tsx` — page wrapper using `useParams`
- `src/App.tsx` — `/submissions/:submissionId/review` route added

