### PR TITLE
feat: wire activity feed to real API data (Bounty #822)

### DIFF
--- a/frontend/src/api/activity.ts
+++ b/frontend/src/api/activity.ts
@@ -1,0 +1,15 @@
+import { apiClient } from '../services/apiClient';
+
+export interface ActivityEvent {
+  id: string;
+  type: 'completed' | 'submitted' | 'posted' | 'review';
+  username: string;
+  avatar_url?: string | null;
+  detail: string;
+  timestamp: string;
+}
+
+export async function listActivity(limit?: number): Promise<ActivityEvent[]> {
+  const params = limit ? { limit } : {};
+  return apiClient.get<ActivityEvent[]>('/activity', { params });
+}

--- a/frontend/src/hooks/useActivity.ts
+++ b/frontend/src/hooks/useActivity.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+import { listActivity } from '../api/activity';
+import type { ActivityEvent } from '../api/activity';
+
+export function useActivity() {
+  return useQuery<ActivityEvent[]>({
+    queryKey: ['activity'],
+    queryFn: () => listActivity(10),
+    refetchInterval: 30_000,
+    staleTime: 30_000,
+    retry: 1,
+  });
+}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -5,12 +5,15 @@ import { ActivityFeed } from '../components/home/ActivityFeed';
 import { HowItWorksCondensed } from '../components/home/HowItWorksCondensed';
 import { FeaturedBounties } from '../components/home/FeaturedBounties';
 import { WhySolFoundry } from '../components/home/WhySolFoundry';
+import { useActivity } from '../hooks/useActivity';
 
 export function HomePage() {
+  const { data: activityEvents } = useActivity();
+
   return (
     <PageLayout noFooter={false}>
       <HeroSection />
-      <ActivityFeed />
+      <ActivityFeed events={activityEvents} />
       <HowItWorksCondensed />
       <FeaturedBounties />
       <WhySolFoundry />


### PR DESCRIPTION
## Summary

Wires the Activity Feed component to real API data. Addresses **Bounty #822**.

---

## Changes

### ` (new)
- ` 鈥?fetches activity events from backend
- Type-safe ` interface

### ` (new)
- React Query hook with 30-second auto-refresh
- Graceful retry policy (retry: 1) for resilience
- Reuses existing TanStack Query patterns

### ` (modified)
- Imports ` hook
- Passes real activity data to ` component
- Falls back to mock data when API unavailable (existing component behavior)

---

## Acceptance Criteria

- [x] Activity feed shows real events from the API
- [x] Events update without page refresh (30s polling)
- [x] Shows mock data when API unavailable (graceful fallback)

---

## Testing

1. Start frontend dev server
2. Navigate to home page
3. Activity feed should display events from ` endpoint
4. Events refresh every 30 seconds automatically

---

## Related

Bounty #822 鈥?https://github.com/SolFoundry/solfoundry/issues/822