### PR TITLE
feat: add toast notification system (Closes #825)

### DIFF
--- a/frontend/src/__tests__/toast-context.test.tsx
+++ b/frontend/src/__tests__/toast-context.test.tsx
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { ToastProvider, useToast } from '../contexts/ToastContext';
+
+function Demo() {
+  const { pushToast } = useToast();
+
+  return (
+    <div>
+      <button
+        onClick={() =>
+          pushToast({
+            title: 'Saved',
+            description: 'Bounty updated successfully',
+            variant: 'success',
+            durationMs: 100,
+          })
+        }
+      >
+        Trigger success
+      </button>
+      <button
+        onClick={() => {
+          pushToast({ title: 'First', variant: 'info', durationMs: 1000 });
+          pushToast({ title: 'Second', variant: 'warning', durationMs: 1000 });
+        }}
+      >
+        Trigger stack
+      </button>
+    </div>
+  );
+}
+
+describe('ToastProvider', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it('renders a toast with alert role and dismiss control', () => {
+    render(
+      <ToastProvider>
+        <Demo />
+      </ToastProvider>,
+    );
+
+    act(() => {
+      fireEvent.click(screen.getByText('Trigger success'));
+    });
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Saved');
+    expect(screen.getByRole('alert')).toHaveTextContent('Bounty updated successfully');
+    expect(screen.getByLabelText('Dismiss notification')).toBeInTheDocument();
+  });
+
+  it('stacks multiple toasts', () => {
+    render(
+      <ToastProvider>
+        <Demo />
+      </ToastProvider>,
+    );
+
+    act(() => {
+      fireEvent.click(screen.getByText('Trigger stack'));
+    });
+
+    expect(screen.getAllByRole('alert')).toHaveLength(2);
+    expect(screen.getByText('First')).toBeInTheDocument();
+    expect(screen.getByText('Second')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/bounty/BountyCreateWizard.tsx
+++ b/frontend/src/components/bounty/BountyCreateWizard.tsx
@@ -5,6 +5,7 @@ import { Check, ChevronRight, Loader2, Copy } from 'lucide-react';
 import type { BountyCreatePayload } from '../../types/bounty';
 import { createBounty, getTreasuryDepositInfo, verifyEscrowDeposit } from '../../api/bounties';
 import { pageTransition } from '../../lib/animations';
+import { useToast } from '../../contexts/ToastContext';
 
 const PRESET_AMOUNTS = [10, 20, 50, 100, 200];
 const PLATFORM_FEE_PCT = 0.05;
@@ -183,7 +184,10 @@ function Step2({
           {PRESET_AMOUNTS.map((amt) => (
             <button
               key={amt}
-              onClick={() => { onChange('reward_amount', amt); onChange('custom_amount', ''); }}
+              onClick={() => {
+                onChange('reward_amount', amt);
+                onChange('custom_amount', '');
+              }}
               className={`px-4 py-2 rounded-lg border text-sm font-mono font-medium transition-all duration-150 ${
                 state.reward_amount === amt && !state.custom_amount
                   ? 'bg-emerald text-text-inverse border-emerald'
@@ -270,6 +274,7 @@ function Step3({
   onSubmit: () => void;
   creating: boolean;
 }) {
+  const { pushToast } = useToast();
   const [verifying, setVerifying] = useState(false);
   const [verifyError, setVerifyError] = useState<string | null>(null);
   const [copiedAddr, setCopiedAddr] = useState(false);
@@ -280,6 +285,11 @@ function Step3({
     if (!state.treasury_address) return;
     navigator.clipboard.writeText(state.treasury_address).then(() => {
       setCopiedAddr(true);
+      pushToast({
+        title: 'Treasury address copied',
+        description: 'Paste it into your wallet to fund the bounty.',
+        variant: 'info',
+      });
       setTimeout(() => setCopiedAddr(false), 2000);
     });
   };
@@ -292,11 +302,20 @@ function Step3({
       const result = await verifyEscrowDeposit({ bounty_id: state.bounty_id, tx_signature: state.tx_signature });
       if (result.verified) {
         onChange('verified', true);
+        pushToast({
+          title: 'Payment verified',
+          description: 'Escrow funding is confirmed. You can publish the bounty now.',
+          variant: 'success',
+        });
       } else {
-        setVerifyError(result.error ?? 'Verification failed. Check your transaction signature.');
+        const message = result.error ?? 'Verification failed. Check your transaction signature.';
+        setVerifyError(message);
+        pushToast({ title: 'Verification failed', description: message, variant: 'error' });
       }
     } catch {
-      setVerifyError('Verification failed. Try again.');
+      const message = 'Verification failed. Try again.';
+      setVerifyError(message);
+      pushToast({ title: 'Verification failed', description: message, variant: 'error' });
     } finally {
       setVerifying(false);
     }
@@ -332,7 +351,7 @@ function Step3({
             onChange={(e) => onChange('tx_signature', e.target.value)}
             disabled={state.verified}
             placeholder="5KfR8xMn..."
-            className={`flex-1 bg-forge-700 border border-border rounded-lg px-4 py-3 text-sm text-text-primary placeholder:text-text-muted focus:border-emerald focus:ring-1 focus:ring-emerald/30 outline-none transition-all duration-150`}
+            className="flex-1 bg-forge-700 border border-border rounded-lg px-4 py-3 text-sm text-text-primary placeholder:text-text-muted focus:border-emerald focus:ring-1 focus:ring-emerald/30 outline-none transition-all duration-150"
           />
           <button
             onClick={handleVerify}
@@ -380,6 +399,7 @@ function Step3({
 
 export function BountyCreateWizard() {
   const navigate = useNavigate();
+  const { pushToast } = useToast();
   const [step, setStep] = useState(0);
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -403,6 +423,7 @@ export function BountyCreateWizard() {
   }, []);
 
   const handleStep1Next = () => setStep(1);
+
   const handleStep2Next = async () => {
     setCreating(true);
     setError(null);
@@ -421,9 +442,16 @@ export function BountyCreateWizard() {
       onChange('bounty_id', bounty.id);
       onChange('treasury_address', depositInfo.treasury_address);
       onChange('total_to_fund', depositInfo.total_to_fund);
+      pushToast({
+        title: 'Bounty draft created',
+        description: 'Funding details are ready. Send payment to publish it live.',
+        variant: 'success',
+      });
       setStep(2);
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : 'Failed to create bounty. Try again.');
+      const message = e instanceof Error ? e.message : 'Failed to create bounty. Try again.';
+      setError(message);
+      pushToast({ title: 'Bounty creation failed', description: message, variant: 'error' });
     } finally {
       setCreating(false);
     }
@@ -435,9 +463,16 @@ export function BountyCreateWizard() {
     setError(null);
     try {
       await verifyEscrowDeposit({ bounty_id: state.bounty_id, tx_signature: state.tx_signature });
+      pushToast({
+        title: 'Bounty published',
+        description: 'Your bounty is now live for contributors.',
+        variant: 'success',
+      });
       setSuccess(true);
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : 'Failed to publish bounty. Try again.');
+      const message = e instanceof Error ? e.message : 'Failed to publish bounty. Try again.';
+      setError(message);
+      pushToast({ title: 'Publish failed', description: message, variant: 'error' });
     } finally {
       setCreating(false);
     }
@@ -467,13 +502,7 @@ export function BountyCreateWizard() {
       )}
 
       <AnimatePresence mode="wait">
-        <motion.div
-          key={step}
-          variants={pageTransition}
-          initial="initial"
-          animate="animate"
-          exit="exit"
-        >
+        <motion.div key={step} variants={pageTransition} initial="initial" animate="animate" exit="exit">
           {step === 0 && <Step1 state={state} onChange={onChange} onNext={handleStep1Next} />}
           {step === 1 && <Step2 state={state} onChange={onChange} onNext={handleStep2Next} onBack={() => setStep(0)} />}
           {step === 2 && <Step3 state={state} onChange={onChange} onBack={() => setStep(1)} onSubmit={handlePublish} creating={creating} />}

--- a/frontend/src/components/bounty/SubmissionForm.tsx
+++ b/frontend/src/components/bounty/SubmissionForm.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Loader2, Check, Copy } from 'lucide-react';
 import type { Bounty } from '../../types/bounty';
 import { createSubmission, getReviewFee, verifyReviewFee } from '../../api/bounties';
+import { useToast } from '../../contexts/ToastContext';
 
 interface SubmissionFormProps {
   bounty: Bounty;
@@ -10,6 +11,7 @@ interface SubmissionFormProps {
 
 export function SubmissionForm({ bounty, onSuccess }: SubmissionFormProps) {
   const hasRepo = bounty.has_repo ?? !!bounty.github_repo_url;
+  const { pushToast } = useToast();
   const [url, setUrl] = useState('');
   const [description, setDescription] = useState('');
   const [txSig, setTxSig] = useState('');
@@ -21,7 +23,6 @@ export function SubmissionForm({ bounty, onSuccess }: SubmissionFormProps) {
   const [copied, setCopied] = useState(false);
   const [feeInfo, setFeeInfo] = useState<{ fndry_amount: number; fndry_price_usd: number } | null>(null);
 
-  // Treasury address placeholder — in production comes from API
   const TREASURY = '9xKfBountyTreasuryAddressHere...';
 
   React.useEffect(() => {
@@ -38,19 +39,38 @@ export function SubmissionForm({ bounty, onSuccess }: SubmissionFormProps) {
       const result = await verifyReviewFee({ bounty_id: bounty.id, tx_signature: txSig });
       if (result.verified) {
         setFeeVerified(true);
+        pushToast({
+          title: 'Review fee verified',
+          description: 'Your FNDRY payment was confirmed. You can submit now.',
+          variant: 'success',
+        });
       } else {
-        setError(result.error ?? 'Fee verification failed. Check your transaction signature.');
+        const message = result.error ?? 'Fee verification failed. Check your transaction signature.';
+        setError(message);
+        pushToast({ title: 'Verification failed', description: message, variant: 'error' });
       }
     } catch {
-      setError('Fee verification failed. Try again.');
+      const message = 'Fee verification failed. Try again.';
+      setError(message);
+      pushToast({ title: 'Verification failed', description: message, variant: 'error' });
     } finally {
       setVerifying(false);
     }
   };
 
   const handleSubmit = async () => {
-    if (!url.trim()) { setError('URL is required.'); return; }
-    if (!feeVerified) { setError('Verify your FNDRY review fee first.'); return; }
+    if (!url.trim()) {
+      const message = 'URL is required.';
+      setError(message);
+      pushToast({ title: 'Submission blocked', description: message, variant: 'warning' });
+      return;
+    }
+    if (!feeVerified) {
+      const message = 'Verify your FNDRY review fee first.';
+      setError(message);
+      pushToast({ title: 'Submission blocked', description: message, variant: 'warning' });
+      return;
+    }
     setSubmitting(true);
     setError(null);
     try {
@@ -61,9 +81,16 @@ export function SubmissionForm({ bounty, onSuccess }: SubmissionFormProps) {
         tx_signature: txSig,
       });
       setSuccess(true);
+      pushToast({
+        title: 'Submission received',
+        description: 'AI review will begin shortly.',
+        variant: 'success',
+      });
       onSuccess?.();
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : 'Submission failed. Try again.');
+      const message = e instanceof Error ? e.message : 'Submission failed. Try again.';
+      setError(message);
+      pushToast({ title: 'Submission failed', description: message, variant: 'error' });
     } finally {
       setSubmitting(false);
     }
@@ -72,6 +99,11 @@ export function SubmissionForm({ bounty, onSuccess }: SubmissionFormProps) {
   const copyTreasury = () => {
     navigator.clipboard.writeText(TREASURY).then(() => {
       setCopied(true);
+      pushToast({
+        title: 'Treasury address copied',
+        description: 'Paste it into your wallet to pay the review fee.',
+        variant: 'info',
+      });
       setTimeout(() => setCopied(false), 2000);
     });
   };
@@ -118,7 +150,6 @@ export function SubmissionForm({ bounty, onSuccess }: SubmissionFormProps) {
         </div>
       )}
 
-      {/* FNDRY Review Fee */}
       <div className="border-t border-b border-border py-4 my-2">
         <p className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-3">FNDRY Review Fee</p>
         {feeInfo && (

--- a/frontend/src/contexts/ToastContext.tsx
+++ b/frontend/src/contexts/ToastContext.tsx
@@ -1,0 +1,115 @@
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { AlertCircle, AlertTriangle, CheckCircle2, Info, X } from 'lucide-react';
+
+export type ToastVariant = 'success' | 'error' | 'warning' | 'info';
+
+export interface ToastOptions {
+  title: string;
+  description?: string;
+  variant?: ToastVariant;
+  durationMs?: number;
+}
+
+interface ToastRecord extends Required<ToastOptions> {
+  id: string;
+}
+
+interface ToastContextValue {
+  pushToast: (options: ToastOptions) => string;
+  dismissToast: (id: string) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+const ICONS: Record<ToastVariant, React.ReactNode> = {
+  success: <CheckCircle2 className="w-5 h-5" />,
+  error: <AlertCircle className="w-5 h-5" />,
+  warning: <AlertTriangle className="w-5 h-5" />,
+  info: <Info className="w-5 h-5" />,
+};
+
+const STYLES: Record<ToastVariant, string> = {
+  success: 'border-emerald/30 bg-emerald-bg text-emerald',
+  error: 'border-status-error/30 bg-status-error/10 text-status-error',
+  warning: 'border-status-warning/30 bg-amber-500/10 text-status-warning',
+  info: 'border-status-info/30 bg-status-info/10 text-status-info',
+};
+
+function ToastViewport({ toasts, onDismiss }: { toasts: ToastRecord[]; onDismiss: (id: string) => void }) {
+  return (
+    <div
+      className="fixed top-20 right-4 z-50 flex w-[calc(100vw-2rem)] max-w-sm flex-col gap-3"
+      aria-live="polite"
+      aria-atomic="true"
+    >
+      <AnimatePresence initial={false}>
+        {toasts.map((toast) => (
+          <motion.div
+            key={toast.id}
+            role="alert"
+            initial={{ opacity: 0, x: 80, scale: 0.96 }}
+            animate={{ opacity: 1, x: 0, scale: 1 }}
+            exit={{ opacity: 0, x: 80, scale: 0.96 }}
+            transition={{ duration: 0.2, ease: 'easeOut' }}
+            className={`rounded-xl border px-4 py-3 shadow-2xl backdrop-blur ${STYLES[toast.variant]}`}
+          >
+            <div className="flex items-start gap-3">
+              <div className="mt-0.5 flex-shrink-0">{ICONS[toast.variant]}</div>
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-semibold leading-5">{toast.title}</p>
+                {toast.description && (
+                  <p className="mt-1 text-sm leading-5 text-text-secondary">{toast.description}</p>
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={() => onDismiss(toast.id)}
+                aria-label="Dismiss notification"
+                className="flex-shrink-0 text-text-muted transition-colors hover:text-text-primary"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </div>
+          </motion.div>
+        ))}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<ToastRecord[]>([]);
+
+  const dismissToast = useCallback((id: string) => {
+    setToasts((current) => current.filter((toast) => toast.id !== id));
+  }, []);
+
+  const pushToast = useCallback(
+    ({ title, description, variant = 'info', durationMs = 5000 }: ToastOptions) => {
+      const id = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      setToasts((current) => [
+        ...current,
+        { id, title, description: description ?? '', variant, durationMs },
+      ]);
+      window.setTimeout(() => dismissToast(id), durationMs);
+      return id;
+    },
+    [dismissToast],
+  );
+
+  const value = useMemo(() => ({ pushToast, dismissToast }), [pushToast, dismissToast]);
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <ToastViewport toasts={toasts} onDismiss={dismissToast} />
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error('useToast must be used inside ToastProvider');
+  return ctx;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { AuthProvider } from './contexts/AuthContext';
+import { ToastProvider } from './contexts/ToastContext';
 import { queryClient } from './services/queryClient';
 import App from './App';
 import './index.css';
@@ -15,7 +16,9 @@ createRoot(root).render(
     <BrowserRouter>
       <QueryClientProvider client={queryClient}>
         <AuthProvider>
-          <App />
+          <ToastProvider>
+            <App />
+          </ToastProvider>
         </AuthProvider>
       </QueryClientProvider>
     </BrowserRouter>

--- a/frontend/src/pages/GitHubCallbackPage.tsx
+++ b/frontend/src/pages/GitHubCallbackPage.tsx
@@ -5,11 +5,13 @@ import { useAuth } from '../hooks/useAuth';
 import { exchangeGitHubCode } from '../api/auth';
 import { setAuthToken } from '../services/apiClient';
 import { fadeIn } from '../lib/animations';
+import { useToast } from '../contexts/ToastContext';
 
 export function GitHubCallbackPage() {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const { login } = useAuth();
+  const { pushToast } = useToast();
   const didRun = useRef(false);
 
   useEffect(() => {
@@ -21,35 +23,43 @@ export function GitHubCallbackPage() {
     const error = searchParams.get('error');
 
     if (error || !code) {
+      pushToast({
+        title: 'GitHub sign-in failed',
+        description: error ? `GitHub returned: ${error}` : 'Missing OAuth code from GitHub callback.',
+        variant: 'error',
+      });
       navigate('/', { replace: true });
       return;
     }
 
     exchangeGitHubCode(code, state ?? undefined)
       .then((response) => {
-        // Store tokens + user in auth context
         const authUser = { ...response.user, wallet_verified: false };
         login(response.access_token, response.refresh_token ?? '', authUser);
         setAuthToken(response.access_token);
-        // Store refresh token for future use
         if (response.refresh_token) {
           localStorage.setItem('sf_refresh_token', response.refresh_token);
         }
+        pushToast({
+          title: 'Signed in with GitHub',
+          description: `Welcome back, ${authUser.username}.`,
+          variant: 'success',
+        });
         navigate('/', { replace: true });
       })
       .catch(() => {
+        pushToast({
+          title: 'GitHub sign-in failed',
+          description: 'Could not complete the GitHub OAuth flow. Please try again.',
+          variant: 'error',
+        });
         navigate('/', { replace: true });
       });
-  }, []);
+  }, [login, navigate, pushToast, searchParams]);
 
   return (
     <div className="min-h-screen bg-forge-950 flex items-center justify-center">
-      <motion.div
-        variants={fadeIn}
-        initial="initial"
-        animate="animate"
-        className="text-center"
-      >
+      <motion.div variants={fadeIn} initial="initial" animate="animate" className="text-center">
         <div className="w-12 h-12 rounded-full border-2 border-emerald border-t-transparent animate-spin mx-auto mb-4" />
         <p className="text-text-muted font-mono text-sm">Signing in with GitHub...</p>
       </motion.div>


### PR DESCRIPTION
Implements a reusable toast notification system with stacked notifications, top-right slide-in behavior, dismiss controls, and variant styling.

Integrated toast feedback into key user actions:
- GitHub OAuth success/error
- bounty draft creation + publish flow
- escrow/review fee verification
- submission success/error
- treasury address copy actions

Validation:
- `npm test -- --run src/__tests__/toast-context.test.tsx` ✅
- `npm run build` ⚠️ currently fails on existing upstream missing `src/lib/animations` and `src/lib/utils` imports unrelated to this change

Closes #825

**Wallet:** 7UqBdYyy9LG59Un6yzjAW8HPcTC4J63B9cZxBHWhhHsg