### PR TITLE
feat: add bounty countdown timer (Closes #826)

### DIFF
--- a/frontend/src/__tests__/bounty-countdown.test.tsx
+++ b/frontend/src/__tests__/bounty-countdown.test.tsx
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { BountyCountdown, formatCountdown } from '../components/bounty/BountyCountdown';
+
+describe('formatCountdown', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-06T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('formats remaining time as days hours minutes', () => {
+    expect(formatCountdown('2026-04-07T02:30:00Z')).toBe('1d 2h 30m');
+  });
+
+  it('returns expired after deadline passes', () => {
+    expect(formatCountdown('2026-04-05T23:00:00Z')).toBe('Expired');
+  });
+});
+
+describe('BountyCountdown', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-06T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders warning color for less than 24 hours', () => {
+    render(<BountyCountdown deadline="2026-04-06T12:00:00Z" />);
+    const text = screen.getByText('0d 12h 0m');
+    expect(text.parentElement).toHaveClass('text-status-warning');
+  });
+
+  it('renders urgent color for less than 1 hour', () => {
+    render(<BountyCountdown deadline="2026-04-06T00:45:00Z" />);
+    const text = screen.getByText('0d 0h 45m');
+    expect(text.parentElement).toHaveClass('text-status-error');
+  });
+
+  it('renders expired state', () => {
+    render(<BountyCountdown deadline="2026-04-05T23:45:00Z" />);
+    const text = screen.getByText('Expired');
+    expect(text.parentElement).toHaveClass('text-status-error');
+  });
+});

--- a/frontend/src/components/bounty/BountyCard.tsx
+++ b/frontend/src/components/bounty/BountyCard.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { GitPullRequest, Clock } from 'lucide-react';
+import { GitPullRequest } from 'lucide-react';
 import type { Bounty } from '../../types/bounty';
 import { cardHover } from '../../lib/animations';
-import { timeLeft, formatCurrency, LANG_COLORS } from '../../lib/utils';
+import { formatCurrency, LANG_COLORS } from '../../lib/utils';
+import { BountyCountdown } from './BountyCountdown';
 
 function TierBadge({ tier }: { tier: string }) {
   const styles: Record<string, string> = {
@@ -110,12 +111,7 @@ export function BountyCard({ bounty }: BountyCardProps) {
             <GitPullRequest className="w-3.5 h-3.5" />
             {bounty.submission_count} PRs
           </span>
-          {bounty.deadline && (
-            <span className="inline-flex items-center gap-1">
-              <Clock className="w-3.5 h-3.5" />
-              {timeLeft(bounty.deadline)}
-            </span>
-          )}
+          {bounty.deadline && <BountyCountdown deadline={bounty.deadline} compact />}
         </div>
       </div>
 

--- a/frontend/src/components/bounty/BountyCountdown.tsx
+++ b/frontend/src/components/bounty/BountyCountdown.tsx
@@ -1,0 +1,62 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Clock } from 'lucide-react';
+
+interface CountdownState {
+  expired: boolean;
+  totalMs: number;
+  days: number;
+  hours: number;
+  minutes: number;
+}
+
+function getCountdownState(deadline: string): CountdownState {
+  const totalMs = new Date(deadline).getTime() - Date.now();
+
+  if (Number.isNaN(totalMs) || totalMs <= 0) {
+    return { expired: true, totalMs: 0, days: 0, hours: 0, minutes: 0 };
+  }
+
+  const totalMinutes = Math.floor(totalMs / 60000);
+  const days = Math.floor(totalMinutes / (60 * 24));
+  const hours = Math.floor((totalMinutes % (60 * 24)) / 60);
+  const minutes = totalMinutes % 60;
+
+  return { expired: false, totalMs, days, hours, minutes };
+}
+
+function getToneClass(state: CountdownState) {
+  if (state.expired) return 'text-status-error';
+  if (state.totalMs < 60 * 60 * 1000) return 'text-status-error';
+  if (state.totalMs < 24 * 60 * 60 * 1000) return 'text-status-warning';
+  return 'text-text-muted';
+}
+
+export function formatCountdown(deadline: string) {
+  const state = getCountdownState(deadline);
+  if (state.expired) return 'Expired';
+  return `${state.days}d ${state.hours}h ${state.minutes}m`;
+}
+
+export function BountyCountdown({ deadline, compact = false }: { deadline: string; compact?: boolean }) {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const timer = window.setInterval(() => setNow(Date.now()), 30000);
+    return () => window.clearInterval(timer);
+  }, []);
+
+  const state = useMemo(() => {
+    void now;
+    return getCountdownState(deadline);
+  }, [deadline, now]);
+
+  const toneClass = getToneClass(state);
+  const label = state.expired ? 'Expired' : `${state.days}d ${state.hours}h ${state.minutes}m`;
+
+  return (
+    <span className={`inline-flex items-center gap-1 ${toneClass}`} aria-label={`Time remaining: ${label}`}>
+      <Clock className={compact ? 'w-3.5 h-3.5' : 'w-4 h-4'} />
+      <span className="font-mono">{label}</span>
+    </span>
+  );
+}

--- a/frontend/src/components/bounty/BountyDetail.tsx
+++ b/frontend/src/components/bounty/BountyDetail.tsx
@@ -1,12 +1,13 @@
 import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { ArrowLeft, Clock, GitPullRequest, ExternalLink, Loader2, Check, Copy } from 'lucide-react';
+import { ArrowLeft, GitPullRequest, ExternalLink, Check, Copy } from 'lucide-react';
 import type { Bounty } from '../../types/bounty';
-import { timeLeft, timeAgo, formatCurrency, LANG_COLORS } from '../../lib/utils';
+import { timeAgo, formatCurrency, LANG_COLORS } from '../../lib/utils';
 import { useAuth } from '../../hooks/useAuth';
 import { SubmissionForm } from './SubmissionForm';
 import { fadeIn } from '../../lib/animations';
+import { BountyCountdown } from './BountyCountdown';
 
 interface BountyDetailProps {
   bounty: Bounty;
@@ -138,9 +139,7 @@ export function BountyDetail({ bounty }: BountyDetailProps) {
             {bounty.deadline && (
               <div className="flex items-center justify-between text-sm">
                 <span className="text-text-muted">Deadline</span>
-                <span className="font-mono text-status-warning inline-flex items-center gap-1">
-                  <Clock className="w-3.5 h-3.5" /> {timeLeft(bounty.deadline)}
-                </span>
+                <BountyCountdown deadline={bounty.deadline} compact />
               </div>
             )}
             <div className="flex items-center justify-between text-sm">


### PR DESCRIPTION
Adds a reusable countdown timer component for bounty deadlines and integrates it into both bounty cards and the bounty detail sidebar.

Highlights:
- shows days / hours / minutes remaining
- updates automatically without page refresh
- warning color under 24 hours
- urgent color under 1 hour
- shows `Expired` after deadline passes
- used on bounty cards and detail page

Validation:
- `npm test -- --run src/__tests__/bounty-countdown.test.tsx` ✅
- `npm run build` still fails on existing upstream missing `src/lib/animations` and `src/lib/utils` imports unrelated to this change

Closes #826

**Wallet:** 7UqBdYyy9LG59Un6yzjAW8HPcTC4J63B9cZxBHWhhHsg