### PR TITLE
feat: add search bar to bounties page (Closes #823)

### DIFF
--- a/frontend/src/__tests__/bounty-search.test.tsx
+++ b/frontend/src/__tests__/bounty-search.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BountyGrid } from '../components/bounty/BountyGrid';
+
+const useInfiniteBountiesMock = vi.fn();
+
+vi.mock('../hooks/useBounties', () => ({
+  useInfiniteBounties: (...args: unknown[]) => useInfiniteBountiesMock(...args),
+}));
+
+vi.mock('../components/bounty/BountyCard', () => ({
+  BountyCard: ({ bounty }: { bounty: { title: string } }) => <div>{bounty.title}</div>,
+}));
+
+function renderGrid() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <BountyGrid />
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe('BountyGrid search', () => {
+  beforeEach(() => {
+    useInfiniteBountiesMock.mockReturnValue({
+      data: { pages: [{ items: [{ id: '1', title: 'Toast task' }], total: 1 }] },
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      isLoading: false,
+      isError: false,
+    });
+  });
+
+  afterEach(() => {
+    useInfiniteBountiesMock.mockReset();
+  });
+
+  it('debounces search and passes it to the bounty query params', async () => {
+    renderGrid();
+
+    expect(useInfiniteBountiesMock).toHaveBeenLastCalledWith({
+      status: 'open',
+      skill: undefined,
+      search: undefined,
+    });
+
+    fireEvent.change(screen.getByLabelText('Search bounties'), { target: { value: 'toast' } });
+
+    await waitFor(
+      () => {
+        expect(useInfiniteBountiesMock).toHaveBeenLastCalledWith({
+          status: 'open',
+          skill: undefined,
+          search: 'toast',
+        });
+      },
+      { timeout: 1200 },
+    );
+  });
+
+  it('clears the search input with the clear button', async () => {
+    renderGrid();
+
+    const input = screen.getByLabelText('Search bounties') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'timer' } });
+    expect(input.value).toBe('timer');
+
+    fireEvent.click(screen.getByLabelText('Clear search'));
+    expect(input.value).toBe('');
+
+    await waitFor(
+      () => {
+        expect(useInfiniteBountiesMock).toHaveBeenLastCalledWith({
+          status: 'open',
+          skill: undefined,
+          search: undefined,
+        });
+      },
+      { timeout: 1200 },
+    );
+  });
+});

--- a/frontend/src/api/bounties.ts
+++ b/frontend/src/api/bounties.ts
@@ -13,6 +13,7 @@ export interface BountiesListParams {
   limit?: number;
   offset?: number;
   skill?: string;
+  search?: string;
   tier?: string;
   reward_token?: string;
 }

--- a/frontend/src/components/bounty/BountyGrid.tsx
+++ b/frontend/src/components/bounty/BountyGrid.tsx
@@ -1,21 +1,36 @@
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { ChevronDown, Loader2, Plus } from 'lucide-react';
+import { ChevronDown, Loader2, Plus, Search, X } from 'lucide-react';
 import { BountyCard } from './BountyCard';
 import { useInfiniteBounties } from '../../hooks/useBounties';
 import { staggerContainer, staggerItem } from '../../lib/animations';
 
 const FILTER_SKILLS = ['All', 'TypeScript', 'Rust', 'Solidity', 'Python', 'Go', 'JavaScript'];
+const SEARCH_DEBOUNCE_MS = 300;
 
 export function BountyGrid() {
   const [activeSkill, setActiveSkill] = useState<string>('All');
   const [statusFilter, setStatusFilter] = useState<string>('open');
+  const [searchInput, setSearchInput] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
 
-  const params = {
-    status: statusFilter,
-    skill: activeSkill !== 'All' ? activeSkill : undefined,
-  };
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      setDebouncedSearch(searchInput.trim());
+    }, SEARCH_DEBOUNCE_MS);
+
+    return () => window.clearTimeout(timer);
+  }, [searchInput]);
+
+  const params = useMemo(
+    () => ({
+      status: statusFilter,
+      skill: activeSkill !== 'All' ? activeSkill : undefined,
+      search: debouncedSearch || undefined,
+    }),
+    [activeSkill, debouncedSearch, statusFilter],
+  );
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, isError } =
     useInfiniteBounties(params);
@@ -25,7 +40,6 @@ export function BountyGrid() {
   return (
     <section id="bounties" className="py-16 md:py-24">
       <div className="max-w-7xl mx-auto px-4">
-        {/* Header row */}
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-8">
           <h2 className="font-sans text-2xl font-semibold text-text-primary">Open Bounties</h2>
           <div className="flex items-center gap-2">
@@ -36,7 +50,6 @@ export function BountyGrid() {
               <Plus className="w-4 h-4" />
               Post a Bounty
             </Link>
-            {/* Status filter */}
             <div className="relative">
               <select
                 value={statusFilter}
@@ -53,7 +66,28 @@ export function BountyGrid() {
           </div>
         </div>
 
-        {/* Filter pills */}
+        <div className="relative mb-6">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted pointer-events-none" />
+          <input
+            type="search"
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+            placeholder="Search by title, description, or tags..."
+            aria-label="Search bounties"
+            className="w-full rounded-xl border border-border bg-forge-800 py-3 pl-10 pr-11 text-sm text-text-primary placeholder:text-text-muted outline-none transition-colors duration-150 focus:border-emerald focus:ring-1 focus:ring-emerald/30"
+          />
+          {searchInput && (
+            <button
+              type="button"
+              onClick={() => setSearchInput('')}
+              aria-label="Clear search"
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-text-muted hover:text-text-primary transition-colors"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          )}
+        </div>
+
         <div className="flex items-center gap-2 flex-wrap mb-8">
           {FILTER_SKILLS.map((skill) => (
             <button
@@ -70,7 +104,6 @@ export function BountyGrid() {
           ))}
         </div>
 
-        {/* Loading state */}
         {isLoading && (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
             {Array.from({ length: 6 }).map((_, i) => (
@@ -84,7 +117,6 @@ export function BountyGrid() {
           </div>
         )}
 
-        {/* Error state */}
         {isError && !isLoading && (
           <div className="text-center py-16">
             <p className="text-text-muted mb-4">Could not load bounties. Backend may be offline.</p>
@@ -92,17 +124,19 @@ export function BountyGrid() {
           </div>
         )}
 
-        {/* Empty state */}
         {!isLoading && !isError && allBounties.length === 0 && (
           <div className="text-center py-16">
             <p className="text-text-muted text-lg mb-2">No bounties found</p>
             <p className="text-text-muted text-sm">
-              {activeSkill !== 'All' ? `Try a different language filter.` : 'Check back soon for new bounties.'}
+              {debouncedSearch
+                ? 'Try a different search term or clear filters.'
+                : activeSkill !== 'All'
+                ? 'Try a different language filter.'
+                : 'Check back soon for new bounties.'}
             </p>
           </div>
         )}
 
-        {/* Bounty grid */}
         {!isLoading && allBounties.length > 0 && (
           <motion.div
             variants={staggerContainer}
@@ -119,7 +153,6 @@ export function BountyGrid() {
           </motion.div>
         )}
 
-        {/* Load more */}
         {hasNextPage && (
           <div className="mt-10 text-center">
             <button

--- a/frontend/src/lib/animations.ts
+++ b/frontend/src/lib/animations.ts
@@ -1,0 +1,36 @@
+export const fadeIn = {
+  initial: { opacity: 0, y: 8 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.2, ease: 'easeOut' } },
+};
+
+export const pageTransition = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.22, ease: 'easeOut' } },
+  exit: { opacity: 0, y: -8, transition: { duration: 0.16, ease: 'easeIn' } },
+};
+
+export const staggerContainer = {
+  initial: {},
+  animate: { transition: { staggerChildren: 0.06 } },
+};
+
+export const staggerItem = {
+  initial: { opacity: 0, y: 10 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.18, ease: 'easeOut' } },
+};
+
+export const slideInRight = {
+  initial: { opacity: 0, x: 24 },
+  animate: { opacity: 1, x: 0, transition: { duration: 0.2, ease: 'easeOut' } },
+};
+
+export const cardHover = {
+  rest: { y: 0, scale: 1 },
+  hover: { y: -4, scale: 1.01, transition: { duration: 0.18, ease: 'easeOut' } },
+};
+
+export const buttonHover = {
+  rest: { scale: 1 },
+  hover: { scale: 1.02, transition: { duration: 0.15, ease: 'easeOut' } },
+  tap: { scale: 0.98 },
+};

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,38 @@
+const numberFormatter = new Intl.NumberFormat('en-US');
+
+export const LANG_COLORS: Record<string, string> = {
+  TypeScript: '#3178C6',
+  JavaScript: '#F7DF1E',
+  Python: '#3776AB',
+  Rust: '#DEA584',
+  Solidity: '#8A92B2',
+  Go: '#00ADD8',
+  React: '#61DAFB',
+};
+
+export function formatCurrency(amount: number, token: string) {
+  if (!Number.isFinite(amount)) return `0 ${token}`;
+  const compact = amount >= 1000 ? `${(amount / 1000).toFixed(amount % 1000 === 0 ? 0 : 1)}k` : numberFormatter.format(amount);
+  return `${compact} ${token}`;
+}
+
+export function timeAgo(input: string) {
+  const diffMs = Date.now() - new Date(input).getTime();
+  const diffMinutes = Math.max(0, Math.floor(diffMs / 60000));
+  if (diffMinutes < 1) return 'just now';
+  if (diffMinutes < 60) return `${diffMinutes}m ago`;
+  const diffHours = Math.floor(diffMinutes / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  const diffDays = Math.floor(diffHours / 24);
+  return `${diffDays}d ago`;
+}
+
+export function timeLeft(input: string) {
+  const diffMs = new Date(input).getTime() - Date.now();
+  if (diffMs <= 0) return 'Expired';
+  const totalMinutes = Math.floor(diffMs / 60000);
+  const days = Math.floor(totalMinutes / (60 * 24));
+  const hours = Math.floor((totalMinutes % (60 * 24)) / 60);
+  const minutes = totalMinutes % 60;
+  return `${days}d ${hours}h ${minutes}m`;
+}

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -1,1 +1,18 @@
 import '@testing-library/jest-dom';
+
+class MockIntersectionObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() {
+    return [];
+  }
+}
+
+if (!('IntersectionObserver' in globalThis)) {
+  Object.defineProperty(globalThis, 'IntersectionObserver', {
+    writable: true,
+    configurable: true,
+    value: MockIntersectionObserver,
+  });
+}


### PR DESCRIPTION
Adds a debounced search input to the `/bounties` page and wires it into the existing bounty query params so search works alongside the current status and language filters.

Highlights:
- search input visible on the bounties page
- 300ms debounce before querying
- clear button to reset search instantly
- search param passed together with existing `status` and `skill` filters
- improved empty-state copy for search results
- focused test coverage for debounce + clear behavior

Validation:
- `npm test -- --run src/__tests__/bounty-search.test.tsx` ✅

Note:
- the repo was missing tracked `frontend/src/lib/animations.ts` and `frontend/src/lib/utils.ts` modules even though many existing components import them; this PR includes minimal implementations so the current frontend code can resolve those imports consistently.

Closes #823

**Wallet:** 7UqBdYyy9LG59Un6yzjAW8HPcTC4J63B9cZxBHWhhHsg