### PR TITLE
feat: wire activity feed to real api data (Closes #822)

### DIFF
--- a/frontend/src/__tests__/activity-feed-home.test.tsx
+++ b/frontend/src/__tests__/activity-feed-home.test.tsx
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ActivityFeed } from '../components/home/ActivityFeed';
+
+const useActivityMock = vi.fn();
+
+vi.mock('../hooks/useActivity', () => ({
+  useActivity: () => useActivityMock(),
+}));
+
+vi.mock('../lib/animations', () => ({
+  slideInRight: { initial: {}, animate: {} },
+}));
+
+describe('home activity feed', () => {
+  beforeEach(() => {
+    useActivityMock.mockReset();
+  });
+
+  it('renders real activity events from the hook', () => {
+    useActivityMock.mockReturnValue({
+      data: [
+        {
+          id: 'evt-1',
+          type: 'submitted',
+          username: 'alice',
+          detail: 'PR to Bounty #12',
+          timestamp: new Date().toISOString(),
+        },
+      ],
+      isLoading: false,
+      isError: false,
+    });
+
+    render(<ActivityFeed />);
+    expect(screen.getByText('alice')).toBeInTheDocument();
+    expect(screen.getByText(/PR to Bounty #12/)).toBeInTheDocument();
+  });
+
+  it('shows no recent activity state when API returns empty', () => {
+    useActivityMock.mockReturnValue({ data: [], isLoading: false, isError: false });
+    render(<ActivityFeed />);
+    expect(screen.getByText('No recent activity')).toBeInTheDocument();
+  });
+
+  it('falls back gracefully when API is unavailable', () => {
+    useActivityMock.mockReturnValue({ data: undefined, isLoading: false, isError: true });
+    render(<ActivityFeed />);
+    expect(screen.getByText(/showing fallback activity/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/api/activity.ts
+++ b/frontend/src/api/activity.ts
@@ -1,0 +1,45 @@
+import { apiClient } from '../services/apiClient';
+
+export interface ActivityEvent {
+  id: string;
+  type: 'completed' | 'submitted' | 'posted' | 'review' | 'payout';
+  username: string;
+  avatar_url?: string | null;
+  detail: string;
+  timestamp: string;
+}
+
+function normalizeType(type?: string): ActivityEvent['type'] {
+  switch (type) {
+    case 'completed':
+    case 'submitted':
+    case 'posted':
+    case 'review':
+    case 'payout':
+      return type;
+    default:
+      return 'posted';
+  }
+}
+
+function mapEvent(raw: Record<string, unknown>, index: number): ActivityEvent {
+  return {
+    id: String(raw.id ?? `activity-${index}`),
+    type: normalizeType(String(raw.type ?? raw.event_type ?? 'posted')),
+    username: String(raw.username ?? raw.actor_username ?? raw.user ?? 'Unknown'),
+    avatar_url: (raw.avatar_url as string | null | undefined) ?? (raw.actor_avatar_url as string | null | undefined) ?? null,
+    detail: String(raw.detail ?? raw.message ?? raw.summary ?? 'Activity updated'),
+    timestamp: String(raw.timestamp ?? raw.created_at ?? raw.occurred_at ?? new Date().toISOString()),
+  };
+}
+
+export async function getRecentActivity(): Promise<ActivityEvent[]> {
+  const response = await apiClient<ActivityEvent[] | { items?: Record<string, unknown>[]; events?: Record<string, unknown>[] }>('/api/activity');
+
+  if (Array.isArray(response)) {
+    return response.map((item, index) => mapEvent(item as unknown as Record<string, unknown>, index));
+  }
+
+  const items = response.items ?? response.events ?? [];
+  return items.map((item, index) => mapEvent(item, index));
+}

--- a/frontend/src/components/home/ActivityFeed.tsx
+++ b/frontend/src/components/home/ActivityFeed.tsx
@@ -1,19 +1,11 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { slideInRight } from '../../lib/animations';
 import { timeAgo } from '../../lib/utils';
+import { useActivity } from '../../hooks/useActivity';
+import type { ActivityEvent } from '../../api/activity';
 
-interface ActivityEvent {
-  id: string;
-  type: 'completed' | 'submitted' | 'posted' | 'review';
-  username: string;
-  avatar_url?: string | null;
-  detail: string;
-  timestamp: string;
-}
-
-// Mock events for when API doesn't return activity
-const MOCK_EVENTS: ActivityEvent[] = [
+const FALLBACK_EVENTS: ActivityEvent[] = [
   {
     id: '1',
     type: 'completed',
@@ -30,34 +22,34 @@ const MOCK_EVENTS: ActivityEvent[] = [
   },
   {
     id: '3',
-    type: 'posted',
-    username: 'SolanaLabs',
-    detail: 'Bounty #145 — $3,500 USDC',
+    type: 'payout',
+    username: 'SolFoundry',
+    detail: 'FNDRY payout released',
     timestamp: new Date(Date.now() - 45 * 60 * 1000).toISOString(),
-  },
-  {
-    id: '4',
-    type: 'review',
-    username: 'AI Review',
-    detail: 'Bounty #42 — 8.5/10',
-    timestamp: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
   },
 ];
 
 function getActionText(type: ActivityEvent['type']) {
   switch (type) {
-    case 'completed': return 'earned';
-    case 'submitted': return 'submitted';
-    case 'posted': return 'posted';
-    case 'review': return 'AI Review passed for';
-    default: return 'updated';
+    case 'completed':
+      return 'earned';
+    case 'submitted':
+      return 'submitted';
+    case 'posted':
+      return 'posted';
+    case 'review':
+      return 'reviewed';
+    case 'payout':
+      return 'received';
+    default:
+      return 'updated';
   }
 }
 
 function EventItem({ event }: { event: ActivityEvent }) {
-  const isMagenta = event.type === 'review';
+  const isAccent = event.type === 'review' ? 'text-magenta' : 'text-emerald';
   return (
-    <div className="flex items-center gap-3 py-2 px-3 rounded-lg hover:bg-forge-850 transition-colors duration-150">
+    <div className="flex items-center gap-3 py-2 px-3 rounded-lg hover:bg-forge-850 transition-colors duration-150 min-w-0">
       {event.avatar_url ? (
         <img src={event.avatar_url} className="w-6 h-6 rounded-full flex-shrink-0" alt="" />
       ) : (
@@ -65,23 +57,20 @@ function EventItem({ event }: { event: ActivityEvent }) {
           <span className="font-mono text-xs text-text-muted">{event.username[0]?.toUpperCase()}</span>
         </div>
       )}
-      <p className="text-sm text-text-secondary flex-1 truncate">
-        <span className="font-medium text-text-primary">{event.username}</span>
-        {' '}{getActionText(event.type)}{' '}
-        <span className={`font-mono ${isMagenta ? 'text-magenta' : 'text-emerald'}`}>{event.detail}</span>
+      <p className="text-sm text-text-secondary flex-1 min-w-0">
+        <span className="font-medium text-text-primary">{event.username}</span>{' '}
+        {getActionText(event.type)}{' '}
+        <span className={`font-mono ${isAccent} break-words`}>{event.detail}</span>
       </p>
       <span className="font-mono text-xs text-text-muted flex-shrink-0">{timeAgo(event.timestamp)}</span>
     </div>
   );
 }
 
-export function ActivityFeed({ events }: { events?: ActivityEvent[] }) {
-  const displayEvents = events?.length ? events.slice(0, 4) : MOCK_EVENTS;
-  const [visibleEvents, setVisibleEvents] = useState<ActivityEvent[]>(displayEvents.slice(0, 4));
-
-  useEffect(() => {
-    setVisibleEvents(displayEvents.slice(0, 4));
-  }, [events]);
+export function ActivityFeed() {
+  const { data, isLoading, isError } = useActivity();
+  const displayEvents = isError ? FALLBACK_EVENTS : data ?? [];
+  const visibleEvents = displayEvents.slice(0, 4);
 
   return (
     <section className="w-full border-y border-border bg-forge-900/50 py-4 overflow-hidden">
@@ -90,22 +79,51 @@ export function ActivityFeed({ events }: { events?: ActivityEvent[] }) {
           <span className="w-2 h-2 rounded-full bg-emerald animate-pulse-glow" />
           <span className="font-mono text-xs text-text-muted uppercase tracking-wider">Recent Activity</span>
         </div>
-        <div className="space-y-1">
-          <AnimatePresence mode="popLayout">
-            {visibleEvents.map((event) => (
-              <motion.div
-                key={event.id}
-                variants={slideInRight}
-                initial="initial"
-                animate="animate"
-                exit={{ opacity: 0, x: -20, transition: { duration: 0.2 } }}
-                layout
-              >
-                <EventItem event={event} />
-              </motion.div>
+
+        {isLoading && (
+          <div className="space-y-1" aria-busy="true">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="flex items-center gap-3 py-2 px-3 rounded-lg">
+                <div className="w-6 h-6 rounded-full bg-forge-800 overflow-hidden">
+                  <div className="h-full w-full bg-gradient-to-r from-forge-800 via-forge-700 to-forge-800 bg-[length:200%_100%] animate-shimmer" />
+                </div>
+                <div className="flex-1 h-4 rounded bg-forge-800 overflow-hidden">
+                  <div className="h-full w-full bg-gradient-to-r from-forge-800 via-forge-700 to-forge-800 bg-[length:200%_100%] animate-shimmer" />
+                </div>
+                <div className="w-12 h-3 rounded bg-forge-800 overflow-hidden">
+                  <div className="h-full w-full bg-gradient-to-r from-forge-800 via-forge-700 to-forge-800 bg-[length:200%_100%] animate-shimmer" />
+                </div>
+              </div>
             ))}
-          </AnimatePresence>
-        </div>
+          </div>
+        )}
+
+        {!isLoading && visibleEvents.length === 0 && !isError && (
+          <div className="py-4 px-3 text-sm text-text-muted">No recent activity</div>
+        )}
+
+        {!isLoading && visibleEvents.length > 0 && (
+          <div className="space-y-1">
+            <AnimatePresence mode="popLayout">
+              {visibleEvents.map((event) => (
+                <motion.div
+                  key={event.id}
+                  variants={slideInRight}
+                  initial="initial"
+                  animate="animate"
+                  exit={{ opacity: 0, x: -20, transition: { duration: 0.2 } }}
+                  layout
+                >
+                  <EventItem event={event} />
+                </motion.div>
+              ))}
+            </AnimatePresence>
+          </div>
+        )}
+
+        {isError && (
+          <div className="mt-3 text-xs text-text-muted font-mono">API unavailable — showing fallback activity.</div>
+        )}
       </div>
     </section>
   );

--- a/frontend/src/hooks/useActivity.ts
+++ b/frontend/src/hooks/useActivity.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { getRecentActivity } from '../api/activity';
+
+export function useActivity() {
+  return useQuery({
+    queryKey: ['recent-activity'],
+    queryFn: getRecentActivity,
+    staleTime: 15_000,
+    refetchInterval: 30_000,
+  });
+}


### PR DESCRIPTION
Replaces the home page activity feed mock data with a real API-backed query and keeps the UX resilient when the activity endpoint is unavailable.

Highlights:
- adds `GET /api/activity` integration via `api/activity.ts`
- adds `useActivity()` hook with 30s auto-refresh
- supports real activity events from the backend
- shows `No recent activity` for empty responses
- gracefully falls back to demo activity when the API is unavailable
- keeps the component self-contained and lightweight for the home page

Validation:
- `npm test -- --run src/__tests__/activity-feed-home.test.tsx` ✅

Closes #822

**Wallet:** 7UqBdYyy9LG59Un6yzjAW8HPcTC4J63B9cZxBHWhhHsg