### PR TITLE
fix: Mobile responsive polish for bounty cards, hero, and layout

### DIFF
--- a/frontend/src/components/bounty/BountyCard.tsx
+++ b/frontend/src/components/bounty/BountyCard.tsx
@@ -100,30 +100,28 @@ export function BountyCard({ bounty }: BountyCardProps) {
       {/* Separator */}
       <div className="mt-4 border-t border-border/50" />
 
-      {/* Row 4: Reward + Meta */}
-      <div className="flex items-center justify-between mt-3">
-        <span className="font-mono text-lg font-semibold text-emerald">
+      {/* Row 4: Reward + Meta + Status */}
+      <div className="flex items-center justify-between mt-3 gap-2">
+        <span className="font-mono text-lg font-semibold text-emerald truncate">
           {formatCurrency(bounty.reward_amount, bounty.reward_token)}
         </span>
-        <div className="flex items-center gap-3 text-xs text-text-muted">
+        <div className="flex items-center gap-2 text-xs text-text-muted flex-shrink-0">
+          <span className={`inline-flex items-center gap-1 ${statusColor}`}>
+            <span className={`w-1.5 h-1.5 rounded-full ${dotColor}`} />
+            {statusLabel}
+          </span>
           <span className="inline-flex items-center gap-1">
             <GitPullRequest className="w-3.5 h-3.5" />
-            {bounty.submission_count} PRs
+            {bounty.submission_count}
           </span>
           {bounty.deadline && (
-            <span className="inline-flex items-center gap-1">
+            <span className="hidden sm:inline-flex items-center gap-1">
               <Clock className="w-3.5 h-3.5" />
               {timeLeft(bounty.deadline)}
             </span>
           )}
         </div>
       </div>
-
-      {/* Status badge */}
-      <span className={`absolute bottom-4 right-5 text-xs font-medium inline-flex items-center gap-1 ${statusColor}`}>
-        <span className={`w-1.5 h-1.5 rounded-full ${dotColor}`} />
-        {statusLabel}
-      </span>
     </motion.div>
   );
 }

--- a/frontend/src/components/home/ActivityFeed.tsx
+++ b/frontend/src/components/home/ActivityFeed.tsx
@@ -70,7 +70,7 @@ function EventItem({ event }: { event: ActivityEvent }) {
         {' '}{getActionText(event.type)}{' '}
         <span className={`font-mono ${isMagenta ? 'text-magenta' : 'text-emerald'}`}>{event.detail}</span>
       </p>
-      <span className="font-mono text-xs text-text-muted flex-shrink-0">{timeAgo(event.timestamp)}</span>
+      <span className="font-mono text-xs text-text-muted flex-shrink-0 max-w-[4.5rem] truncate">{timeAgo(event.timestamp)}</span>
     </div>
   );
 }

--- a/frontend/src/components/home/HeroSection.tsx
+++ b/frontend/src/components/home/HeroSection.tsx
@@ -114,7 +114,7 @@ export function HeroSection() {
         <div className="p-5 font-mono text-sm leading-relaxed">
           <div className="overflow-hidden">
             <span className="text-emerald">$ </span>
-            <span className="text-text-secondary overflow-hidden whitespace-nowrap inline-block animate-typewriter">
+            <span className="text-text-secondary overflow-hidden whitespace-nowrap inline-block animate-typewriter text-xs sm:text-sm">
               forge bounty --reward 100 --lang typescript --tier 2
             </span>
             {typewriterDone && (
@@ -154,7 +154,7 @@ export function HeroSection() {
         initial={{ opacity: 0, y: 16 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ delay: 0.3, duration: 0.5 }}
-        className="font-display text-4xl md:text-5xl font-bold text-text-primary tracking-wider text-center mt-10"
+        className="font-display text-3xl sm:text-4xl md:text-5xl font-bold text-text-primary tracking-wider text-center mt-10"
       >
         THE AI-POWERED BOUNTY{' '}
         <span className="text-emerald">FORGE</span>
@@ -211,7 +211,7 @@ export function HeroSection() {
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         transition={{ delay: 0.8, duration: 0.5 }}
-        className="flex items-center justify-center gap-6 mt-8 font-mono text-sm text-text-muted"
+        className="flex flex-wrap items-center justify-center gap-x-6 gap-y-2 mt-8 font-mono text-xs sm:text-sm text-text-muted"
       >
         <span>
           <span className="text-text-primary font-semibold">

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -92,7 +92,7 @@ export function Footer() {
           <div>
             <h4 className="font-sans text-sm font-semibold text-text-primary mb-4">$FNDRY Token</h4>
             <p className="text-sm text-text-muted mb-3">Contract Address:</p>
-            <div className="font-mono text-xs text-text-muted bg-forge-800 rounded px-3 py-2 inline-flex items-center gap-2 w-full">
+            <div className="font-mono text-xs text-text-muted bg-forge-800 rounded px-3 py-2 inline-flex items-center gap-2 min-w-0">
               <span className="truncate">{FNDRY_CA.slice(0, 8)}...{FNDRY_CA.slice(-4)}</span>
               <button
                 onClick={copyCA}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -143,3 +143,21 @@ input[type="number"]::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
+
+/* Mobile responsive — prevent horizontal overflow */
+html, body {
+  overflow-x: hidden;
+}
+
+/* Fix any elements that might cause horizontal scroll */
+img, svg, video, canvas {
+  max-width: 100%;
+  height: auto;
+}
+
+/* Bounty card mobile padding tweak */
+@media (max-width: 767px) {
+  .font-display {
+    letter-spacing: 0.05em;
+  }
+}


### PR DESCRIPTION
Polishes the mobile experience at 375px and 768px breakpoints.

**Changes:**

**BountyCard:**
- Moved status badge inline with reward/meta row instead of absolute positioning (prevents overlap on small screens)
- Added `truncate` on reward amount and `flex-shrink-0` on meta items
- Deadline now hidden on mobile (`hidden sm:inline-flex`) to prevent crowding

**HeroSection:**
- Terminal command text scales down on mobile (`text-xs sm:text-sm`)
- Headline scales from `text-3xl` → `sm:text-4xl` → `md:text-5xl`
- Stats strip uses `flex-wrap` and smaller text on mobile (`text-xs sm:text-sm`)

**Global CSS:**
- Added `overflow-x: hidden` on html/body to prevent horizontal scroll
- Added `max-width: 100%` on media elements to prevent overflow
- Reduced letter-spacing on display font at mobile breakpoints

**ActivityFeed:**
- Timestamp gets `max-w` and `truncate` to prevent overflow

**Footer:**
- CA address box uses `min-w-0` instead of `w-full` to allow shrinking

Closes #824

**Wallet:** 7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU