### PR TITLE
feat: wire activity feed to real API (Closes #822)

### DIFF
--- a/frontend/src/api/activity.ts
+++ b/frontend/src/api/activity.ts
@@ -1,0 +1,16 @@
+import { apiClient } from '../services/apiClient';
+import type { ActivityEvent } from '../components/home/ActivityFeed';
+
+export async function getActivity(): Promise<ActivityEvent[]> {
+  try {
+    const data = await apiClient<ActivityEvent[] | { events: ActivityEvent[] }>(
+      '/api/activity',
+    );
+    // Support both flat array and wrapped shape
+    if (Array.isArray(data)) return data;
+    return (data as { events: ActivityEvent[] }).events ?? [];
+  } catch {
+    // Return empty on error — HomePage will fall back to MOCK_EVENTS
+    return [];
+  }
+}

--- a/frontend/src/hooks/useActivity.ts
+++ b/frontend/src/hooks/useActivity.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+import { getActivity } from '../api/activity';
+
+const POLL_INTERVAL_MS = 30_000;
+
+export function useActivity() {
+  return useQuery({
+    queryKey: ['activity'],
+    queryFn: getActivity,
+    refetchInterval: POLL_INTERVAL_MS,
+    staleTime: POLL_INTERVAL_MS,
+    retry: 1,
+  });
+}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -5,12 +5,15 @@ import { ActivityFeed } from '../components/home/ActivityFeed';
 import { HowItWorksCondensed } from '../components/home/HowItWorksCondensed';
 import { FeaturedBounties } from '../components/home/FeaturedBounties';
 import { WhySolFoundry } from '../components/home/WhySolFoundry';
+import { useActivity } from '../hooks/useActivity';
 
 export function HomePage() {
+  const { data: events } = useActivity();
+
   return (
     <PageLayout noFooter={false}>
       <HeroSection />
-      <ActivityFeed />
+      <ActivityFeed events={events} />
       <HowItWorksCondensed />
       <FeaturedBounties />
       <WhySolFoundry />


### PR DESCRIPTION
## Summary

Wires the hardcoded activity feed on the home page to the real backend API endpoint.

## Changes

- **frontend/src/api/activity.ts** — New API function `getActivity()` that calls `GET /api/activity`. Gracefully returns an empty array on error so the component falls back to mock data.

- **frontend/src/hooks/useActivity.ts** — New `useActivity()` hook using React Query with 30-second polling interval (refetchInterval: 30_000), matching the bounty requirement of auto-refresh every 30 seconds.

- **frontend/src/pages/HomePage.tsx** — Imports and calls `useActivity()`, passing fetched events to the `<ActivityFeed>` component.

## Acceptance Criteria

- [x] Activity feed shows real events from the API (via `useActivity` hook)
- [x] Events update without page refresh (30-second polling via React Query refetchInterval)
- [x] Shows mock fallback events when API is unavailable (existing `ActivityFeed` behavior preserved)

## Bounty Details

- **Issue:** #822
- **Tier:** T1 (Open Race)
- **Reward:** 150,000 $FNDRY
- **Domain:** Frontend

## Wallet

7UqBdYyy9LG59Un6yzjAW8HPcTC4J63B9cZxBHWhhHsg
