### PR TITLE
Wire home activity feed to API data

### DIFF
--- a/frontend/src/api/activity.ts
+++ b/frontend/src/api/activity.ts
@@ -1,0 +1,52 @@
+import { apiClient } from '../services/apiClient';
+
+export type ActivityEventType = 'completed' | 'submitted' | 'posted' | 'review' | 'payout';
+
+export interface ActivityEvent {
+  id: string;
+  type: ActivityEventType;
+  username: string;
+  avatar_url?: string | null;
+  detail: string;
+  timestamp: string;
+}
+
+type RawActivityEvent = Partial<ActivityEvent> & {
+  user?: string;
+  actor?: string;
+  actor_username?: string;
+  avatar?: string | null;
+  created_at?: string;
+  occurred_at?: string;
+  message?: string;
+  description?: string;
+  bounty_title?: string;
+  amount?: number;
+  token?: string;
+};
+
+function normalizeActivityEvent(event: RawActivityEvent, index: number): ActivityEvent {
+  const timestamp = event.timestamp ?? event.created_at ?? event.occurred_at ?? new Date().toISOString();
+  const username = event.username ?? event.actor_username ?? event.actor ?? event.user ?? 'SolFoundry';
+  const amountDetail = event.amount && event.token ? `${event.amount.toLocaleString()} ${event.token}` : undefined;
+
+  return {
+    id: event.id ?? `${timestamp}-${index}`,
+    type: event.type ?? 'posted',
+    username,
+    avatar_url: event.avatar_url ?? event.avatar ?? null,
+    detail: event.detail ?? event.message ?? event.description ?? event.bounty_title ?? amountDetail ?? 'bounty activity',
+    timestamp,
+  };
+}
+
+export async function listActivityEvents(): Promise<ActivityEvent[]> {
+  const response = await apiClient<RawActivityEvent[] | { items?: RawActivityEvent[]; events?: RawActivityEvent[] }>(
+    '/api/activity',
+    { retries: 1, timeoutMs: 8_000 },
+  );
+
+  const events = Array.isArray(response) ? response : response.items ?? response.events ?? [];
+
+  return events.map(normalizeActivityEvent);
+}

--- a/frontend/src/components/home/ActivityFeed.tsx
+++ b/frontend/src/components/home/ActivityFeed.tsx
@@ -2,47 +2,8 @@ import React, { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { slideInRight } from '../../lib/animations';
 import { timeAgo } from '../../lib/utils';
-
-interface ActivityEvent {
-  id: string;
-  type: 'completed' | 'submitted' | 'posted' | 'review';
-  username: string;
-  avatar_url?: string | null;
-  detail: string;
-  timestamp: string;
-}
-
-// Mock events for when API doesn't return activity
-const MOCK_EVENTS: ActivityEvent[] = [
-  {
-    id: '1',
-    type: 'completed',
-    username: 'devbuilder',
-    detail: '$500 USDC from Bounty #42',
-    timestamp: new Date(Date.now() - 3 * 60 * 1000).toISOString(),
-  },
-  {
-    id: '2',
-    type: 'submitted',
-    username: 'KodeSage',
-    detail: 'PR to Bounty #38',
-    timestamp: new Date(Date.now() - 15 * 60 * 1000).toISOString(),
-  },
-  {
-    id: '3',
-    type: 'posted',
-    username: 'SolanaLabs',
-    detail: 'Bounty #145 — $3,500 USDC',
-    timestamp: new Date(Date.now() - 45 * 60 * 1000).toISOString(),
-  },
-  {
-    id: '4',
-    type: 'review',
-    username: 'AI Review',
-    detail: 'Bounty #42 — 8.5/10',
-    timestamp: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
-  },
-];
+import { useActivityFeed } from '../../hooks/useActivityFeed';
+import type { ActivityEvent } from '../../api/activity';
 
 function getActionText(type: ActivityEvent['type']) {
   switch (type) {
@@ -50,6 +11,7 @@ function getActionText(type: ActivityEvent['type']) {
     case 'submitted': return 'submitted';
     case 'posted': return 'posted';
     case 'review': return 'AI Review passed for';
+    case 'payout': return 'paid';
     default: return 'updated';
   }
 }
@@ -76,12 +38,17 @@ function EventItem({ event }: { event: ActivityEvent }) {
 }
 
 export function ActivityFeed({ events }: { events?: ActivityEvent[] }) {
-  const displayEvents = events?.length ? events.slice(0, 4) : MOCK_EVENTS;
+  const activityQuery = useActivityFeed();
+  const isControlled = events !== undefined;
+  const displayEvents = isControlled ? events : activityQuery.data ?? [];
   const [visibleEvents, setVisibleEvents] = useState<ActivityEvent[]>(displayEvents.slice(0, 4));
 
   useEffect(() => {
     setVisibleEvents(displayEvents.slice(0, 4));
-  }, [events]);
+  }, [displayEvents]);
+
+  const isUnavailable = !isControlled && activityQuery.isError;
+  const isEmpty = !isUnavailable && !activityQuery.isLoading && visibleEvents.length === 0;
 
   return (
     <section className="w-full border-y border-border bg-forge-900/50 py-4 overflow-hidden">
@@ -91,20 +58,31 @@ export function ActivityFeed({ events }: { events?: ActivityEvent[] }) {
           <span className="font-mono text-xs text-text-muted uppercase tracking-wider">Recent Activity</span>
         </div>
         <div className="space-y-1">
-          <AnimatePresence mode="popLayout">
-            {visibleEvents.map((event) => (
-              <motion.div
-                key={event.id}
-                variants={slideInRight}
-                initial="initial"
-                animate="animate"
-                exit={{ opacity: 0, x: -20, transition: { duration: 0.2 } }}
-                layout
-              >
-                <EventItem event={event} />
-              </motion.div>
-            ))}
-          </AnimatePresence>
+          {activityQuery.isLoading && !isControlled ? (
+            <p className="px-3 py-2 text-sm text-text-muted">Loading recent activity...</p>
+          ) : null}
+          {isUnavailable ? (
+            <p className="px-3 py-2 text-sm text-text-muted">Activity feed is temporarily unavailable.</p>
+          ) : null}
+          {isEmpty ? (
+            <p className="px-3 py-2 text-sm text-text-muted">No recent activity.</p>
+          ) : null}
+          {!activityQuery.isLoading && !isUnavailable && visibleEvents.length > 0 ? (
+            <AnimatePresence mode="popLayout">
+              {visibleEvents.map((event) => (
+                <motion.div
+                  key={event.id}
+                  variants={slideInRight}
+                  initial="initial"
+                  animate="animate"
+                  exit={{ opacity: 0, x: -20, transition: { duration: 0.2 } }}
+                  layout
+                >
+                  <EventItem event={event} />
+                </motion.div>
+              ))}
+            </AnimatePresence>
+          ) : null}
         </div>
       </div>
     </section>

--- a/frontend/src/hooks/useActivityFeed.ts
+++ b/frontend/src/hooks/useActivityFeed.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { listActivityEvents } from '../api/activity';
+
+export function useActivityFeed() {
+  return useQuery({
+    queryKey: ['activity-feed'],
+    queryFn: listActivityEvents,
+    refetchInterval: 30_000,
+    staleTime: 15_000,
+    retry: 1,
+  });
+}

--- a/frontend/src/lib/animations.ts
+++ b/frontend/src/lib/animations.ts
@@ -1,0 +1,43 @@
+import type { Variants } from 'framer-motion';
+
+const easeOut = [0.16, 1, 0.3, 1] as const;
+
+export const fadeIn: Variants = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.35, ease: easeOut } },
+};
+
+export const slideInRight: Variants = {
+  initial: { opacity: 0, x: 24 },
+  animate: { opacity: 1, x: 0, transition: { duration: 0.3, ease: easeOut } },
+};
+
+export const staggerContainer: Variants = {
+  animate: {
+    transition: {
+      staggerChildren: 0.08,
+    },
+  },
+};
+
+export const staggerItem: Variants = {
+  initial: { opacity: 0, y: 10 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.25, ease: easeOut } },
+};
+
+export const cardHover: Variants = {
+  rest: { y: 0, borderColor: 'rgba(82, 82, 110, 0.55)' },
+  hover: {
+    y: -3,
+    borderColor: 'rgba(52, 211, 153, 0.45)',
+    transition: { duration: 0.18, ease: easeOut },
+  },
+};
+
+export const buttonHover: Variants = {
+  rest: { scale: 1 },
+  hover: { scale: 1.03, transition: { duration: 0.16, ease: easeOut } },
+  tap: { scale: 0.98 },
+};
+
+export const pageTransition = fadeIn;

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,63 @@
+import { twMerge } from 'tailwind-merge';
+
+export const LANG_COLORS: Record<string, string> = {
+  TypeScript: '#3178c6',
+  JavaScript: '#f7df1e',
+  Rust: '#dea584',
+  Solana: '#14f195',
+  React: '#61dafb',
+  Python: '#3776ab',
+  Go: '#00add8',
+  Backend: '#9b87f5',
+  Frontend: '#34d399',
+};
+
+export function cn(...classes: Array<string | false | null | undefined>) {
+  return twMerge(classes.filter(Boolean).join(' '));
+}
+
+export function formatCurrency(amount: number, token: string) {
+  const compact = amount >= 1_000_000
+    ? `${(amount / 1_000_000).toFixed(amount % 1_000_000 === 0 ? 0 : 1)}M`
+    : amount >= 1_000
+      ? `${(amount / 1_000).toFixed(amount % 1_000 === 0 ? 0 : 1)}K`
+      : amount.toLocaleString();
+
+  return `${compact} ${token}`;
+}
+
+export function timeAgo(date: string) {
+  const timestamp = new Date(date).getTime();
+  const seconds = Math.max(0, Math.floor((Date.now() - timestamp) / 1000));
+
+  if (seconds < 60) return 'just now';
+
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo ago`;
+
+  return `${Math.floor(months / 12)}y ago`;
+}
+
+export function timeLeft(date: string) {
+  const diff = new Date(date).getTime() - Date.now();
+
+  if (diff <= 0) return 'Expired';
+
+  const minutes = Math.floor(diff / 60000);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+
+  if (days > 0) return `${days}d ${hours % 24}h left`;
+  if (hours > 0) return `${hours}h ${minutes % 60}m left`;
+
+  return `${Math.max(1, minutes)}m left`;
+}


### PR DESCRIPTION
Closes #822

## Summary
- Adds `/api/activity` client normalization for activity events
- Adds a React Query hook that refreshes activity every 30 seconds
- Updates the home activity feed to use live API data by default
- Shows empty and unavailable states instead of hardcoded mock activity
- Includes missing frontend helper modules required by existing imports

## Validation
- `npm run build` from `frontend/`