### PR TITLE
fix: polish mobile responsive layouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,8 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
-lib64/
+/lib/
+/lib64/
 parts/
 sdist/
 var/

--- a/frontend/src/__tests__/Navbar.test.tsx
+++ b/frontend/src/__tests__/Navbar.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { Navbar } from '../components/layout/Navbar';
+
+vi.mock('../hooks/useAuth', () => ({
+  useAuth: () => ({
+    user: null,
+    isAuthenticated: false,
+    logout: vi.fn(),
+  }),
+}));
+
+vi.mock('../hooks/useStats', () => ({
+  useStats: () => ({
+    data: { open_bounties: 12 },
+  }),
+}));
+
+vi.mock('../api/auth', () => ({
+  getGitHubAuthorizeUrl: vi.fn(),
+}));
+
+function renderNavbar(initialPath = '/') {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route
+          path="*"
+          element={
+            <>
+              <Navbar />
+              <div>page content</div>
+            </>
+          }
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('Navbar mobile menu', () => {
+  beforeEach(() => {
+    window.scrollTo = vi.fn();
+  });
+
+  it('toggles the mobile menu and closes it after navigation', async () => {
+    const user = userEvent.setup();
+    renderNavbar('/');
+
+    const toggle = screen.getByRole('button', { name: /open navigation menu/i });
+    await user.click(toggle);
+
+    const leaderboardLink = screen.getAllByRole('link', { name: 'Leaderboard' }).find((link) =>
+      link.closest('div')?.className.includes('flex flex-col'),
+    );
+
+    expect(leaderboardLink).toBeDefined();
+    await user.click(leaderboardLink!);
+
+    expect(screen.queryByRole('button', { name: /close navigation menu/i })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/bounty/BountyCard.tsx
+++ b/frontend/src/components/bounty/BountyCard.tsx
@@ -61,7 +61,7 @@ export function BountyCard({ bounty }: BountyCardProps) {
       initial="rest"
       whileHover="hover"
       onClick={() => navigate(`/bounties/${bounty.id}`)}
-      className="relative rounded-xl border border-border bg-forge-900 p-5 cursor-pointer transition-colors duration-200 overflow-hidden group"
+      className="group relative cursor-pointer overflow-hidden rounded-xl border border-border bg-forge-900 p-5 transition-colors duration-200"
     >
       {/* Row 1: Repo + Tier */}
       <div className="flex items-center justify-between text-sm">
@@ -84,7 +84,7 @@ export function BountyCard({ bounty }: BountyCardProps) {
 
       {/* Row 3: Language dots */}
       {skills.length > 0 && (
-        <div className="flex items-center gap-3 mt-3">
+        <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-2">
           {skills.map((lang) => (
             <span key={lang} className="inline-flex items-center gap-1.5 text-xs text-text-muted">
               <span
@@ -101,11 +101,17 @@ export function BountyCard({ bounty }: BountyCardProps) {
       <div className="mt-4 border-t border-border/50" />
 
       {/* Row 4: Reward + Meta */}
-      <div className="flex items-center justify-between mt-3">
-        <span className="font-mono text-lg font-semibold text-emerald">
-          {formatCurrency(bounty.reward_amount, bounty.reward_token)}
-        </span>
-        <div className="flex items-center gap-3 text-xs text-text-muted">
+      <div className="mt-3 flex flex-col gap-3">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <span className="font-mono text-lg font-semibold text-emerald">
+            {formatCurrency(bounty.reward_amount, bounty.reward_token)}
+          </span>
+          <span className={`text-xs font-medium inline-flex items-center gap-1 ${statusColor}`}>
+            <span className={`w-1.5 h-1.5 rounded-full ${dotColor}`} />
+            {statusLabel}
+          </span>
+        </div>
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-2 text-xs text-text-muted">
           <span className="inline-flex items-center gap-1">
             <GitPullRequest className="w-3.5 h-3.5" />
             {bounty.submission_count} PRs
@@ -118,12 +124,6 @@ export function BountyCard({ bounty }: BountyCardProps) {
           )}
         </div>
       </div>
-
-      {/* Status badge */}
-      <span className={`absolute bottom-4 right-5 text-xs font-medium inline-flex items-center gap-1 ${statusColor}`}>
-        <span className={`w-1.5 h-1.5 rounded-full ${dotColor}`} />
-        {statusLabel}
-      </span>
     </motion.div>
   );
 }

--- a/frontend/src/components/bounty/BountyCreateWizard.tsx
+++ b/frontend/src/components/bounty/BountyCreateWizard.tsx
@@ -306,7 +306,7 @@ function Step3({
     <div className="space-y-5">
       <div>
         <p className="text-sm text-text-secondary mb-3">Send USDC to the following address:</p>
-        <div className="font-mono text-sm bg-forge-700 border border-border rounded-lg px-4 py-3 flex items-center justify-between gap-3">
+        <div className="flex items-center justify-between gap-3 rounded-lg border border-border bg-forge-700 px-4 py-3 font-mono text-sm">
           <span className="truncate text-text-primary">{treasuryAddress}</span>
           <button
             onClick={copyAddr}
@@ -325,7 +325,7 @@ function Step3({
 
       <div>
         <label className="block text-sm font-medium text-text-secondary mb-2">Paste Transaction Signature</label>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
           <input
             type="text"
             value={state.tx_signature}
@@ -337,7 +337,7 @@ function Step3({
           <button
             onClick={handleVerify}
             disabled={!state.tx_signature.trim() || verifying || state.verified || !state.bounty_id}
-            className="px-4 py-3 rounded-lg bg-emerald text-text-inverse font-semibold text-sm hover:bg-emerald-light transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-1.5 whitespace-nowrap"
+            className="flex w-full items-center justify-center gap-1.5 whitespace-nowrap rounded-lg bg-emerald px-4 py-3 text-sm font-semibold text-text-inverse transition-colors duration-200 hover:bg-emerald-light disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto"
           >
             {verifying ? <Loader2 className="w-4 h-4 animate-spin" /> : state.verified ? <Check className="w-4 h-4" /> : null}
             {state.verified ? 'Verified' : verifying ? 'Verifying...' : 'Verify Payment'}

--- a/frontend/src/components/bounty/BountyDetail.tsx
+++ b/frontend/src/components/bounty/BountyDetail.tsx
@@ -36,9 +36,9 @@ export function BountyDetail({ bounty }: BountyDetailProps) {
         <div className="lg:col-span-2 space-y-6">
           {/* Title + meta */}
           <div className="rounded-xl border border-border bg-forge-900 p-6">
-            <div className="flex items-start justify-between gap-4 mb-4">
-              <div className="flex-1">
-                <div className="flex items-center gap-2 mb-3 text-xs font-mono text-text-muted">
+            <div className="mb-4 flex items-start justify-between gap-4">
+              <div className="flex-1 min-w-0">
+                <div className="mb-3 flex flex-wrap items-center gap-2 break-all text-xs font-mono text-text-muted">
                   {bounty.org_avatar_url && (
                     <img src={bounty.org_avatar_url} alt="" className="w-4 h-4 rounded-full" />
                   )}
@@ -57,7 +57,7 @@ export function BountyDetail({ bounty }: BountyDetailProps) {
 
             {/* Skills */}
             {bounty.skills?.length > 0 && (
-              <div className="flex items-center gap-3 mb-4">
+              <div className="mb-4 flex flex-wrap items-center gap-x-3 gap-y-2">
                 {bounty.skills.map((lang) => (
                   <span key={lang} className="inline-flex items-center gap-1.5 text-xs text-text-muted">
                     <span className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: LANG_COLORS[lang] ?? '#888' }} />
@@ -125,33 +125,33 @@ export function BountyDetail({ bounty }: BountyDetailProps) {
 
           {/* Info card */}
           <div className="rounded-xl border border-border bg-forge-900 p-5 space-y-4">
-            <div className="flex items-center justify-between text-sm">
+            <div className="flex items-start justify-between gap-3 text-sm">
               <span className="text-text-muted">Status</span>
-              <span className={`font-medium ${bounty.status === 'open' ? 'text-emerald' : 'text-magenta'}`}>
+              <span className={`text-right font-medium ${bounty.status === 'open' ? 'text-emerald' : 'text-magenta'}`}>
                 {bounty.status}
               </span>
             </div>
-            <div className="flex items-center justify-between text-sm">
+            <div className="flex items-start justify-between gap-3 text-sm">
               <span className="text-text-muted">Tier</span>
               <span className="font-mono text-text-primary">{bounty.tier ?? 'T1'}</span>
             </div>
             {bounty.deadline && (
-              <div className="flex items-center justify-between text-sm">
+              <div className="flex items-start justify-between gap-3 text-sm">
                 <span className="text-text-muted">Deadline</span>
-                <span className="font-mono text-status-warning inline-flex items-center gap-1">
+                <span className="font-mono text-status-warning inline-flex items-center gap-1 text-right">
                   <Clock className="w-3.5 h-3.5" /> {timeLeft(bounty.deadline)}
                 </span>
               </div>
             )}
-            <div className="flex items-center justify-between text-sm">
+            <div className="flex items-start justify-between gap-3 text-sm">
               <span className="text-text-muted">Submissions</span>
               <span className="font-mono text-text-primary inline-flex items-center gap-1">
                 <GitPullRequest className="w-3.5 h-3.5" /> {bounty.submission_count}
               </span>
             </div>
-            <div className="flex items-center justify-between text-sm">
+            <div className="flex items-start justify-between gap-3 text-sm">
               <span className="text-text-muted">Posted</span>
-              <span className="font-mono text-text-muted">{timeAgo(bounty.created_at)}</span>
+              <span className="text-right font-mono text-text-muted">{timeAgo(bounty.created_at)}</span>
             </div>
           </div>
         </div>

--- a/frontend/src/components/bounty/BountyGrid.tsx
+++ b/frontend/src/components/bounty/BountyGrid.tsx
@@ -26,22 +26,22 @@ export function BountyGrid() {
     <section id="bounties" className="py-16 md:py-24">
       <div className="max-w-7xl mx-auto px-4">
         {/* Header row */}
-        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-8">
+        <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <h2 className="font-sans text-2xl font-semibold text-text-primary">Open Bounties</h2>
-          <div className="flex items-center gap-2">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
             <Link
               to="/bounties/create"
-              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-emerald text-forge-950 font-semibold text-sm hover:bg-emerald/90 transition-colors duration-150"
+              className="inline-flex items-center justify-center gap-1.5 rounded-lg bg-emerald px-3 py-2 text-sm font-semibold text-forge-950 transition-colors duration-150 hover:bg-emerald/90"
             >
               <Plus className="w-4 h-4" />
               Post a Bounty
             </Link>
             {/* Status filter */}
-            <div className="relative">
+            <div className="relative sm:min-w-[140px]">
               <select
                 value={statusFilter}
                 onChange={(e) => setStatusFilter(e.target.value)}
-                className="appearance-none bg-forge-800 border border-border rounded-lg px-3 py-1.5 pr-8 text-sm text-text-secondary font-medium focus:border-emerald outline-none transition-colors duration-150 cursor-pointer"
+                className="w-full cursor-pointer appearance-none rounded-lg border border-border bg-forge-800 px-3 py-2 pr-8 text-sm font-medium text-text-secondary outline-none transition-colors duration-150 focus:border-emerald"
               >
                 <option value="open">Open</option>
                 <option value="funded">Funded</option>
@@ -54,7 +54,7 @@ export function BountyGrid() {
         </div>
 
         {/* Filter pills */}
-        <div className="flex items-center gap-2 flex-wrap mb-8">
+        <div className="mb-8 flex flex-wrap items-center gap-2">
           {FILTER_SKILLS.map((skill) => (
             <button
               key={skill}

--- a/frontend/src/components/home/HeroSection.tsx
+++ b/frontend/src/components/home/HeroSection.tsx
@@ -87,7 +87,7 @@ export function HeroSection() {
   };
 
   return (
-    <section className="relative min-h-[90vh] flex flex-col items-center justify-center px-4 pt-24 pb-16 overflow-hidden">
+    <section className="relative min-h-[90vh] flex flex-col items-center justify-center overflow-hidden px-4 pb-16 pt-24">
       {/* Background layers */}
       <div className="absolute inset-0 bg-grid-forge bg-grid-forge pointer-events-none" style={{ backgroundSize: '40px 40px' }} />
       <div className="absolute inset-0 bg-gradient-hero pointer-events-none" />
@@ -98,7 +98,7 @@ export function HeroSection() {
         variants={fadeIn}
         initial="initial"
         animate="animate"
-        className="w-full max-w-xl rounded-xl border border-border bg-forge-900/90 backdrop-blur-sm overflow-hidden shadow-2xl shadow-black/50"
+        className="w-full max-w-xl overflow-hidden rounded-xl border border-border bg-forge-900/90 shadow-2xl shadow-black/50 backdrop-blur-sm"
       >
         {/* Title bar */}
         <div className="flex items-center gap-2 px-4 py-2.5 bg-forge-800 border-b border-border">
@@ -111,10 +111,13 @@ export function HeroSection() {
         </div>
 
         {/* Terminal body */}
-        <div className="p-5 font-mono text-sm leading-relaxed">
-          <div className="overflow-hidden">
+        <div className="p-4 sm:p-5 font-mono text-xs leading-relaxed sm:text-sm">
+          <div className="overflow-x-auto">
             <span className="text-emerald">$ </span>
-            <span className="text-text-secondary overflow-hidden whitespace-nowrap inline-block animate-typewriter">
+            <span className="hidden text-text-secondary overflow-hidden whitespace-nowrap sm:inline-block animate-typewriter">
+              forge bounty --reward 100 --lang typescript --tier 2
+            </span>
+            <span className="text-text-secondary break-all sm:hidden">
               forge bounty --reward 100 --lang typescript --tier 2
             </span>
             {typewriterDone && (
@@ -154,7 +157,7 @@ export function HeroSection() {
         initial={{ opacity: 0, y: 16 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ delay: 0.3, duration: 0.5 }}
-        className="font-display text-4xl md:text-5xl font-bold text-text-primary tracking-wider text-center mt-10"
+        className="mt-10 text-center font-display text-3xl font-bold tracking-wide text-text-primary sm:text-4xl md:text-5xl"
       >
         THE AI-POWERED BOUNTY{' '}
         <span className="text-emerald">FORGE</span>
@@ -164,7 +167,7 @@ export function HeroSection() {
         initial={{ opacity: 0, y: 12 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ delay: 0.45, duration: 0.5 }}
-        className="font-sans text-lg text-text-secondary text-center mt-4 max-w-lg"
+        className="mt-4 max-w-lg text-center font-sans text-base text-text-secondary sm:text-lg"
       >
         Fund bounties. Ship code. Earn rewards.
       </motion.p>
@@ -211,7 +214,7 @@ export function HeroSection() {
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         transition={{ delay: 0.8, duration: 0.5 }}
-        className="flex items-center justify-center gap-6 mt-8 font-mono text-sm text-text-muted"
+        className="mt-8 flex flex-wrap items-center justify-center gap-x-4 gap-y-2 text-center font-mono text-sm text-text-muted sm:gap-6"
       >
         <span>
           <span className="text-text-primary font-semibold">

--- a/frontend/src/components/how-it-works/FlowTabs.tsx
+++ b/frontend/src/components/how-it-works/FlowTabs.tsx
@@ -188,7 +188,7 @@ function StepFlow({ steps, color = 'emerald' }: { steps: Step[]; color?: 'emeral
           <p className="mt-2 text-sm text-text-secondary leading-relaxed">{step.description}</p>
 
           {/* Terminal snippet */}
-          <div className="mt-3 rounded-lg bg-forge-800 border border-border px-3 py-2">
+          <div className="mt-3 overflow-x-auto rounded-lg border border-border bg-forge-800 px-3 py-2">
             <code className={`font-mono text-xs ${step.isMagenta ? 'text-magenta' : 'text-emerald'}`}>
               {step.snippet}
             </code>
@@ -205,10 +205,10 @@ export function FlowTabs() {
   return (
     <div>
       {/* Tab switcher */}
-      <div className="flex items-center gap-1 p-1 rounded-xl bg-forge-800 mx-auto w-fit mb-12">
+      <div className="mx-auto mb-12 flex w-full max-w-md flex-col gap-1 rounded-xl bg-forge-800 p-1 sm:w-fit sm:max-w-none sm:flex-row sm:items-center">
         <button
           onClick={() => setActiveTab('usdc')}
-          className={`px-5 py-2.5 rounded-lg text-sm font-semibold transition-all duration-200 ${
+          className={`rounded-lg px-5 py-2.5 text-sm font-semibold transition-all duration-200 ${
             activeTab === 'usdc'
               ? 'bg-emerald text-text-inverse'
               : 'text-text-muted hover:text-text-secondary'
@@ -218,7 +218,7 @@ export function FlowTabs() {
         </button>
         <button
           onClick={() => setActiveTab('fndry')}
-          className={`px-5 py-2.5 rounded-lg text-sm font-semibold transition-all duration-200 ${
+          className={`rounded-lg px-5 py-2.5 text-sm font-semibold transition-all duration-200 ${
             activeTab === 'fndry'
               ? 'bg-magenta text-text-inverse'
               : 'text-text-muted hover:text-text-secondary'

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -33,6 +33,11 @@ export function Navbar() {
     return () => window.removeEventListener('scroll', onScroll);
   }, []);
 
+  useEffect(() => {
+    setMenuOpen(false);
+    setDropdownOpen(false);
+  }, [location.pathname]);
+
   const handleGitHubSignIn = async () => {
     try {
       const url = await getGitHubAuthorizeUrl();
@@ -61,16 +66,16 @@ export function Navbar() {
         }`}
       />
 
-      <div className="max-w-7xl mx-auto h-full px-4 flex items-center justify-between">
+      <div className="max-w-7xl mx-auto h-full px-4 flex items-center justify-between gap-3">
         {/* Left: Logo + Nav */}
-        <div className="flex items-center gap-8">
-          <Link to="/" className="flex items-center gap-2.5 group">
+        <div className="flex items-center gap-4 min-w-0">
+          <Link to="/" className="flex items-center gap-2.5 group min-w-0">
             <img
               src="/logo-icon.png"
               alt="SolFoundry"
               className="w-7 h-7 group-hover:drop-shadow-[0_0_8px_rgba(0,230,118,0.4)] transition-all duration-200"
             />
-            <span className="font-display text-lg font-semibold text-text-primary tracking-wide">
+            <span className="hidden min-[400px]:inline font-display text-lg font-semibold text-text-primary tracking-wide">
               SolFoundry
             </span>
           </Link>
@@ -100,7 +105,7 @@ export function Navbar() {
         </div>
 
         {/* Right: Live count + Auth */}
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-2 sm:gap-3 flex-shrink-0">
           {/* Live bounty count */}
           {stats && (
             <div className="hidden sm:inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-emerald-bg border border-emerald-border">
@@ -113,7 +118,10 @@ export function Navbar() {
           {isAuthenticated && user ? (
             <div className="relative">
               <button
-                onClick={() => setDropdownOpen(!dropdownOpen)}
+                onClick={() => {
+                  setDropdownOpen(!dropdownOpen);
+                  setMenuOpen(false);
+                }}
                 className="flex items-center gap-2 px-2 py-1 rounded-lg hover:bg-forge-800 transition-colors duration-200"
               >
                 {user.avatar_url ? (
@@ -157,17 +165,22 @@ export function Navbar() {
           ) : (
             <button
               onClick={handleGitHubSignIn}
-              className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-forge-800 border border-border hover:border-border-hover text-text-primary text-sm font-medium transition-all duration-200 hover:bg-forge-700"
+              className="inline-flex items-center gap-2 px-3 sm:px-4 py-2 rounded-lg bg-forge-800 border border-border hover:border-border-hover text-text-primary text-sm font-medium transition-all duration-200 hover:bg-forge-700"
             >
               <GitHubIcon />
-              <span className="hidden sm:block">Sign in with GitHub</span>
-              <span className="sm:hidden">Sign in</span>
+              <span className="hidden min-[480px]:block">Sign in with GitHub</span>
+              <span className="hidden min-[400px]:block min-[480px]:hidden">Sign in</span>
             </button>
           )}
 
           {/* Mobile hamburger */}
           <button
-            onClick={() => setMenuOpen(!menuOpen)}
+            onClick={() => {
+              setMenuOpen(!menuOpen);
+              setDropdownOpen(false);
+            }}
+            aria-expanded={menuOpen}
+            aria-label={menuOpen ? 'Close navigation menu' : 'Open navigation menu'}
             className="md:hidden p-2 rounded-lg hover:bg-forge-800 transition-colors text-text-secondary"
           >
             {menuOpen ? <X className="w-5 h-5" /> : <Menu className="w-5 h-5" />}
@@ -190,7 +203,11 @@ export function Navbar() {
                   key={link.to}
                   to={link.to}
                   onClick={() => setMenuOpen(false)}
-                  className="px-4 py-2.5 rounded-lg text-sm font-medium text-text-secondary hover:text-text-primary hover:bg-forge-850 transition-colors duration-150"
+                  className={`px-4 py-3 rounded-lg text-sm font-medium transition-colors duration-150 ${
+                    isActive(link.to)
+                      ? 'bg-forge-850 text-text-primary'
+                      : 'text-text-secondary hover:text-text-primary hover:bg-forge-850'
+                  }`}
                 >
                   {link.label}
                 </Link>

--- a/frontend/src/components/layout/PageLayout.tsx
+++ b/frontend/src/components/layout/PageLayout.tsx
@@ -12,14 +12,14 @@ interface PageLayoutProps {
 
 export function PageLayout({ children, noFooter = false, className = '' }: PageLayoutProps) {
   return (
-    <div className="min-h-screen bg-forge-950 text-text-primary">
+    <div className="min-h-screen overflow-x-clip bg-forge-950 text-text-primary">
       <Navbar />
       <motion.main
         variants={pageTransition}
         initial="initial"
         animate="animate"
         exit="exit"
-        className={`pt-16 ${className}`}
+        className={`overflow-x-clip pt-16 ${className}`}
       >
         {children}
       </motion.main>

--- a/frontend/src/components/leaderboard/LeaderboardTable.tsx
+++ b/frontend/src/components/leaderboard/LeaderboardTable.tsx
@@ -36,10 +36,10 @@ export function LeaderboardTable({ entries }: LeaderboardTableProps) {
       variants={fadeIn}
       initial="initial"
       animate="animate"
-      className="max-w-4xl mx-auto mt-6 rounded-xl border border-border bg-forge-900 overflow-hidden"
+      className="max-w-4xl mx-auto mt-6 overflow-x-auto rounded-xl border border-border bg-forge-900"
     >
       {/* Header */}
-      <div className="flex items-center px-4 py-3 border-b border-border/50 text-xs font-semibold text-text-muted uppercase tracking-wider">
+      <div className="flex min-w-[640px] items-center border-b border-border/50 px-4 py-3 text-xs font-semibold uppercase tracking-wider text-text-muted">
         <div className="w-[60px] text-center">Rank</div>
         <div className="flex-1">User</div>
         <div className="w-[100px] text-center">Bounties</div>
@@ -52,7 +52,7 @@ export function LeaderboardTable({ entries }: LeaderboardTableProps) {
           key={entry.username}
           layout
           layoutId={`leaderboard-${entry.username}`}
-          className="flex items-center px-4 py-3 border-b border-border/30 last:border-b-0 hover:bg-forge-850 transition-colors duration-150 cursor-pointer"
+          className="flex min-w-[640px] cursor-pointer items-center border-b border-border/30 px-4 py-3 transition-colors duration-150 last:border-b-0 hover:bg-forge-850"
         >
           <div className="w-[60px] text-center font-mono text-sm text-text-muted">
             #{entry.rank}

--- a/frontend/src/components/leaderboard/PodiumCards.tsx
+++ b/frontend/src/components/leaderboard/PodiumCards.tsx
@@ -32,7 +32,7 @@ function PodiumCard({ entry, rank }: { entry: LeaderboardEntry; rank: number }) 
   return (
     <motion.div
       variants={staggerItem}
-      className={`relative flex flex-col items-center rounded-xl border bg-forge-900 ${borderClass} ${padding} min-w-[140px]`}
+      className={`relative flex min-w-0 flex-col items-center rounded-xl border bg-forge-900 ${borderClass} ${padding} w-full sm:min-w-[140px]`}
     >
       {/* Crown for #1 */}
       {isGold && (
@@ -55,7 +55,7 @@ function PodiumCard({ entry, rank }: { entry: LeaderboardEntry; rank: number }) 
         </div>
       )}
 
-      <span className="mt-3 font-sans text-sm font-semibold text-text-primary">{entry.username}</span>
+      <span className="mt-3 max-w-full truncate font-sans text-sm font-semibold text-text-primary">{entry.username}</span>
       <span className="mt-1 font-mono text-xs text-text-muted">{entry.bountiesCompleted} bounties</span>
       <span className="mt-1 font-mono text-lg font-semibold text-emerald">
         ${entry.earningsFndry.toLocaleString()}
@@ -84,7 +84,7 @@ export function PodiumCards({ entries }: PodiumCardsProps) {
       variants={staggerContainer}
       initial="initial"
       animate="animate"
-      className="flex items-end justify-center gap-4 md:gap-6 mb-12"
+      className="mb-12 flex flex-col items-stretch justify-center gap-4 sm:flex-row sm:items-end md:gap-6"
     >
       {ordered.map((entry, i) => (
         <PodiumCard key={entry.username} entry={entry} rank={ranks[i]} />

--- a/frontend/src/components/profile/ProfileDashboard.tsx
+++ b/frontend/src/components/profile/ProfileDashboard.tsx
@@ -53,18 +53,20 @@ function MyBountiesTab({ bounties, loading }: { bounties: Bounty[]; loading: boo
         <motion.div
           key={b.id}
           variants={staggerItem}
-          className="flex items-center gap-4 px-4 py-3 rounded-lg bg-forge-900 border border-border hover:bg-forge-850 transition-colors cursor-pointer"
+          className="flex flex-col items-start gap-3 rounded-lg border border-border bg-forge-900 px-4 py-3 transition-colors cursor-pointer hover:bg-forge-850 sm:flex-row sm:items-center"
           onClick={() => window.location.href = `/bounties/${b.id}`}
         >
           <div className="flex-1 min-w-0">
             <p className="text-sm font-medium text-text-primary truncate">{b.title}</p>
             <p className="text-xs text-text-muted mt-0.5">{timeAgo(b.created_at)}</p>
           </div>
-          <span className="font-mono text-sm font-semibold text-emerald">{formatCurrency(b.reward_amount, b.reward_token)}</span>
-          <BountyStatusBadge status={b.status} />
-          <span className="text-xs text-text-muted inline-flex items-center gap-1">
-            <GitPullRequest className="w-3.5 h-3.5" /> {b.submission_count}
-          </span>
+          <div className="flex flex-wrap items-center gap-3">
+            <span className="font-mono text-sm font-semibold text-emerald">{formatCurrency(b.reward_amount, b.reward_token)}</span>
+            <BountyStatusBadge status={b.status} />
+            <span className="text-xs text-text-muted inline-flex items-center gap-1">
+              <GitPullRequest className="w-3.5 h-3.5" /> {b.submission_count}
+            </span>
+          </div>
         </motion.div>
       ))}
     </motion.div>
@@ -86,7 +88,7 @@ function EarningsTab() {
   const totalEarned = MONTHLY_MOCK.reduce((s, m) => s + m.usdc, 0);
   return (
     <div className="space-y-6">
-      <div className="grid grid-cols-3 gap-4">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
         {[
           { label: 'Total Earned', value: `$${totalEarned}`, color: 'text-emerald' },
           { label: 'This Month', value: '$800', color: 'text-emerald' },
@@ -165,7 +167,7 @@ export function ProfileDashboard() {
     <motion.div variants={fadeIn} initial="initial" animate="animate" className="max-w-4xl mx-auto px-4 py-8">
       {/* Header */}
       <div className="rounded-xl border border-border bg-forge-900 p-6 mb-6">
-        <div className="flex items-start gap-5">
+        <div className="flex flex-col items-start gap-5 sm:flex-row">
           {user.avatar_url ? (
             <img src={user.avatar_url} className="w-16 h-16 rounded-full border-2 border-border" alt={user.username} />
           ) : (
@@ -182,7 +184,7 @@ export function ProfileDashboard() {
         </div>
 
         {/* Tab switcher */}
-        <div className="flex items-center gap-1 p-1 rounded-lg bg-forge-800 mt-6 w-fit">
+        <div className="mt-6 flex flex-wrap items-center gap-1 rounded-lg bg-forge-800 p-1">
           {TABS.map((tab) => (
             <button
               key={tab}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -115,6 +115,7 @@
 html {
   scroll-behavior: smooth;
   font-size: 16px;
+  overflow-x: hidden;
 }
 
 body {
@@ -123,6 +124,7 @@ body {
   -moz-osx-font-smoothing: grayscale;
   background-color: #050505;
   color: #F0F0F5;
+  overflow-x: hidden;
 }
 
 /* Custom scrollbar */

--- a/frontend/src/lib/animations.ts
+++ b/frontend/src/lib/animations.ts
@@ -1,0 +1,39 @@
+import type { Variants } from 'framer-motion';
+
+export const fadeIn: Variants = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.3, ease: 'easeOut' } },
+  exit: { opacity: 0, y: 8, transition: { duration: 0.2, ease: 'easeIn' } },
+};
+
+export const pageTransition: Variants = {
+  initial: { opacity: 0, y: 10 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.25, ease: 'easeOut' } },
+  exit: { opacity: 0, y: -8, transition: { duration: 0.18, ease: 'easeIn' } },
+};
+
+export const staggerContainer: Variants = {
+  initial: {},
+  animate: { transition: { staggerChildren: 0.06 } },
+};
+
+export const staggerItem: Variants = {
+  initial: { opacity: 0, y: 10 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.25, ease: 'easeOut' } },
+};
+
+export const cardHover: Variants = {
+  rest: { y: 0, scale: 1 },
+  hover: { y: -3, scale: 1.01, transition: { duration: 0.18, ease: 'easeOut' } },
+};
+
+export const buttonHover: Variants = {
+  rest: { scale: 1 },
+  hover: { scale: 1.03, transition: { duration: 0.15, ease: 'easeOut' } },
+  tap: { scale: 0.98 },
+};
+
+export const slideInRight: Variants = {
+  initial: { opacity: 0, x: 20 },
+  animate: { opacity: 1, x: 0, transition: { duration: 0.25, ease: 'easeOut' } },
+};

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,70 @@
+export const LANG_COLORS: Record<string, string> = {
+  TypeScript: '#3178C6',
+  JavaScript: '#F7DF1E',
+  React: '#61DAFB',
+  Rust: '#DEA584',
+  Solidity: '#AA6746',
+  Python: '#3572A5',
+  Go: '#00ADD8',
+  UI: '#E879F9',
+  Frontend: '#00E676',
+  Backend: '#F59E0B',
+  Solana: '#9945FF',
+};
+
+export function formatCurrency(amount?: number | string | null, token = 'USDC') {
+  const value = Number(amount ?? 0);
+  const compact = new Intl.NumberFormat('en-US', {
+    notation: Math.abs(value) >= 1000 ? 'compact' : 'standard',
+    maximumFractionDigits: value >= 1000 ? 1 : 2,
+  }).format(value);
+
+  if (token?.toUpperCase() === 'USDC') return `$${compact}`;
+  return `${compact} ${token}`;
+}
+
+export function timeAgo(dateLike?: string | number | Date | null) {
+  if (!dateLike) return '—';
+  const time = new Date(dateLike).getTime();
+  if (Number.isNaN(time)) return '—';
+
+  const diffMs = Date.now() - time;
+  const future = diffMs < 0;
+  const seconds = Math.max(0, Math.abs(diffMs) / 1000);
+
+  const units: Array<[Intl.RelativeTimeFormatUnit, number]> = [
+    ['year', 31536000],
+    ['month', 2592000],
+    ['week', 604800],
+    ['day', 86400],
+    ['hour', 3600],
+    ['minute', 60],
+  ];
+
+  const rtf = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
+  for (const [unit, unitSeconds] of units) {
+    if (seconds >= unitSeconds) {
+      const count = Math.round(seconds / unitSeconds);
+      return rtf.format(future ? count : -count, unit);
+    }
+  }
+  return future ? 'soon' : 'just now';
+}
+
+export function timeLeft(dateLike?: string | number | Date | null) {
+  if (!dateLike) return '—';
+  const deadline = new Date(dateLike).getTime();
+  if (Number.isNaN(deadline)) return '—';
+
+  const diffMs = deadline - Date.now();
+  if (diffMs <= 0) return 'Expired';
+
+  const totalMinutes = Math.ceil(diffMs / 60000);
+  const days = Math.floor(totalMinutes / 1440);
+  const hours = Math.floor((totalMinutes % 1440) / 60);
+  const minutes = totalMinutes % 60;
+
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  return `${minutes}m`;
+}

--- a/frontend/src/pages/LeaderboardPage.tsx
+++ b/frontend/src/pages/LeaderboardPage.tsx
@@ -27,8 +27,8 @@ export function LeaderboardPage() {
         </div>
 
         {/* Time filter */}
-        <div className="flex items-center justify-center mb-10">
-          <div className="flex items-center gap-1 p-1 rounded-lg bg-forge-800">
+        <div className="mb-10 flex items-center justify-center">
+          <div className="flex flex-wrap items-center justify-center gap-1 rounded-lg bg-forge-800 p-1">
             {PERIODS.map((p) => (
               <button
                 key={p.value}


### PR DESCRIPTION
## Summary
- Polish mobile layouts for bounty cards, bounty detail metadata, hero terminal, navigation, leaderboard, profile, and bounty creation flows
- Prevent horizontal overflow at small widths while keeping desktop layouts intact
- Add focused coverage for mobile navbar menu behavior
- Restore tracked frontend shared helpers used across the app and narrow the broad Python `lib/` ignore rule so `frontend/src/lib` can be committed

## Verification
- `npm run build`
- `npm run test -- Navbar.test.tsx`
- Headless Chrome overflow check at mobile/tablet widths for `/`, `/bounties`, `/leaderboard`, `/how-it-works`, `/bounties/create`: no horizontal overflow detected

Closes #833

## Payout
Solana wallet: `7asDntRHyEkZmZpyArYTvEp7y6PXHXZFkFNmiitozvrL`
