### PR TITLE
feat: add bounty search bar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
+/lib/
 lib64/
 parts/
 sdist/

--- a/frontend/src/__tests__/bounty-grid-search.test.tsx
+++ b/frontend/src/__tests__/bounty-grid-search.test.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BountyGrid } from '../components/bounty/BountyGrid';
+import { useInfiniteBounties } from '../hooks/useBounties';
+import type { Bounty } from '../types/bounty';
+
+vi.mock('../hooks/useBounties', () => ({
+  useInfiniteBounties: vi.fn(),
+}));
+
+const mockUseInfiniteBounties = vi.mocked(useInfiniteBounties);
+
+const bounties: Bounty[] = [
+  {
+    id: 'bounty-1',
+    title: 'Build Rust indexer',
+    description: 'Parse on-chain settlement events',
+    status: 'open',
+    tier: 'T1',
+    reward_amount: 100000,
+    reward_token: 'FNDRY',
+    org_name: 'SolFoundry',
+    repo_name: 'solfoundry',
+    issue_number: 101,
+    category: 'backend',
+    skills: ['Rust'],
+    submission_count: 0,
+    created_at: '2026-05-01T00:00:00Z',
+  },
+  {
+    id: 'bounty-2',
+    title: 'Polish React bounty cards',
+    description: 'Improve responsive layout and tag spacing',
+    status: 'open',
+    tier: 'T1',
+    reward_amount: 100000,
+    reward_token: 'FNDRY',
+    org_name: 'SolFoundry',
+    repo_name: 'solfoundry',
+    issue_number: 102,
+    category: 'frontend',
+    skills: ['React', 'TypeScript'],
+    submission_count: 2,
+    created_at: '2026-05-01T00:00:00Z',
+  },
+];
+
+function renderGrid() {
+  return render(
+    <MemoryRouter>
+      <BountyGrid />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  mockUseInfiniteBounties.mockReturnValue({
+    data: { pages: [{ items: bounties, total: bounties.length, limit: 12, offset: 0 }], pageParams: [0] },
+    fetchNextPage: vi.fn(),
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    isLoading: false,
+    isError: false,
+  } as unknown as ReturnType<typeof useInfiniteBounties>);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe('BountyGrid search', () => {
+  it('filters loaded bounties with a debounced search query and clears the query', () => {
+    renderGrid();
+
+    expect(screen.getByRole('searchbox', { name: /search bounties/i })).toBeInTheDocument();
+    expect(screen.getByText('Build Rust indexer')).toBeInTheDocument();
+    expect(screen.getByText('Polish React bounty cards')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByRole('searchbox', { name: /search bounties/i }), {
+      target: { value: 'responsive' },
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
+
+    expect(screen.queryByText('Build Rust indexer')).not.toBeInTheDocument();
+    expect(screen.getByText('Polish React bounty cards')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /clear search/i }));
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
+
+    expect(screen.getByText('Build Rust indexer')).toBeInTheDocument();
+    expect(screen.getByText('Polish React bounty cards')).toBeInTheDocument();
+  });
+
+  it('keeps existing status and skill filters in the bounties query', () => {
+    renderGrid();
+
+    expect(mockUseInfiniteBounties).toHaveBeenLastCalledWith({ status: 'open', skill: undefined });
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'funded' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Python' }));
+
+    expect(mockUseInfiniteBounties).toHaveBeenLastCalledWith({ status: 'funded', skill: 'Python' });
+  });
+});

--- a/frontend/src/components/bounty/BountyGrid.tsx
+++ b/frontend/src/components/bounty/BountyGrid.tsx
@@ -1,7 +1,7 @@
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { ChevronDown, Loader2, Plus } from 'lucide-react';
+import { ChevronDown, Loader2, Plus, Search, X } from 'lucide-react';
 import { BountyCard } from './BountyCard';
 import { useInfiniteBounties } from '../../hooks/useBounties';
 import { staggerContainer, staggerItem } from '../../lib/animations';
@@ -11,6 +11,8 @@ const FILTER_SKILLS = ['All', 'TypeScript', 'Rust', 'Solidity', 'Python', 'Go', 
 export function BountyGrid() {
   const [activeSkill, setActiveSkill] = useState<string>('All');
   const [statusFilter, setStatusFilter] = useState<string>('open');
+  const [searchQuery, setSearchQuery] = useState<string>('');
+  const [debouncedSearchQuery, setDebouncedSearchQuery] = useState<string>('');
 
   const params = {
     status: statusFilter,
@@ -20,7 +22,38 @@ export function BountyGrid() {
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, isError } =
     useInfiniteBounties(params);
 
-  const allBounties = data?.pages.flatMap((p) => p.items) ?? [];
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      setDebouncedSearchQuery(searchQuery.trim().toLowerCase());
+    }, 250);
+
+    return () => window.clearTimeout(timeout);
+  }, [searchQuery]);
+
+  const allBounties = useMemo(() => data?.pages.flatMap((p) => p.items) ?? [], [data]);
+
+  const filteredBounties = useMemo(() => {
+    if (!debouncedSearchQuery) return allBounties;
+
+    return allBounties.filter((bounty) => {
+      const issueNumber = bounty.issue_number ? `#${bounty.issue_number}` : '';
+      const searchableText = [
+        bounty.title,
+        bounty.description,
+        bounty.category,
+        bounty.org_name,
+        bounty.repo_name,
+        bounty.github_issue_url,
+        issueNumber,
+        ...bounty.skills,
+      ]
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase();
+
+      return searchableText.includes(debouncedSearchQuery);
+    });
+  }, [allBounties, debouncedSearchQuery]);
 
   return (
     <section id="bounties" className="py-16 md:py-24">
@@ -51,6 +84,29 @@ export function BountyGrid() {
               <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-text-muted pointer-events-none" />
             </div>
           </div>
+        </div>
+
+        {/* Search */}
+        <div className="relative mb-4">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted pointer-events-none" />
+          <input
+            type="search"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="Search bounties by title, description, or tags"
+            aria-label="Search bounties"
+            className="w-full rounded-lg border border-border bg-forge-900 py-2.5 pl-10 pr-10 text-sm text-text-primary placeholder:text-text-muted outline-none transition-colors duration-150 focus:border-emerald"
+          />
+          {searchQuery && (
+            <button
+              type="button"
+              onClick={() => setSearchQuery('')}
+              aria-label="Clear search"
+              className="absolute right-2 top-1/2 -translate-y-1/2 inline-flex h-7 w-7 items-center justify-center rounded-md text-text-muted transition-colors duration-150 hover:bg-forge-800 hover:text-text-primary focus:outline-none focus:ring-2 focus:ring-emerald/60"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          )}
         </div>
 
         {/* Filter pills */}
@@ -93,17 +149,19 @@ export function BountyGrid() {
         )}
 
         {/* Empty state */}
-        {!isLoading && !isError && allBounties.length === 0 && (
+        {!isLoading && !isError && filteredBounties.length === 0 && (
           <div className="text-center py-16">
             <p className="text-text-muted text-lg mb-2">No bounties found</p>
             <p className="text-text-muted text-sm">
-              {activeSkill !== 'All' ? `Try a different language filter.` : 'Check back soon for new bounties.'}
+              {debouncedSearchQuery || activeSkill !== 'All'
+                ? 'Try a different search or filter.'
+                : 'Check back soon for new bounties.'}
             </p>
           </div>
         )}
 
         {/* Bounty grid */}
-        {!isLoading && allBounties.length > 0 && (
+        {!isLoading && filteredBounties.length > 0 && (
           <motion.div
             variants={staggerContainer}
             initial="initial"
@@ -111,7 +169,7 @@ export function BountyGrid() {
             viewport={{ once: true, margin: '-50px' }}
             className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5"
           >
-            {allBounties.map((bounty) => (
+            {filteredBounties.map((bounty) => (
               <motion.div key={bounty.id} variants={staggerItem}>
                 <BountyCard bounty={bounty} />
               </motion.div>

--- a/frontend/src/lib/animations.ts
+++ b/frontend/src/lib/animations.ts
@@ -1,0 +1,49 @@
+import type { Variants } from 'framer-motion';
+
+const easeOut = [0.16, 1, 0.3, 1] as const;
+
+export const fadeIn: Variants = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.35, ease: easeOut } },
+};
+
+export const pageTransition: Variants = {
+  initial: { opacity: 0, y: 16 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.35, ease: easeOut } },
+  exit: { opacity: 0, y: -8, transition: { duration: 0.2, ease: easeOut } },
+};
+
+export const staggerContainer: Variants = {
+  initial: {},
+  animate: {
+    transition: {
+      staggerChildren: 0.06,
+      delayChildren: 0.04,
+    },
+  },
+};
+
+export const staggerItem: Variants = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.28, ease: easeOut } },
+};
+
+export const cardHover: Variants = {
+  rest: { y: 0, scale: 1 },
+  hover: {
+    y: -3,
+    scale: 1.01,
+    transition: { duration: 0.18, ease: easeOut },
+  },
+};
+
+export const buttonHover: Variants = {
+  rest: { scale: 1 },
+  hover: { scale: 1.03, transition: { duration: 0.16, ease: easeOut } },
+  tap: { scale: 0.98 },
+};
+
+export const slideInRight: Variants = {
+  initial: { opacity: 0, x: 24 },
+  animate: { opacity: 1, x: 0, transition: { duration: 0.28, ease: easeOut } },
+};

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,64 @@
+import { twMerge } from 'tailwind-merge';
+
+export const LANG_COLORS: Record<string, string> = {
+  TypeScript: '#3178C6',
+  JavaScript: '#F7DF1E',
+  React: '#61DAFB',
+  Rust: '#DEA584',
+  Solidity: '#627EEA',
+  Python: '#3776AB',
+  Go: '#00ADD8',
+  Solana: '#14F195',
+  Anchor: '#9945FF',
+};
+
+export function cn(...classes: Array<string | false | null | undefined>): string {
+  return twMerge(classes.filter(Boolean).join(' '));
+}
+
+export function formatCurrency(amount: number, token = 'USDC'): string {
+  const formatter = new Intl.NumberFormat('en-US', {
+    maximumFractionDigits: amount >= 1000 ? 0 : 2,
+  });
+  return `${formatter.format(amount)} ${token}`;
+}
+
+export function timeAgo(timestamp: string): string {
+  const date = new Date(timestamp);
+  const diffMs = Date.now() - date.getTime();
+
+  if (Number.isNaN(diffMs)) return 'Unknown';
+  if (diffMs < 60_000) return 'Just now';
+
+  const minutes = Math.floor(diffMs / 60_000);
+  if (minutes < 60) return `${minutes}m ago`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo ago`;
+
+  const years = Math.floor(months / 12);
+  return `${years}y ago`;
+}
+
+export function timeLeft(deadline: string): string {
+  const end = new Date(deadline).getTime();
+  const diffMs = end - Date.now();
+
+  if (Number.isNaN(diffMs)) return 'No deadline';
+  if (diffMs <= 0) return 'Expired';
+
+  const totalMinutes = Math.ceil(diffMs / 60_000);
+  const days = Math.floor(totalMinutes / 1_440);
+  const hours = Math.floor((totalMinutes % 1_440) / 60);
+  const minutes = totalMinutes % 60;
+
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  return `${minutes}m`;
+}

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -1,1 +1,16 @@
 import '@testing-library/jest-dom';
+
+class MockIntersectionObserver implements IntersectionObserver {
+  readonly root: Element | Document | null = null;
+  readonly rootMargin = '0px';
+  readonly thresholds: ReadonlyArray<number> = [];
+
+  disconnect(): void {}
+  observe(): void {}
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+  unobserve(): void {}
+}
+
+globalThis.IntersectionObserver = MockIntersectionObserver;


### PR DESCRIPTION
## Summary
- Add a debounced search input to the `/bounties` grid.
- Filter loaded bounties by title, description, category, repo metadata, issue number, and skill tags while preserving existing status/language filters.
- Add a clear-search control and focused search tests.
- Restore missing shared frontend `lib` modules and narrow the root `/lib/` ignore rule so those modules are tracked.

## Bounty
Closes #823

Solana payout wallet: `2KzLaDZ2n8C7xyM62naY6xLAeyFo3xqmT8ivV5o6GQHh`

## Validation
- `npm test -- --run src/__tests__/bounty-grid-search.test.tsx`
- `npm run build`
- `npm test -- --run` currently fails on pre-existing stale suites that import missing components/backend files and missing `@playwright/test`; the new search test and existing `apiClient` tests pass.
