### PR TITLE
feat: add live bounty countdown timer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ eggs/
 .eggs/
 lib/
 lib64/
+!frontend/src/lib/
+!frontend/src/lib/**
 parts/
 sdist/
 var/

--- a/frontend/src/__tests__/countdown-timer.test.tsx
+++ b/frontend/src/__tests__/countdown-timer.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CountdownTimer, getCountdownState } from '../components/bounty/CountdownTimer';
+
+describe('getCountdownState', () => {
+  const now = new Date('2026-05-01T12:00:00Z').getTime();
+
+  it('formats days, hours, and minutes remaining', () => {
+    const state = getCountdownState('2026-05-03T14:30:00Z', now);
+
+    expect(state.label).toBe('2d 2h 30m');
+    expect(state.urgency).toBe('normal');
+  });
+
+  it('marks deadlines under 24 hours as warning', () => {
+    const state = getCountdownState('2026-05-02T06:00:00Z', now);
+
+    expect(state.label).toBe('18h 0m');
+    expect(state.urgency).toBe('warning');
+  });
+
+  it('marks deadlines under 1 hour as urgent', () => {
+    const state = getCountdownState('2026-05-01T12:45:00Z', now);
+
+    expect(state.label).toBe('45m');
+    expect(state.urgency).toBe('urgent');
+  });
+
+  it('marks past deadlines as expired', () => {
+    const state = getCountdownState('2026-05-01T11:59:00Z', now);
+
+    expect(state.label).toBe('Expired');
+    expect(state.urgency).toBe('expired');
+  });
+});
+
+describe('CountdownTimer', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-01T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('updates without a page refresh', () => {
+    render(<CountdownTimer deadline="2026-05-01T12:02:00Z" />);
+
+    expect(screen.getByRole('timer')).toHaveTextContent('2m');
+
+    act(() => {
+      vi.advanceTimersByTime(61_000);
+    });
+
+    expect(screen.getByRole('timer')).toHaveTextContent('1m');
+  });
+
+  it('exposes urgency state for visual indicators', () => {
+    render(<CountdownTimer deadline="2026-05-01T12:30:00Z" />);
+
+    expect(screen.getByTestId('bounty-countdown')).toHaveAttribute('data-urgency', 'urgent');
+  });
+});

--- a/frontend/src/components/bounty/BountyCard.tsx
+++ b/frontend/src/components/bounty/BountyCard.tsx
@@ -4,7 +4,8 @@ import { motion } from 'framer-motion';
 import { GitPullRequest, Clock } from 'lucide-react';
 import type { Bounty } from '../../types/bounty';
 import { cardHover } from '../../lib/animations';
-import { timeLeft, formatCurrency, LANG_COLORS } from '../../lib/utils';
+import { formatCurrency, LANG_COLORS } from '../../lib/utils';
+import { CountdownTimer } from './CountdownTimer';
 
 function TierBadge({ tier }: { tier: string }) {
   const styles: Record<string, string> = {
@@ -113,7 +114,7 @@ export function BountyCard({ bounty }: BountyCardProps) {
           {bounty.deadline && (
             <span className="inline-flex items-center gap-1">
               <Clock className="w-3.5 h-3.5" />
-              {timeLeft(bounty.deadline)}
+              <CountdownTimer deadline={bounty.deadline} />
             </span>
           )}
         </div>

--- a/frontend/src/components/bounty/BountyDetail.tsx
+++ b/frontend/src/components/bounty/BountyDetail.tsx
@@ -3,10 +3,11 @@ import { Link, useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { ArrowLeft, Clock, GitPullRequest, ExternalLink, Loader2, Check, Copy } from 'lucide-react';
 import type { Bounty } from '../../types/bounty';
-import { timeLeft, timeAgo, formatCurrency, LANG_COLORS } from '../../lib/utils';
+import { timeAgo, formatCurrency, LANG_COLORS } from '../../lib/utils';
 import { useAuth } from '../../hooks/useAuth';
 import { SubmissionForm } from './SubmissionForm';
 import { fadeIn } from '../../lib/animations';
+import { CountdownTimer } from './CountdownTimer';
 
 interface BountyDetailProps {
   bounty: Bounty;
@@ -138,8 +139,9 @@ export function BountyDetail({ bounty }: BountyDetailProps) {
             {bounty.deadline && (
               <div className="flex items-center justify-between text-sm">
                 <span className="text-text-muted">Deadline</span>
-                <span className="font-mono text-status-warning inline-flex items-center gap-1">
-                  <Clock className="w-3.5 h-3.5" /> {timeLeft(bounty.deadline)}
+                <span className="inline-flex items-center gap-1">
+                  <Clock className="w-3.5 h-3.5 text-text-muted" />
+                  <CountdownTimer deadline={bounty.deadline} size="md" />
                 </span>
               </div>
             )}

--- a/frontend/src/components/bounty/CountdownTimer.tsx
+++ b/frontend/src/components/bounty/CountdownTimer.tsx
@@ -1,0 +1,99 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { cn } from '../../lib/utils';
+
+export type CountdownUrgency = 'normal' | 'warning' | 'urgent' | 'expired' | 'invalid';
+
+interface CountdownState {
+  label: string;
+  urgency: CountdownUrgency;
+  remainingMs: number;
+}
+
+const MINUTE_MS = 60_000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+
+export function getCountdownState(deadline: string, now = Date.now()): CountdownState {
+  const end = new Date(deadline).getTime();
+
+  if (Number.isNaN(end)) {
+    return { label: 'No deadline', urgency: 'invalid', remainingMs: 0 };
+  }
+
+  const remainingMs = end - now;
+
+  if (remainingMs <= 0) {
+    return { label: 'Expired', urgency: 'expired', remainingMs: 0 };
+  }
+
+  const totalMinutes = Math.max(1, Math.ceil(remainingMs / MINUTE_MS));
+  const days = Math.floor(totalMinutes / 1_440);
+  const hours = Math.floor((totalMinutes % 1_440) / 60);
+  const minutes = totalMinutes % 60;
+
+  const labelParts = [
+    days > 0 ? `${days}d` : null,
+    hours > 0 || days > 0 ? `${hours}h` : null,
+    `${minutes}m`,
+  ].filter(Boolean);
+
+  const urgency: CountdownUrgency =
+    remainingMs < HOUR_MS ? 'urgent' : remainingMs < DAY_MS ? 'warning' : 'normal';
+
+  return {
+    label: labelParts.join(' '),
+    urgency,
+    remainingMs,
+  };
+}
+
+interface CountdownTimerProps {
+  deadline: string;
+  size?: 'sm' | 'md';
+  className?: string;
+}
+
+const urgencyStyles: Record<CountdownUrgency, string> = {
+  normal: 'text-text-muted',
+  warning: 'text-status-warning',
+  urgent: 'text-status-error',
+  expired: 'text-text-muted',
+  invalid: 'text-text-muted',
+};
+
+const sizeStyles = {
+  sm: 'text-xs',
+  md: 'text-sm',
+};
+
+export function CountdownTimer({ deadline, size = 'sm', className }: CountdownTimerProps) {
+  const [now, setNow] = useState(() => Date.now());
+  const countdown = useMemo(() => getCountdownState(deadline, now), [deadline, now]);
+
+  useEffect(() => {
+    setNow(Date.now());
+
+    const timer = window.setInterval(() => {
+      setNow(Date.now());
+    }, 1_000);
+
+    return () => window.clearInterval(timer);
+  }, [deadline]);
+
+  return (
+    <span
+      role="timer"
+      aria-live={countdown.urgency === 'urgent' || countdown.urgency === 'expired' ? 'polite' : 'off'}
+      data-testid="bounty-countdown"
+      data-urgency={countdown.urgency}
+      className={cn(
+        'font-mono font-medium tabular-nums transition-colors duration-300',
+        urgencyStyles[countdown.urgency],
+        sizeStyles[size],
+        className,
+      )}
+    >
+      {countdown.label}
+    </span>
+  );
+}

--- a/frontend/src/lib/animations.ts
+++ b/frontend/src/lib/animations.ts
@@ -1,0 +1,49 @@
+import type { Variants } from 'framer-motion';
+
+const easeOut = [0.16, 1, 0.3, 1] as const;
+
+export const fadeIn: Variants = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.35, ease: easeOut } },
+};
+
+export const pageTransition: Variants = {
+  initial: { opacity: 0, y: 16 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.35, ease: easeOut } },
+  exit: { opacity: 0, y: -8, transition: { duration: 0.2, ease: easeOut } },
+};
+
+export const staggerContainer: Variants = {
+  initial: {},
+  animate: {
+    transition: {
+      staggerChildren: 0.06,
+      delayChildren: 0.04,
+    },
+  },
+};
+
+export const staggerItem: Variants = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.28, ease: easeOut } },
+};
+
+export const cardHover: Variants = {
+  rest: { y: 0, scale: 1 },
+  hover: {
+    y: -3,
+    scale: 1.01,
+    transition: { duration: 0.18, ease: easeOut },
+  },
+};
+
+export const buttonHover: Variants = {
+  rest: { scale: 1 },
+  hover: { scale: 1.03, transition: { duration: 0.16, ease: easeOut } },
+  tap: { scale: 0.98 },
+};
+
+export const slideInRight: Variants = {
+  initial: { opacity: 0, x: 24 },
+  animate: { opacity: 1, x: 0, transition: { duration: 0.28, ease: easeOut } },
+};

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,47 @@
+import { twMerge } from 'tailwind-merge';
+
+export const LANG_COLORS: Record<string, string> = {
+  TypeScript: '#3178C6',
+  JavaScript: '#F7DF1E',
+  React: '#61DAFB',
+  Rust: '#DEA584',
+  Solidity: '#627EEA',
+  Python: '#3776AB',
+  Go: '#00ADD8',
+  Solana: '#14F195',
+  Anchor: '#9945FF',
+};
+
+export function cn(...classes: Array<string | false | null | undefined>): string {
+  return twMerge(classes.filter(Boolean).join(' '));
+}
+
+export function formatCurrency(amount: number, token = 'USDC'): string {
+  const formatter = new Intl.NumberFormat('en-US', {
+    maximumFractionDigits: amount >= 1000 ? 0 : 2,
+  });
+  return `${formatter.format(amount)} ${token}`;
+}
+
+export function timeAgo(timestamp: string): string {
+  const date = new Date(timestamp);
+  const diffMs = Date.now() - date.getTime();
+
+  if (Number.isNaN(diffMs)) return 'Unknown';
+  if (diffMs < 60_000) return 'Just now';
+
+  const minutes = Math.floor(diffMs / 60_000);
+  if (minutes < 60) return `${minutes}m ago`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo ago`;
+
+  const years = Math.floor(months / 12);
+  return `${years}y ago`;
+}


### PR DESCRIPTION
## Summary
- Adds a reusable live countdown timer for bounty deadlines
- Shows normal, warning (<24h), urgent (<1h), expired, and invalid deadline states
- Displays the timer on bounty cards and bounty detail pages
- Restores tracked frontend shared utility modules that current frontend imports depend on

Closes #826

## Payout
Solana wallet: `2KzLaDZ2n8C7xyM62naY6xLAeyFo3xqmT8ivV5o6GQHh`

## Validation
- `npm test -- --run src/__tests__/countdown-timer.test.tsx`
- `npm run build`