### PR TITLE
Fix GitHub OAuth callback routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ eggs/
 .eggs/
 lib/
 lib64/
+!frontend/src/lib/
+!frontend/src/lib/**
 parts/
 sdist/
 var/

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,4 +1,4 @@
-# nginx config for SolFoundry SPA. Proxies /api, /auth, /ws to backend.
+# nginx config for SolFoundry SPA. Proxies /api and /ws to backend.
 server {
     listen 80;
     server_name _;
@@ -20,15 +20,6 @@ server {
 
     # Proxy API requests to backend
     location /api/ {
-        proxy_pass http://backend:8000;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-
-    # Proxy auth requests to backend
-    location /auth/ {
         proxy_pass http://backend:8000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/frontend/src/__tests__/github-auth.test.ts
+++ b/frontend/src/__tests__/github-auth.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { exchangeGitHubCode, getGitHubAuthorizeUrl } from '../api/auth';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+const authResponse = {
+  access_token: 'access-token',
+  refresh_token: 'refresh-token',
+  token_type: 'bearer',
+  user: {
+    id: '1',
+    username: 'octocat',
+    avatar_url: 'https://github.com/octocat.png',
+  },
+};
+
+describe('GitHub auth API', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('uses browser navigation for GitHub authorize', async () => {
+    await expect(getGitHubAuthorizeUrl()).resolves.toBe('/api/auth/github/authorize');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('exchanges the OAuth code through the callback endpoint', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(authResponse));
+
+    await expect(exchangeGitHubCode('code-123', 'state-456')).resolves.toEqual(authResponse);
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toBe('/api/auth/github/callback');
+    expect(options.method).toBe('POST');
+    expect(JSON.parse(options.body as string)).toEqual({
+      code: 'code-123',
+      state: 'state-456',
+    });
+  });
+
+  it('falls back to GET callback exchange when POST is not supported', async () => {
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse({ detail: 'Not found' }, 404))
+      .mockResolvedValueOnce(jsonResponse(authResponse));
+
+    await expect(exchangeGitHubCode('code-123', 'state-456')).resolves.toEqual(authResponse);
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    const [url, options] = mockFetch.mock.calls[1];
+    expect(url).toBe('/api/auth/github/callback?code=code-123&state=state-456');
+    expect(options.method).toBe('GET');
+  });
+
+  it('falls back to the legacy exchange endpoint', async () => {
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse({ detail: 'Not found' }, 404))
+      .mockResolvedValueOnce(jsonResponse({ detail: 'Method not allowed' }, 405))
+      .mockResolvedValueOnce(jsonResponse(authResponse));
+
+    await expect(exchangeGitHubCode('code-123')).resolves.toEqual(authResponse);
+
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    const [url, options] = mockFetch.mock.calls[2];
+    expect(url).toBe('/api/auth/github');
+    expect(options.method).toBe('POST');
+    expect(JSON.parse(options.body as string)).toEqual({ code: 'code-123' });
+  });
+});

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,4 +1,4 @@
-import { apiClient } from '../services/apiClient';
+import { apiClient, isApiError } from '../services/apiClient';
 import type { User } from '../types/user';
 
 export interface AuthTokens {
@@ -11,16 +11,45 @@ export interface GitHubCallbackResponse extends AuthTokens {
   user: User;
 }
 
+const API_BASE: string =
+  import.meta.env?.VITE_API_URL != null && import.meta.env.VITE_API_URL !== ''
+    ? (import.meta.env.VITE_API_URL as string).replace(/\/$/, '')
+    : '';
+
+const GITHUB_AUTHORIZE_PATH = '/api/auth/github/authorize';
+const GITHUB_CALLBACK_PATH = '/api/auth/github/callback';
+const LEGACY_GITHUB_CALLBACK_PATH = '/api/auth/github';
+
 export async function getGitHubAuthorizeUrl(): Promise<string> {
-  const data = await apiClient<{ authorize_url: string }>('/api/auth/github/authorize');
-  return data.authorize_url;
+  return `${API_BASE}${GITHUB_AUTHORIZE_PATH}`;
 }
 
 export async function exchangeGitHubCode(code: string, state?: string): Promise<GitHubCallbackResponse> {
-  return apiClient<GitHubCallbackResponse>('/api/auth/github', {
-    method: 'POST',
-    body: { code, ...(state ? { state } : {}) },
-  });
+  const body = { code, ...(state ? { state } : {}) };
+
+  try {
+    return await apiClient<GitHubCallbackResponse>(GITHUB_CALLBACK_PATH, {
+      method: 'POST',
+      body,
+    });
+  } catch (error) {
+    if (isApiError(error) && (error.status === 404 || error.status === 405)) {
+      try {
+        return await apiClient<GitHubCallbackResponse>(GITHUB_CALLBACK_PATH, {
+          params: { code, ...(state ? { state } : {}) },
+        });
+      } catch (fallbackError) {
+        if (isApiError(fallbackError) && (fallbackError.status === 404 || fallbackError.status === 405)) {
+          return apiClient<GitHubCallbackResponse>(LEGACY_GITHUB_CALLBACK_PATH, {
+            method: 'POST',
+            body,
+          });
+        }
+        throw fallbackError;
+      }
+    }
+    throw error;
+  }
 }
 
 export async function getMe(): Promise<User> {

--- a/frontend/src/lib/animations.ts
+++ b/frontend/src/lib/animations.ts
@@ -1,0 +1,49 @@
+import type { Variants } from 'framer-motion';
+
+const easeOut = [0.16, 1, 0.3, 1] as const;
+
+export const fadeIn: Variants = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.35, ease: easeOut } },
+};
+
+export const pageTransition: Variants = {
+  initial: { opacity: 0, y: 16 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.35, ease: easeOut } },
+  exit: { opacity: 0, y: -8, transition: { duration: 0.2, ease: easeOut } },
+};
+
+export const staggerContainer: Variants = {
+  initial: {},
+  animate: {
+    transition: {
+      staggerChildren: 0.06,
+      delayChildren: 0.04,
+    },
+  },
+};
+
+export const staggerItem: Variants = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.28, ease: easeOut } },
+};
+
+export const cardHover: Variants = {
+  rest: { y: 0, scale: 1 },
+  hover: {
+    y: -3,
+    scale: 1.01,
+    transition: { duration: 0.18, ease: easeOut },
+  },
+};
+
+export const buttonHover: Variants = {
+  rest: { scale: 1 },
+  hover: { scale: 1.03, transition: { duration: 0.16, ease: easeOut } },
+  tap: { scale: 0.98 },
+};
+
+export const slideInRight: Variants = {
+  initial: { opacity: 0, x: 24 },
+  animate: { opacity: 1, x: 0, transition: { duration: 0.28, ease: easeOut } },
+};

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,70 @@
+import { twMerge } from 'tailwind-merge';
+
+export const LANG_COLORS: Record<string, string> = {
+  TypeScript: '#3178C6',
+  JavaScript: '#F7DF1E',
+  React: '#61DAFB',
+  Rust: '#DEA584',
+  Solidity: '#627EEA',
+  Python: '#3776AB',
+  Go: '#00ADD8',
+  Solana: '#14F195',
+  Anchor: '#9945FF',
+};
+
+export function cn(...classes: Array<string | false | null | undefined>): string {
+  return twMerge(classes.filter(Boolean).join(' '));
+}
+
+export function formatCurrency(amount: number, token = 'USDC'): string {
+  const formatter = new Intl.NumberFormat('en-US', {
+    maximumFractionDigits: amount >= 1000 ? 0 : 2,
+  });
+  return `${formatter.format(amount)} ${token}`;
+}
+
+export function timeAgo(timestamp: string): string {
+  const date = new Date(timestamp);
+  const diffMs = Date.now() - date.getTime();
+
+  if (Number.isNaN(diffMs)) return 'Unknown';
+  if (diffMs < 60_000) return 'Just now';
+
+  const minutes = Math.floor(diffMs / 60_000);
+  if (minutes < 60) return `${minutes}m ago`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo ago`;
+
+  const years = Math.floor(months / 12);
+  return `${years}y ago`;
+}
+
+export function timeLeft(timestamp: string): string {
+  const date = new Date(timestamp);
+  const diffMs = date.getTime() - Date.now();
+
+  if (Number.isNaN(diffMs)) return 'Unknown';
+  if (diffMs <= 0) return 'Expired';
+
+  const minutes = Math.floor(diffMs / 60_000);
+  if (minutes < 60) return `${minutes}m left`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h left`;
+
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d left`;
+
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo left`;
+
+  const years = Math.floor(months / 12);
+  return `${years}y left`;
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -10,10 +10,6 @@ export default defineConfig({
         target: 'http://localhost:8000',
         changeOrigin: true,
       },
-      '/auth': {
-        target: 'http://localhost:8000',
-        changeOrigin: true,
-      },
       '/ws': {
         target: 'ws://localhost:8000',
         ws: true,


### PR DESCRIPTION
Summary
- Keep the frontend callback page available at /auth/github/callback by leaving /auth routes with the SPA.
- Send sign-in links straight to the backend authorize endpoint.
- Exchange OAuth codes through the callback endpoint, with fallbacks for older backend routes.
- Restore the shared frontend helper modules that current components import.

Closes #821

Wallet: `2KzLaDZ2n8C7xyM62naY6xLAeyFo3xqmT8ivV5o6GQHh`

Validation
- npm test -- --run src/__tests__/github-auth.test.ts
- npm run build