### PR TITLE
feat: add bounty countdown timer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ eggs/
 .eggs/
 lib/
 lib64/
+!frontend/src/lib/
+!frontend/src/lib/**
 parts/
 sdist/
 var/

--- a/frontend/src/components/bounty/BountyCard.tsx
+++ b/frontend/src/components/bounty/BountyCard.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { GitPullRequest, Clock } from 'lucide-react';
+import { GitPullRequest } from 'lucide-react';
 import type { Bounty } from '../../types/bounty';
 import { cardHover } from '../../lib/animations';
-import { timeLeft, formatCurrency, LANG_COLORS } from '../../lib/utils';
+import { formatCurrency, LANG_COLORS } from '../../lib/utils';
+import { BountyCountdown } from './BountyCountdown';
 
 function TierBadge({ tier }: { tier: string }) {
   const styles: Record<string, string> = {
@@ -111,10 +112,7 @@ export function BountyCard({ bounty }: BountyCardProps) {
             {bounty.submission_count} PRs
           </span>
           {bounty.deadline && (
-            <span className="inline-flex items-center gap-1">
-              <Clock className="w-3.5 h-3.5" />
-              {timeLeft(bounty.deadline)}
-            </span>
+            <BountyCountdown deadline={bounty.deadline} />
           )}
         </div>
       </div>

--- a/frontend/src/components/bounty/BountyCountdown.test.tsx
+++ b/frontend/src/components/bounty/BountyCountdown.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { BountyCountdown } from './BountyCountdown';
+
+describe('BountyCountdown', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('shows days, hours, and minutes remaining with normal urgency', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-11T00:00:00Z'));
+
+    render(<BountyCountdown deadline="2026-05-13T03:04:00Z" />);
+
+    expect(screen.getByText('2d 3h 4m')).toBeInTheDocument();
+    expect(screen.getByLabelText(/2 days, 3 hours, 4 minutes remaining/i)).toHaveClass('text-text-muted');
+  });
+
+  it('uses warning and urgent colors as the deadline approaches', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-11T00:00:00Z'));
+
+    const { rerender } = render(<BountyCountdown deadline="2026-05-11T12:00:00Z" />);
+
+    expect(screen.getByText('12h 0m')).toHaveClass('text-status-warning');
+
+    rerender(<BountyCountdown deadline="2026-05-11T00:45:00Z" />);
+
+    expect(screen.getByText('45m')).toHaveClass('text-status-error');
+  });
+
+  it('updates without a page refresh and shows expired after the deadline passes', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-11T00:00:00Z'));
+
+    render(<BountyCountdown deadline="2026-05-11T00:01:00Z" />);
+
+    expect(screen.getByText('1m')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(61_000);
+    });
+
+    expect(screen.getByText('Expired')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/bounty/BountyCountdown.tsx
+++ b/frontend/src/components/bounty/BountyCountdown.tsx
@@ -1,0 +1,75 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Clock } from 'lucide-react';
+
+interface CountdownParts {
+  label: string;
+  ariaLabel: string;
+  urgencyClass: string;
+}
+
+function getCountdownParts(deadline: string, now: number): CountdownParts {
+  const remainingMs = new Date(deadline).getTime() - now;
+  if (remainingMs <= 0) {
+    return {
+      label: 'Expired',
+      ariaLabel: 'Bounty deadline expired',
+      urgencyClass: 'text-text-muted',
+    };
+  }
+
+  const totalMinutes = Math.ceil(remainingMs / 60_000);
+  const days = Math.floor(totalMinutes / 1_440);
+  const hours = Math.floor((totalMinutes % 1_440) / 60);
+  const minutes = totalMinutes % 60;
+
+  const label = [
+    days > 0 ? `${days}d` : '',
+    hours > 0 || days > 0 ? `${hours}h` : '',
+    `${minutes}m`,
+  ].filter(Boolean).join(' ');
+
+  const ariaParts = [
+    days > 0 ? `${days} ${days === 1 ? 'day' : 'days'}` : '',
+    hours > 0 || days > 0 ? `${hours} ${hours === 1 ? 'hour' : 'hours'}` : '',
+    `${minutes} ${minutes === 1 ? 'minute' : 'minutes'}`,
+  ].filter(Boolean).join(', ');
+
+  const urgencyClass =
+    remainingMs < 60 * 60_000
+      ? 'text-status-error'
+      : remainingMs < 24 * 60 * 60_000
+        ? 'text-status-warning'
+        : 'text-text-muted';
+
+  return {
+    label,
+    ariaLabel: `${ariaParts} remaining`,
+    urgencyClass,
+  };
+}
+
+interface BountyCountdownProps {
+  deadline: string;
+  className?: string;
+}
+
+export function BountyCountdown({ deadline, className = '' }: BountyCountdownProps) {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const intervalId = window.setInterval(() => setNow(Date.now()), 30_000);
+    return () => window.clearInterval(intervalId);
+  }, []);
+
+  const parts = useMemo(() => getCountdownParts(deadline, now), [deadline, now]);
+
+  return (
+    <span
+      aria-label={parts.ariaLabel}
+      className={`inline-flex items-center gap-1 font-mono ${parts.urgencyClass} ${className}`}
+    >
+      <Clock className="w-3.5 h-3.5" />
+      {parts.label}
+    </span>
+  );
+}

--- a/frontend/src/components/bounty/BountyDetail.tsx
+++ b/frontend/src/components/bounty/BountyDetail.tsx
@@ -1,12 +1,13 @@
 import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { ArrowLeft, Clock, GitPullRequest, ExternalLink, Loader2, Check, Copy } from 'lucide-react';
+import { ArrowLeft, GitPullRequest, ExternalLink, Loader2, Check, Copy } from 'lucide-react';
 import type { Bounty } from '../../types/bounty';
-import { timeLeft, timeAgo, formatCurrency, LANG_COLORS } from '../../lib/utils';
+import { timeAgo, formatCurrency, LANG_COLORS } from '../../lib/utils';
 import { useAuth } from '../../hooks/useAuth';
 import { SubmissionForm } from './SubmissionForm';
 import { fadeIn } from '../../lib/animations';
+import { BountyCountdown } from './BountyCountdown';
 
 interface BountyDetailProps {
   bounty: Bounty;
@@ -138,9 +139,7 @@ export function BountyDetail({ bounty }: BountyDetailProps) {
             {bounty.deadline && (
               <div className="flex items-center justify-between text-sm">
                 <span className="text-text-muted">Deadline</span>
-                <span className="font-mono text-status-warning inline-flex items-center gap-1">
-                  <Clock className="w-3.5 h-3.5" /> {timeLeft(bounty.deadline)}
-                </span>
+                <BountyCountdown deadline={bounty.deadline} />
               </div>
             )}
             <div className="flex items-center justify-between text-sm">

--- a/frontend/src/lib/animations.ts
+++ b/frontend/src/lib/animations.ts
@@ -1,0 +1,38 @@
+import type { Variants } from 'framer-motion';
+
+export const fadeIn: Variants = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.35, ease: 'easeOut' } },
+};
+
+export const pageTransition: Variants = {
+  initial: { opacity: 0 },
+  animate: { opacity: 1, transition: { duration: 0.3, ease: 'easeOut' } },
+  exit: { opacity: 0, transition: { duration: 0.2 } },
+};
+
+export const cardHover: Variants = {
+  rest: { y: 0, borderColor: 'rgba(30, 30, 46, 1)' },
+  hover: { y: -4, borderColor: 'rgba(0, 230, 118, 0.35)' },
+};
+
+export const buttonHover: Variants = {
+  rest: { scale: 1 },
+  hover: { scale: 1.03 },
+  tap: { scale: 0.98 },
+};
+
+export const staggerContainer: Variants = {
+  initial: {},
+  animate: { transition: { staggerChildren: 0.06 } },
+};
+
+export const staggerItem: Variants = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.28, ease: 'easeOut' } },
+};
+
+export const slideInRight: Variants = {
+  initial: { opacity: 0, x: 20 },
+  animate: { opacity: 1, x: 0, transition: { duration: 0.28, ease: 'easeOut' } },
+};

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,37 @@
+export const LANG_COLORS: Record<string, string> = {
+  TypeScript: '#3178c6',
+  JavaScript: '#f7df1e',
+  Rust: '#dea584',
+  Solidity: '#627eea',
+  Python: '#3776ab',
+  Go: '#00add8',
+};
+
+export function formatCurrency(amount: number, token: string): string {
+  return `${new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 }).format(amount)} ${token}`;
+}
+
+export function timeAgo(date: string): string {
+  const diffMs = Date.now() - new Date(date).getTime();
+  const minutes = Math.max(0, Math.floor(diffMs / 60_000));
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+export function timeLeft(deadline: string): string {
+  const diffMs = new Date(deadline).getTime() - Date.now();
+  if (diffMs <= 0) return 'Expired';
+
+  const totalMinutes = Math.ceil(diffMs / 60_000);
+  const days = Math.floor(totalMinutes / 1_440);
+  const hours = Math.floor((totalMinutes % 1_440) / 60);
+  const minutes = totalMinutes % 60;
+
+  if (days > 0) return `${days}d ${hours}h ${minutes}m`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  return `${minutes}m`;
+}


### PR DESCRIPTION
## Description
Adds a reusable real-time bounty countdown timer and uses it on bounty cards and detail pages.

Closes #826

## Solana Wallet for Payout
**Wallet:** ACVdXJborhi1xiTzU8rvYYGU4YWpvFwbnG1jgQJAVSg6

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] ✅ Test addition/update

## Checklist
- [x] Code is clean and follows the issue spec exactly
- [x] One PR per bounty (no multiple bounties in one PR)
- [x] Tests included for new functionality
- [x] No `console.log` or debugging code left behind
- [x] No hardcoded secrets or API keys

## Testing
- [x] Unit tests added/updated
- [x] `npx vitest run src/components/bounty/BountyCountdown.test.tsx`
- [x] `npx tsc --noEmit`
- [x] `npm run build`

## Additional Notes
The branch also restores the small shared frontend helper modules that existing frontend components already import, and updates `.gitignore` so `frontend/src/lib` is not hidden by the broad Python `lib/` ignore rule.