### PR TITLE
feat: wire activity feed to API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ eggs/
 .eggs/
 lib/
 lib64/
+!frontend/src/lib/
+!frontend/src/lib/**
 parts/
 sdist/
 var/

--- a/frontend/src/components/home/ActivityFeed.test.tsx
+++ b/frontend/src/components/home/ActivityFeed.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { act } from 'react';
+import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ActivityFeed } from './ActivityFeed';
+
+describe('ActivityFeed', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('fetches recent activity from the API and refreshes every 30 seconds', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve([
+          {
+            id: 'evt-1',
+            type: 'completed',
+            username: 'alice',
+            detail: '100,000 FNDRY from Bounty #822',
+            timestamp: new Date().toISOString(),
+          },
+        ]),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve([
+          {
+            id: 'evt-2',
+            type: 'submitted',
+            username: 'bob',
+            detail: 'PR to Bounty #826',
+            timestamp: new Date().toISOString(),
+          },
+        ]),
+      });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<ActivityFeed />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('alice')).toBeInTheDocument();
+    expect(screen.getByText('100,000 FNDRY from Bounty #822')).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(screen.getByText('bob')).toBeInTheDocument();
+    expect(screen.getByText('PR to Bounty #826')).toBeInTheDocument();
+  });
+
+  it('shows an empty state when the API returns no activity', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([]),
+    }));
+
+    render(<ActivityFeed />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('No recent activity')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/home/ActivityFeed.tsx
+++ b/frontend/src/components/home/ActivityFeed.tsx
@@ -12,38 +12,6 @@ interface ActivityEvent {
   timestamp: string;
 }
 
-// Mock events for when API doesn't return activity
-const MOCK_EVENTS: ActivityEvent[] = [
-  {
-    id: '1',
-    type: 'completed',
-    username: 'devbuilder',
-    detail: '$500 USDC from Bounty #42',
-    timestamp: new Date(Date.now() - 3 * 60 * 1000).toISOString(),
-  },
-  {
-    id: '2',
-    type: 'submitted',
-    username: 'KodeSage',
-    detail: 'PR to Bounty #38',
-    timestamp: new Date(Date.now() - 15 * 60 * 1000).toISOString(),
-  },
-  {
-    id: '3',
-    type: 'posted',
-    username: 'SolanaLabs',
-    detail: 'Bounty #145 — $3,500 USDC',
-    timestamp: new Date(Date.now() - 45 * 60 * 1000).toISOString(),
-  },
-  {
-    id: '4',
-    type: 'review',
-    username: 'AI Review',
-    detail: 'Bounty #42 — 8.5/10',
-    timestamp: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
-  },
-];
-
 function getActionText(type: ActivityEvent['type']) {
   switch (type) {
     case 'completed': return 'earned';
@@ -75,12 +43,48 @@ function EventItem({ event }: { event: ActivityEvent }) {
   );
 }
 
+async function fetchActivity(): Promise<ActivityEvent[]> {
+  const response = await fetch('/api/activity');
+  if (!response.ok) throw new Error('Failed to load activity');
+  const payload = await response.json();
+  return Array.isArray(payload) ? payload : payload.items ?? [];
+}
+
 export function ActivityFeed({ events }: { events?: ActivityEvent[] }) {
-  const displayEvents = events?.length ? events.slice(0, 4) : MOCK_EVENTS;
-  const [visibleEvents, setVisibleEvents] = useState<ActivityEvent[]>(displayEvents.slice(0, 4));
+  const [visibleEvents, setVisibleEvents] = useState<ActivityEvent[]>(events?.slice(0, 4) ?? []);
+  const [isLoading, setIsLoading] = useState(!events);
+  const [isError, setIsError] = useState(false);
 
   useEffect(() => {
-    setVisibleEvents(displayEvents.slice(0, 4));
+    if (events) {
+      setVisibleEvents(events.slice(0, 4));
+      setIsLoading(false);
+      return undefined;
+    }
+
+    let cancelled = false;
+
+    const loadActivity = async () => {
+      try {
+        const activity = await fetchActivity();
+        if (!cancelled) {
+          setVisibleEvents(activity.slice(0, 4));
+          setIsError(false);
+        }
+      } catch {
+        if (!cancelled) setIsError(true);
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    };
+
+    void loadActivity();
+    const intervalId = window.setInterval(loadActivity, 30_000);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+    };
   }, [events]);
 
   return (
@@ -91,6 +95,15 @@ export function ActivityFeed({ events }: { events?: ActivityEvent[] }) {
           <span className="font-mono text-xs text-text-muted uppercase tracking-wider">Recent Activity</span>
         </div>
         <div className="space-y-1">
+          {isLoading && (
+            <p className="py-3 px-3 text-sm text-text-muted">Loading activity...</p>
+          )}
+          {!isLoading && isError && (
+            <p className="py-3 px-3 text-sm text-text-muted">Activity is temporarily unavailable.</p>
+          )}
+          {!isLoading && !isError && visibleEvents.length === 0 && (
+            <p className="py-3 px-3 text-sm text-text-muted">No recent activity</p>
+          )}
           <AnimatePresence mode="popLayout">
             {visibleEvents.map((event) => (
               <motion.div

--- a/frontend/src/lib/animations.ts
+++ b/frontend/src/lib/animations.ts
@@ -1,0 +1,38 @@
+import type { Variants } from 'framer-motion';
+
+export const fadeIn: Variants = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.35, ease: 'easeOut' } },
+};
+
+export const pageTransition: Variants = {
+  initial: { opacity: 0 },
+  animate: { opacity: 1, transition: { duration: 0.3, ease: 'easeOut' } },
+  exit: { opacity: 0, transition: { duration: 0.2 } },
+};
+
+export const cardHover: Variants = {
+  rest: { y: 0, borderColor: 'rgba(30, 30, 46, 1)' },
+  hover: { y: -4, borderColor: 'rgba(0, 230, 118, 0.35)' },
+};
+
+export const buttonHover: Variants = {
+  rest: { scale: 1 },
+  hover: { scale: 1.03 },
+  tap: { scale: 0.98 },
+};
+
+export const staggerContainer: Variants = {
+  initial: {},
+  animate: { transition: { staggerChildren: 0.06 } },
+};
+
+export const staggerItem: Variants = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.28, ease: 'easeOut' } },
+};
+
+export const slideInRight: Variants = {
+  initial: { opacity: 0, x: 20 },
+  animate: { opacity: 1, x: 0, transition: { duration: 0.28, ease: 'easeOut' } },
+};

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,37 @@
+export const LANG_COLORS: Record<string, string> = {
+  TypeScript: '#3178c6',
+  JavaScript: '#f7df1e',
+  Rust: '#dea584',
+  Solidity: '#627eea',
+  Python: '#3776ab',
+  Go: '#00add8',
+};
+
+export function formatCurrency(amount: number, token: string): string {
+  return `${new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 }).format(amount)} ${token}`;
+}
+
+export function timeAgo(date: string): string {
+  const diffMs = Date.now() - new Date(date).getTime();
+  const minutes = Math.max(0, Math.floor(diffMs / 60_000));
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+export function timeLeft(deadline: string): string {
+  const diffMs = new Date(deadline).getTime() - Date.now();
+  if (diffMs <= 0) return 'Expired';
+
+  const totalMinutes = Math.ceil(diffMs / 60_000);
+  const days = Math.floor(totalMinutes / 1_440);
+  const hours = Math.floor((totalMinutes % 1_440) / 60);
+  const minutes = totalMinutes % 60;
+
+  if (days > 0) return `${days}d ${hours}h ${minutes}m`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  return `${minutes}m`;
+}


### PR DESCRIPTION
## Description
Wires the home page activity feed to `/api/activity`, refreshes it every 30 seconds, and adds empty/error/loading states instead of relying on hardcoded mock activity.

Closes #822

## Solana Wallet for Payout
**Wallet:** ACVdXJborhi1xiTzU8rvYYGU4YWpvFwbnG1jgQJAVSg6

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] ✅ Test addition/update

## Checklist
- [x] Code is clean and follows the issue spec exactly
- [x] One PR per bounty (no multiple bounties in one PR)
- [x] Tests included for new functionality
- [x] No `console.log` or debugging code left behind
- [x] No hardcoded secrets or API keys

## Testing
- [x] Unit tests added/updated
- [x] `npx vitest run src/components/home/ActivityFeed.test.tsx`
- [x] `npx tsc --noEmit`
- [x] `npm run build`

## Additional Notes
The branch also restores the shared frontend helper modules currently imported by existing components, and updates `.gitignore` so `frontend/src/lib` files are not hidden by the broad Python `lib/` ignore rule.