### PR TITLE
feat: add toast notification system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ eggs/
 .eggs/
 lib/
 lib64/
+!frontend/src/lib/
+!frontend/src/lib/**
 parts/
 sdist/
 var/

--- a/frontend/src/components/toast/ToastProvider.test.tsx
+++ b/frontend/src/components/toast/ToastProvider.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ToastProvider, useToast } from './ToastProvider';
+
+function ToastButtons() {
+  const { showToast } = useToast();
+
+  return (
+    <div>
+      <button onClick={() => showToast({ type: 'success', title: 'Saved bounty' })}>success</button>
+      <button onClick={() => showToast({ type: 'error', title: 'Upload failed' })}>error</button>
+      <button onClick={() => showToast({ type: 'warning', title: 'Deadline soon' })}>warning</button>
+      <button onClick={() => showToast({ type: 'info', title: 'Review started' })}>info</button>
+    </div>
+  );
+}
+
+describe('ToastProvider', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders accessible stacked toast variants and allows manual close', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ToastProvider>
+        <ToastButtons />
+      </ToastProvider>,
+    );
+
+    await user.click(screen.getByText('success'));
+    await user.click(screen.getByText('error'));
+
+    const alerts = screen.getAllByRole('alert');
+    expect(alerts).toHaveLength(2);
+    expect(screen.getByText('Saved bounty')).toHaveClass('text-status-success');
+    expect(screen.getByText('Upload failed')).toHaveClass('text-status-error');
+
+    await user.click(screen.getAllByLabelText(/dismiss notification/i)[0]);
+
+    expect(screen.queryByText('Saved bounty')).not.toBeInTheDocument();
+    expect(screen.getByText('Upload failed')).toBeInTheDocument();
+  });
+
+  it('auto-dismisses toast notifications after five seconds', async () => {
+    vi.useFakeTimers();
+
+    render(
+      <ToastProvider>
+        <ToastButtons />
+      </ToastProvider>,
+    );
+
+    fireEvent.click(screen.getByText('info'));
+
+    expect(screen.getByText('Review started')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(5_000);
+    });
+
+    expect(screen.queryByText('Review started')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/toast/ToastProvider.tsx
+++ b/frontend/src/components/toast/ToastProvider.tsx
@@ -1,0 +1,103 @@
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import { CheckCircle2, Info, TriangleAlert, X, XCircle } from 'lucide-react';
+
+type ToastType = 'success' | 'error' | 'warning' | 'info';
+
+interface ToastInput {
+  type: ToastType;
+  title: string;
+  message?: string;
+}
+
+interface Toast extends ToastInput {
+  id: string;
+}
+
+interface ToastContextValue {
+  showToast: (toast: ToastInput) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+const toastStyles: Record<ToastType, { text: string; border: string; icon: React.ReactNode }> = {
+  success: {
+    text: 'text-status-success',
+    border: 'border-status-success/30',
+    icon: <CheckCircle2 className="w-4 h-4" />,
+  },
+  error: {
+    text: 'text-status-error',
+    border: 'border-status-error/30',
+    icon: <XCircle className="w-4 h-4" />,
+  },
+  warning: {
+    text: 'text-status-warning',
+    border: 'border-status-warning/30',
+    icon: <TriangleAlert className="w-4 h-4" />,
+  },
+  info: {
+    text: 'text-status-info',
+    border: 'border-status-info/30',
+    icon: <Info className="w-4 h-4" />,
+  },
+};
+
+export function useToast() {
+  const context = useContext(ToastContext);
+  if (!context) throw new Error('useToast must be used within ToastProvider');
+  return context;
+}
+
+interface ToastProviderProps {
+  children: React.ReactNode;
+}
+
+export function ToastProvider({ children }: ToastProviderProps) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const removeToast = useCallback((id: string) => {
+    setToasts((current) => current.filter((toast) => toast.id !== id));
+  }, []);
+
+  const showToast = useCallback((toast: ToastInput) => {
+    const id = crypto.randomUUID();
+    setToasts((current) => [...current, { ...toast, id }]);
+    window.setTimeout(() => removeToast(id), 5_000);
+  }, [removeToast]);
+
+  const value = useMemo(() => ({ showToast }), [showToast]);
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <div className="fixed right-4 top-4 z-50 flex w-[min(24rem,calc(100vw-2rem))] flex-col gap-3">
+        {toasts.map((toast) => {
+          const style = toastStyles[toast.type];
+          return (
+            <div
+              key={toast.id}
+              role="alert"
+              className={`animate-[toast-slide-in_180ms_ease-out] rounded-xl border ${style.border} bg-forge-900/95 p-4 shadow-2xl shadow-black/30 backdrop-blur`}
+            >
+              <div className="flex items-start gap-3">
+                <span className={`mt-0.5 ${style.text}`}>{style.icon}</span>
+                <div className="min-w-0 flex-1">
+                  <p className={`text-sm font-semibold ${style.text}`}>{toast.title}</p>
+                  {toast.message && <p className="mt-1 text-sm text-text-secondary">{toast.message}</p>}
+                </div>
+                <button
+                  type="button"
+                  aria-label="Dismiss notification"
+                  onClick={() => removeToast(toast.id)}
+                  className="rounded-md p-1 text-text-muted transition-colors hover:bg-forge-800 hover:text-text-primary"
+                >
+                  <X className="w-4 h-4" />
+                </button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </ToastContext.Provider>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -107,6 +107,10 @@
     50% { background-position: 100% 50%; }
     100% { background-position: 0% 50%; }
   }
+  @keyframes toast-slide-in {
+    from { opacity: 0; transform: translateX(16px); }
+    to { opacity: 1; transform: translateX(0); }
+  }
 }
 
 /* ============================================================================

--- a/frontend/src/lib/animations.ts
+++ b/frontend/src/lib/animations.ts
@@ -1,0 +1,38 @@
+import type { Variants } from 'framer-motion';
+
+export const fadeIn: Variants = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.35, ease: 'easeOut' } },
+};
+
+export const pageTransition: Variants = {
+  initial: { opacity: 0 },
+  animate: { opacity: 1, transition: { duration: 0.3, ease: 'easeOut' } },
+  exit: { opacity: 0, transition: { duration: 0.2 } },
+};
+
+export const cardHover: Variants = {
+  rest: { y: 0, borderColor: 'rgba(30, 30, 46, 1)' },
+  hover: { y: -4, borderColor: 'rgba(0, 230, 118, 0.35)' },
+};
+
+export const buttonHover: Variants = {
+  rest: { scale: 1 },
+  hover: { scale: 1.03 },
+  tap: { scale: 0.98 },
+};
+
+export const staggerContainer: Variants = {
+  initial: {},
+  animate: { transition: { staggerChildren: 0.06 } },
+};
+
+export const staggerItem: Variants = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.28, ease: 'easeOut' } },
+};
+
+export const slideInRight: Variants = {
+  initial: { opacity: 0, x: 20 },
+  animate: { opacity: 1, x: 0, transition: { duration: 0.28, ease: 'easeOut' } },
+};

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,37 @@
+export const LANG_COLORS: Record<string, string> = {
+  TypeScript: '#3178c6',
+  JavaScript: '#f7df1e',
+  Rust: '#dea584',
+  Solidity: '#627eea',
+  Python: '#3776ab',
+  Go: '#00add8',
+};
+
+export function formatCurrency(amount: number, token: string): string {
+  return `${new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 }).format(amount)} ${token}`;
+}
+
+export function timeAgo(date: string): string {
+  const diffMs = Date.now() - new Date(date).getTime();
+  const minutes = Math.max(0, Math.floor(diffMs / 60_000));
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+export function timeLeft(deadline: string): string {
+  const diffMs = new Date(deadline).getTime() - Date.now();
+  if (diffMs <= 0) return 'Expired';
+
+  const totalMinutes = Math.ceil(diffMs / 60_000);
+  const days = Math.floor(totalMinutes / 1_440);
+  const hours = Math.floor((totalMinutes % 1_440) / 60);
+  const minutes = totalMinutes % 60;
+
+  if (days > 0) return `${days}d ${hours}h ${minutes}m`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  return `${minutes}m`;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { AuthProvider } from './contexts/AuthContext';
+import { ToastProvider } from './components/toast/ToastProvider';
 import { queryClient } from './services/queryClient';
 import App from './App';
 import './index.css';
@@ -15,7 +16,9 @@ createRoot(root).render(
     <BrowserRouter>
       <QueryClientProvider client={queryClient}>
         <AuthProvider>
-          <App />
+          <ToastProvider>
+            <App />
+          </ToastProvider>
         </AuthProvider>
       </QueryClientProvider>
     </BrowserRouter>


### PR DESCRIPTION
## Description
Adds an app-wide toast notification provider with success, error, warning, and info variants, accessible alert semantics, manual dismiss controls, automatic five-second dismissal, and stacked notifications.

Closes #825

## Solana Wallet for Payout
**Wallet:** ACVdXJborhi1xiTzU8rvYYGU4YWpvFwbnG1jgQJAVSg6

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🎨 Style/UI update
- [x] ✅ Test addition/update

## Checklist
- [x] Code is clean and follows the issue spec exactly
- [x] One PR per bounty (no multiple bounties in one PR)
- [x] Tests included for new functionality
- [x] No `console.log` or debugging code left behind
- [x] No hardcoded secrets or API keys

## Testing
- [x] Unit tests added/updated
- [x] `npx vitest run src/components/toast/ToastProvider.test.tsx`
- [x] `npx tsc --noEmit`
- [x] `npm run build`

## Additional Notes
The branch also restores the shared frontend helper modules currently imported by existing components, and updates `.gitignore` so `frontend/src/lib` files are not hidden by the broad Python `lib/` ignore rule.