### PR TITLE
feat: add loading skeleton animations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ eggs/
 .eggs/
 lib/
 lib64/
+!frontend/src/lib/
+!frontend/src/lib/**
 parts/
 sdist/
 var/

--- a/frontend/src/components/bounty/BountyGrid.tsx
+++ b/frontend/src/components/bounty/BountyGrid.tsx
@@ -5,6 +5,7 @@ import { ChevronDown, Loader2, Plus } from 'lucide-react';
 import { BountyCard } from './BountyCard';
 import { useInfiniteBounties } from '../../hooks/useBounties';
 import { staggerContainer, staggerItem } from '../../lib/animations';
+import { BountyCardSkeleton } from '../skeletons/LoadingSkeletons';
 
 const FILTER_SKILLS = ['All', 'TypeScript', 'Rust', 'Solidity', 'Python', 'Go', 'JavaScript'];
 
@@ -73,14 +74,7 @@ export function BountyGrid() {
         {/* Loading state */}
         {isLoading && (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
-            {Array.from({ length: 6 }).map((_, i) => (
-              <div
-                key={i}
-                className="h-52 rounded-xl border border-border bg-forge-900 overflow-hidden"
-              >
-                <div className="h-full bg-gradient-to-r from-forge-900 via-forge-800 to-forge-900 bg-[length:200%_100%] animate-shimmer" />
-              </div>
-            ))}
+            <BountyCardSkeleton count={6} />
           </div>
         )}
 

--- a/frontend/src/components/home/FeaturedBounties.tsx
+++ b/frontend/src/components/home/FeaturedBounties.tsx
@@ -5,6 +5,7 @@ import { ArrowRight } from 'lucide-react';
 import { staggerContainer, staggerItem } from '../../lib/animations';
 import { useBounties } from '../../hooks/useBounties';
 import { BountyCard } from '../bounty/BountyCard';
+import { BountyCardSkeleton } from '../skeletons/LoadingSkeletons';
 
 export function FeaturedBounties() {
   const { data, isLoading, isError } = useBounties({ limit: 4, status: 'open' });
@@ -38,9 +39,7 @@ export function FeaturedBounties() {
 
         {isLoading && (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-            {Array.from({ length: 4 }).map((_, i) => (
-              <div key={i} className="rounded-xl border border-border bg-forge-900 h-48 animate-pulse" />
-            ))}
+            <BountyCardSkeleton count={4} />
           </div>
         )}
 

--- a/frontend/src/components/profile/ProfileDashboard.tsx
+++ b/frontend/src/components/profile/ProfileDashboard.tsx
@@ -7,6 +7,7 @@ import { useBounties } from '../../hooks/useBounties';
 import { timeAgo, formatCurrency } from '../../lib/utils';
 import { fadeIn, staggerContainer, staggerItem } from '../../lib/animations';
 import type { Bounty } from '../../types/bounty';
+import { ProfileSectionSkeleton } from '../skeletons/LoadingSkeletons';
 
 const TABS = ['My Bounties', 'My Submissions', 'Earnings', 'Settings'] as const;
 type Tab = typeof TABS[number];
@@ -35,7 +36,7 @@ function BountyStatusBadge({ status }: { status: string }) {
 
 function MyBountiesTab({ bounties, loading }: { bounties: Bounty[]; loading: boolean }) {
   if (loading) {
-    return <div className="text-text-muted text-sm py-8 text-center">Loading...</div>;
+    return <ProfileSectionSkeleton />;
   }
   if (!bounties.length) {
     return (

--- a/frontend/src/components/skeletons/LoadingSkeletons.test.tsx
+++ b/frontend/src/components/skeletons/LoadingSkeletons.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { BountyCardSkeleton, LeaderboardRowSkeleton, ProfileSectionSkeleton } from './LoadingSkeletons';
+
+describe('LoadingSkeletons', () => {
+  it('renders bounty card skeletons with shimmer and card shape', () => {
+    render(<BountyCardSkeleton count={2} />);
+
+    const skeletons = screen.getAllByLabelText(/loading bounty card/i);
+    expect(skeletons).toHaveLength(2);
+    expect(skeletons[0]).toHaveClass('animate-shimmer');
+    expect(skeletons[0]).toHaveClass('rounded-xl');
+  });
+
+  it('renders leaderboard row skeletons with table row shape', () => {
+    render(<LeaderboardRowSkeleton count={3} />);
+
+    const rows = screen.getAllByLabelText(/loading leaderboard row/i);
+    expect(rows).toHaveLength(3);
+    expect(rows[0]).toHaveClass('grid');
+  });
+
+  it('renders profile section skeleton with avatar and stat placeholders', () => {
+    render(<ProfileSectionSkeleton />);
+
+    expect(screen.getByLabelText(/loading profile section/i)).toBeInTheDocument();
+    expect(screen.getByTestId('profile-skeleton-avatar')).toHaveClass('rounded-full');
+    expect(screen.getAllByTestId('profile-skeleton-stat')).toHaveLength(3);
+  });
+});

--- a/frontend/src/components/skeletons/LoadingSkeletons.tsx
+++ b/frontend/src/components/skeletons/LoadingSkeletons.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+
+const shimmer = 'animate-shimmer bg-gradient-to-r from-forge-900 via-forge-800 to-forge-900 bg-[length:200%_100%]';
+
+export function BountyCardSkeleton({ count = 1 }: { count?: number }) {
+  return (
+    <>
+      {Array.from({ length: count }).map((_, index) => (
+        <div
+          key={index}
+          aria-label="Loading bounty card"
+          aria-busy="true"
+          className={`h-52 rounded-xl border border-border ${shimmer}`}
+        >
+          <div className="h-full p-5">
+            <div className="mb-5 h-4 w-3/4 rounded bg-white/10" />
+            <div className="mb-3 h-5 w-full rounded bg-white/10" />
+            <div className="h-5 w-2/3 rounded bg-white/10" />
+            <div className="mt-8 flex justify-between">
+              <div className="h-6 w-24 rounded bg-white/10" />
+              <div className="h-6 w-20 rounded bg-white/10" />
+            </div>
+          </div>
+        </div>
+      ))}
+    </>
+  );
+}
+
+export function LeaderboardRowSkeleton({ count = 5 }: { count?: number }) {
+  return (
+    <div className="max-w-4xl mx-auto mt-6 rounded-xl border border-border bg-forge-900 overflow-hidden">
+      {Array.from({ length: count }).map((_, index) => (
+        <div
+          key={index}
+          aria-label="Loading leaderboard row"
+          aria-busy="true"
+          className={`grid grid-cols-[60px_1fr_100px_120px] items-center gap-4 border-b border-border/30 px-4 py-3 last:border-b-0 ${shimmer}`}
+        >
+          <div className="h-4 rounded bg-white/10" />
+          <div className="flex items-center gap-3">
+            <div className="h-7 w-7 rounded-full bg-white/10" />
+            <div className="h-4 w-32 rounded bg-white/10" />
+          </div>
+          <div className="h-4 rounded bg-white/10" />
+          <div className="h-4 rounded bg-white/10" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function ProfileSectionSkeleton() {
+  return (
+    <div
+      aria-label="Loading profile section"
+      aria-busy="true"
+      className={`rounded-xl border border-border bg-forge-900 p-6 ${shimmer}`}
+    >
+      <div className="flex items-center gap-4">
+        <div data-testid="profile-skeleton-avatar" className="h-16 w-16 rounded-full bg-white/10" />
+        <div className="flex-1 space-y-3">
+          <div className="h-5 w-40 rounded bg-white/10" />
+          <div className="h-4 w-64 max-w-full rounded bg-white/10" />
+        </div>
+      </div>
+      <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, index) => (
+          <div key={index} data-testid="profile-skeleton-stat" className="h-20 rounded-lg bg-white/10" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/animations.ts
+++ b/frontend/src/lib/animations.ts
@@ -1,0 +1,38 @@
+import type { Variants } from 'framer-motion';
+
+export const fadeIn: Variants = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.35, ease: 'easeOut' } },
+};
+
+export const pageTransition: Variants = {
+  initial: { opacity: 0 },
+  animate: { opacity: 1, transition: { duration: 0.3, ease: 'easeOut' } },
+  exit: { opacity: 0, transition: { duration: 0.2 } },
+};
+
+export const cardHover: Variants = {
+  rest: { y: 0, borderColor: 'rgba(30, 30, 46, 1)' },
+  hover: { y: -4, borderColor: 'rgba(0, 230, 118, 0.35)' },
+};
+
+export const buttonHover: Variants = {
+  rest: { scale: 1 },
+  hover: { scale: 1.03 },
+  tap: { scale: 0.98 },
+};
+
+export const staggerContainer: Variants = {
+  initial: {},
+  animate: { transition: { staggerChildren: 0.06 } },
+};
+
+export const staggerItem: Variants = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.28, ease: 'easeOut' } },
+};
+
+export const slideInRight: Variants = {
+  initial: { opacity: 0, x: 20 },
+  animate: { opacity: 1, x: 0, transition: { duration: 0.28, ease: 'easeOut' } },
+};

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,37 @@
+export const LANG_COLORS: Record<string, string> = {
+  TypeScript: '#3178c6',
+  JavaScript: '#f7df1e',
+  Rust: '#dea584',
+  Solidity: '#627eea',
+  Python: '#3776ab',
+  Go: '#00add8',
+};
+
+export function formatCurrency(amount: number, token: string): string {
+  return `${new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 }).format(amount)} ${token}`;
+}
+
+export function timeAgo(date: string): string {
+  const diffMs = Date.now() - new Date(date).getTime();
+  const minutes = Math.max(0, Math.floor(diffMs / 60_000));
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+export function timeLeft(deadline: string): string {
+  const diffMs = new Date(deadline).getTime() - Date.now();
+  if (diffMs <= 0) return 'Expired';
+
+  const totalMinutes = Math.ceil(diffMs / 60_000);
+  const days = Math.floor(totalMinutes / 1_440);
+  const hours = Math.floor((totalMinutes % 1_440) / 60);
+  const minutes = totalMinutes % 60;
+
+  if (days > 0) return `${days}d ${hours}h ${minutes}m`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  return `${minutes}m`;
+}

--- a/frontend/src/pages/LeaderboardPage.tsx
+++ b/frontend/src/pages/LeaderboardPage.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import { PageLayout } from '../components/layout/PageLayout';
 import { PodiumCards } from '../components/leaderboard/PodiumCards';
 import { LeaderboardTable } from '../components/leaderboard/LeaderboardTable';
+import { LeaderboardRowSkeleton } from '../components/skeletons/LoadingSkeletons';
 import { useLeaderboard } from '../hooks/useLeaderboard';
 import type { TimePeriod } from '../types/leaderboard';
 import { fadeIn } from '../lib/animations';
@@ -47,9 +48,7 @@ export function LeaderboardPage() {
 
         {/* Loading */}
         {isLoading && (
-          <div className="flex justify-center py-16">
-            <div className="w-8 h-8 rounded-full border-2 border-emerald border-t-transparent animate-spin" />
-          </div>
+          <LeaderboardRowSkeleton count={5} />
         )}
 
         {/* Error */}


### PR DESCRIPTION
## Description
Adds reusable shimmer loading skeletons for bounty cards, leaderboard rows, and profile sections, then uses them in the data-loading states across the frontend.

Closes #827

## Solana Wallet for Payout
**Wallet:** ACVdXJborhi1xiTzU8rvYYGU4YWpvFwbnG1jgQJAVSg6

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🎨 Style/UI update
- [x] ✅ Test addition/update

## Checklist
- [x] Code is clean and follows the issue spec exactly
- [x] One PR per bounty (no multiple bounties in one PR)
- [x] Tests included for new functionality
- [x] No `console.log` or debugging code left behind
- [x] No hardcoded secrets or API keys

## Testing
- [x] Unit tests added/updated
- [x] `npx vitest run src/components/skeletons/LoadingSkeletons.test.tsx`
- [x] `npx tsc --noEmit`
- [x] `npm run build`

## Additional Notes
The branch also restores the shared frontend helper modules currently imported by existing components, and updates `.gitignore` so `frontend/src/lib` files are not hidden by the broad Python `lib/` ignore rule.