### PR TITLE
feat: add bounty search bar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ eggs/
 .eggs/
 lib/
 lib64/
+!frontend/src/lib/
+!frontend/src/lib/**
 parts/
 sdist/
 var/

--- a/frontend/src/api/bounties.ts
+++ b/frontend/src/api/bounties.ts
@@ -15,6 +15,7 @@ export interface BountiesListParams {
   skill?: string;
   tier?: string;
   reward_token?: string;
+  search?: string;
 }
 
 export interface BountiesListResponse {

--- a/frontend/src/components/bounty/BountyGrid.tsx
+++ b/frontend/src/components/bounty/BountyGrid.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { ChevronDown, Loader2, Plus } from 'lucide-react';
+import { ChevronDown, Loader2, Plus, Search, X } from 'lucide-react';
 import { BountyCard } from './BountyCard';
 import { useInfiniteBounties } from '../../hooks/useBounties';
 import { staggerContainer, staggerItem } from '../../lib/animations';
@@ -11,10 +11,21 @@ const FILTER_SKILLS = ['All', 'TypeScript', 'Rust', 'Solidity', 'Python', 'Go', 
 export function BountyGrid() {
   const [activeSkill, setActiveSkill] = useState<string>('All');
   const [statusFilter, setStatusFilter] = useState<string>('open');
+  const [searchInput, setSearchInput] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+
+  React.useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      setDebouncedSearch(searchInput.trim());
+    }, 300);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [searchInput]);
 
   const params = {
     status: statusFilter,
     skill: activeSkill !== 'All' ? activeSkill : undefined,
+    search: debouncedSearch || undefined,
   };
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, isError } =
@@ -51,6 +62,31 @@ export function BountyGrid() {
               <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-text-muted pointer-events-none" />
             </div>
           </div>
+        </div>
+
+        {/* Search */}
+        <div className="relative mb-6">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-muted" />
+          <input
+            type="search"
+            value={searchInput}
+            onChange={(event) => setSearchInput(event.target.value)}
+            placeholder="Search bounties by title, description, or tags"
+            className="w-full rounded-xl border border-border bg-forge-900 py-3 pl-10 pr-12 text-sm text-text-primary placeholder:text-text-muted outline-none transition-colors focus:border-emerald"
+          />
+          {searchInput && (
+            <button
+              type="button"
+              aria-label="Clear search"
+              onClick={() => {
+                setSearchInput('');
+                setDebouncedSearch('');
+              }}
+              className="absolute right-3 top-1/2 -translate-y-1/2 rounded-md p-1 text-text-muted transition-colors hover:bg-forge-800 hover:text-text-primary"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          )}
         </div>
 
         {/* Filter pills */}

--- a/frontend/src/components/bounty/BountyGridSearch.test.tsx
+++ b/frontend/src/components/bounty/BountyGridSearch.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { BountyGrid } from './BountyGrid';
+import { listBounties } from '../../api/bounties';
+
+vi.mock('../../api/bounties', () => ({
+  listBounties: vi.fn(),
+}));
+
+const mockedListBounties = vi.mocked(listBounties);
+
+function renderGrid() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <BountyGrid />
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe('BountyGrid search', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockedListBounties.mockReset();
+    mockedListBounties.mockResolvedValue({ items: [], total: 0, limit: 12, offset: 0 });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('debounces search and sends it with the existing bounty filters', () => {
+    renderGrid();
+
+    fireEvent.change(screen.getByPlaceholderText(/search bounties/i), { target: { value: 'rust' } });
+
+    expect(mockedListBounties).toHaveBeenCalledWith(expect.not.objectContaining({ search: 'rust' }));
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(mockedListBounties).toHaveBeenLastCalledWith(expect.objectContaining({
+      status: 'open',
+      search: 'rust',
+    }));
+  });
+
+  it('clears the search query without changing other filters', () => {
+    renderGrid();
+
+    fireEvent.click(screen.getByText('TypeScript'));
+    fireEvent.change(screen.getByPlaceholderText(/search bounties/i), { target: { value: 'api' } });
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    fireEvent.click(screen.getByLabelText(/clear search/i));
+
+    expect(screen.getByPlaceholderText(/search bounties/i)).toHaveValue('');
+    expect(screen.getByText('TypeScript')).toHaveClass('bg-forge-700');
+    expect(mockedListBounties).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'open',
+      skill: 'TypeScript',
+      search: undefined,
+    }));
+  });
+});

--- a/frontend/src/lib/animations.ts
+++ b/frontend/src/lib/animations.ts
@@ -1,0 +1,38 @@
+import type { Variants } from 'framer-motion';
+
+export const fadeIn: Variants = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.35, ease: 'easeOut' } },
+};
+
+export const pageTransition: Variants = {
+  initial: { opacity: 0 },
+  animate: { opacity: 1, transition: { duration: 0.3, ease: 'easeOut' } },
+  exit: { opacity: 0, transition: { duration: 0.2 } },
+};
+
+export const cardHover: Variants = {
+  rest: { y: 0, borderColor: 'rgba(30, 30, 46, 1)' },
+  hover: { y: -4, borderColor: 'rgba(0, 230, 118, 0.35)' },
+};
+
+export const buttonHover: Variants = {
+  rest: { scale: 1 },
+  hover: { scale: 1.03 },
+  tap: { scale: 0.98 },
+};
+
+export const staggerContainer: Variants = {
+  initial: {},
+  animate: { transition: { staggerChildren: 0.06 } },
+};
+
+export const staggerItem: Variants = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.28, ease: 'easeOut' } },
+};
+
+export const slideInRight: Variants = {
+  initial: { opacity: 0, x: 20 },
+  animate: { opacity: 1, x: 0, transition: { duration: 0.28, ease: 'easeOut' } },
+};

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,37 @@
+export const LANG_COLORS: Record<string, string> = {
+  TypeScript: '#3178c6',
+  JavaScript: '#f7df1e',
+  Rust: '#dea584',
+  Solidity: '#627eea',
+  Python: '#3776ab',
+  Go: '#00add8',
+};
+
+export function formatCurrency(amount: number, token: string): string {
+  return `${new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 }).format(amount)} ${token}`;
+}
+
+export function timeAgo(date: string): string {
+  const diffMs = Date.now() - new Date(date).getTime();
+  const minutes = Math.max(0, Math.floor(diffMs / 60_000));
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+export function timeLeft(deadline: string): string {
+  const diffMs = new Date(deadline).getTime() - Date.now();
+  if (diffMs <= 0) return 'Expired';
+
+  const totalMinutes = Math.ceil(diffMs / 60_000);
+  const days = Math.floor(totalMinutes / 1_440);
+  const hours = Math.floor((totalMinutes % 1_440) / 60);
+  const minutes = totalMinutes % 60;
+
+  if (days > 0) return `${days}d ${hours}h ${minutes}m`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  return `${minutes}m`;
+}


### PR DESCRIPTION
## Summary
- Adds a debounced search input to the bounties grid for title/description/tag API filtering.
- Keeps search working alongside existing status and skill filters, with a clear button that resets only the query.
- Restores the missing shared frontend helper modules required by existing imports so the branch builds cleanly.

## Test plan
- `npx vitest run src/components/bounty/BountyGridSearch.test.tsx`
- `npx tsc --noEmit`
- `npm run build`

Closes #823

FNDRY/Solana payout wallet: `ACVdXJborhi1xiTzU8rvYYGU4YWpvFwbnG1jgQJAVSg6`