### PR TITLE
feat: add search to bounties page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ eggs/
 .eggs/
 lib/
 lib64/
+!frontend/src/lib/
+!frontend/src/lib/**
 parts/
 sdist/
 var/

--- a/frontend/src/__tests__/bounty-grid-search.test.tsx
+++ b/frontend/src/__tests__/bounty-grid-search.test.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import type { Bounty } from '../types/bounty';
+import { BountyGrid } from '../components/bounty/BountyGrid';
+
+const mockUseInfiniteBounties = vi.hoisted(() => vi.fn());
+
+vi.mock('../hooks/useBounties', () => ({
+  useInfiniteBounties: mockUseInfiniteBounties,
+}));
+
+vi.mock('../components/bounty/BountyCard', () => ({
+  BountyCard: ({ bounty }: { bounty: Bounty }) => (
+    <article data-testid={`bounty-card-${bounty.id}`}>{bounty.title}</article>
+  ),
+}));
+
+const bounties: Bounty[] = [
+  {
+    id: 'one',
+    title: 'Build Rust escrow parser',
+    description: 'Parse on-chain escrow events',
+    status: 'open',
+    tier: 'T1',
+    reward_amount: 100000,
+    reward_token: 'FNDRY',
+    org_name: 'SolFoundry',
+    repo_name: 'solfoundry',
+    skills: ['Rust'],
+    submission_count: 0,
+    created_at: new Date().toISOString(),
+  },
+  {
+    id: 'two',
+    title: 'Polish bounty cards',
+    description: 'Responsive frontend improvements',
+    status: 'open',
+    tier: 'T1',
+    reward_amount: 150000,
+    reward_token: 'FNDRY',
+    org_name: 'SolFoundry',
+    repo_name: 'solfoundry',
+    skills: ['TypeScript'],
+    submission_count: 0,
+    created_at: new Date().toISOString(),
+  },
+];
+
+function renderGrid() {
+  render(
+    <MemoryRouter>
+      <BountyGrid />
+    </MemoryRouter>,
+  );
+}
+
+describe('BountyGrid search', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      'IntersectionObserver',
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
+    mockUseInfiniteBounties.mockReturnValue({
+      data: { pages: [{ items: bounties, total: bounties.length, limit: 12, offset: 0 }] },
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      isLoading: false,
+      isError: false,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('filters loaded bounties by title, description, repo, and tag text', () => {
+    renderGrid();
+
+    expect(screen.getByText('Build Rust escrow parser')).toBeInTheDocument();
+    expect(screen.getByText('Polish bounty cards')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByRole('searchbox', { name: /search bounties/i }), {
+      target: { value: 'typescript' },
+    });
+    act(() => vi.advanceTimersByTime(250));
+
+    expect(screen.queryByText('Build Rust escrow parser')).not.toBeInTheDocument();
+    expect(screen.getByText('Polish bounty cards')).toBeInTheDocument();
+  });
+
+  it('clears the search query with the clear button', () => {
+    renderGrid();
+
+    fireEvent.change(screen.getByRole('searchbox', { name: /search bounties/i }), {
+      target: { value: 'rust' },
+    });
+    act(() => vi.advanceTimersByTime(250));
+
+    expect(screen.getByText('Build Rust escrow parser')).toBeInTheDocument();
+    expect(screen.queryByText('Polish bounty cards')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /clear bounty search/i }));
+    act(() => vi.advanceTimersByTime(250));
+
+    expect(screen.getByText('Build Rust escrow parser')).toBeInTheDocument();
+    expect(screen.getByText('Polish bounty cards')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/bounty/BountyGrid.tsx
+++ b/frontend/src/components/bounty/BountyGrid.tsx
@@ -1,7 +1,7 @@
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { ChevronDown, Loader2, Plus } from 'lucide-react';
+import { ChevronDown, Loader2, Plus, Search, X } from 'lucide-react';
 import { BountyCard } from './BountyCard';
 import { useInfiniteBounties } from '../../hooks/useBounties';
 import { staggerContainer, staggerItem } from '../../lib/animations';
@@ -11,6 +11,16 @@ const FILTER_SKILLS = ['All', 'TypeScript', 'Rust', 'Solidity', 'Python', 'Go', 
 export function BountyGrid() {
   const [activeSkill, setActiveSkill] = useState<string>('All');
   const [statusFilter, setStatusFilter] = useState<string>('open');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('');
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      setDebouncedSearchQuery(searchQuery.trim().toLowerCase());
+    }, 250);
+
+    return () => window.clearTimeout(timeout);
+  }, [searchQuery]);
 
   const params = {
     status: statusFilter,
@@ -21,6 +31,27 @@ export function BountyGrid() {
     useInfiniteBounties(params);
 
   const allBounties = data?.pages.flatMap((p) => p.items) ?? [];
+  const visibleBounties = useMemo(() => {
+    if (!debouncedSearchQuery) return allBounties;
+
+    return allBounties.filter((bounty) => {
+      const searchableText = [
+        bounty.title,
+        bounty.description,
+        bounty.category,
+        bounty.org_name,
+        bounty.repo_name,
+        bounty.github_issue_url,
+        bounty.github_repo_url,
+        ...(bounty.skills ?? []),
+      ]
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase();
+
+      return searchableText.includes(debouncedSearchQuery);
+    });
+  }, [allBounties, debouncedSearchQuery]);
 
   return (
     <section id="bounties" className="py-16 md:py-24">
@@ -50,6 +81,31 @@ export function BountyGrid() {
               </select>
               <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-text-muted pointer-events-none" />
             </div>
+          </div>
+        </div>
+
+        {/* Search */}
+        <div className="mb-6">
+          <div className="relative max-w-2xl">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted pointer-events-none" />
+            <input
+              type="search"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder="Search bounties by title, description, repo, or tag"
+              aria-label="Search bounties"
+              className="w-full rounded-lg border border-border bg-forge-900 py-2.5 pl-10 pr-11 text-sm text-text-primary placeholder:text-text-muted outline-none transition-colors duration-150 focus:border-emerald"
+            />
+            {searchQuery && (
+              <button
+                type="button"
+                onClick={() => setSearchQuery('')}
+                aria-label="Clear bounty search"
+                className="absolute right-2 top-1/2 -translate-y-1/2 rounded-md p-1.5 text-text-muted transition-colors duration-150 hover:bg-forge-800 hover:text-text-primary"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            )}
           </div>
         </div>
 
@@ -93,17 +149,21 @@ export function BountyGrid() {
         )}
 
         {/* Empty state */}
-        {!isLoading && !isError && allBounties.length === 0 && (
+        {!isLoading && !isError && visibleBounties.length === 0 && (
           <div className="text-center py-16">
             <p className="text-text-muted text-lg mb-2">No bounties found</p>
             <p className="text-text-muted text-sm">
-              {activeSkill !== 'All' ? `Try a different language filter.` : 'Check back soon for new bounties.'}
+              {debouncedSearchQuery
+                ? 'Try a different search term or clear the search.'
+                : activeSkill !== 'All'
+                  ? 'Try a different language filter.'
+                  : 'Check back soon for new bounties.'}
             </p>
           </div>
         )}
 
         {/* Bounty grid */}
-        {!isLoading && allBounties.length > 0 && (
+        {!isLoading && visibleBounties.length > 0 && (
           <motion.div
             variants={staggerContainer}
             initial="initial"
@@ -111,7 +171,7 @@ export function BountyGrid() {
             viewport={{ once: true, margin: '-50px' }}
             className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5"
           >
-            {allBounties.map((bounty) => (
+            {visibleBounties.map((bounty) => (
               <motion.div key={bounty.id} variants={staggerItem}>
                 <BountyCard bounty={bounty} />
               </motion.div>

--- a/frontend/src/lib/animations.ts
+++ b/frontend/src/lib/animations.ts
@@ -1,0 +1,42 @@
+import type { Variants } from 'framer-motion';
+
+export const fadeIn: Variants = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.3, ease: 'easeOut' } },
+};
+
+export const pageTransition: Variants = {
+  initial: { opacity: 0, y: 16 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.35, ease: 'easeOut' } },
+  exit: { opacity: 0, y: -8, transition: { duration: 0.2, ease: 'easeIn' } },
+};
+
+export const staggerContainer: Variants = {
+  initial: {},
+  animate: {
+    transition: {
+      staggerChildren: 0.06,
+    },
+  },
+};
+
+export const staggerItem: Variants = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.25, ease: 'easeOut' } },
+};
+
+export const slideInRight: Variants = {
+  initial: { opacity: 0, x: 24 },
+  animate: { opacity: 1, x: 0, transition: { duration: 0.25, ease: 'easeOut' } },
+};
+
+export const cardHover: Variants = {
+  rest: { y: 0 },
+  hover: { y: -3, transition: { duration: 0.18, ease: 'easeOut' } },
+};
+
+export const buttonHover: Variants = {
+  rest: { scale: 1 },
+  hover: { scale: 1.03, transition: { duration: 0.15, ease: 'easeOut' } },
+  tap: { scale: 0.98 },
+};

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,64 @@
+import type { RewardToken } from '../types/bounty';
+
+export const LANG_COLORS: Record<string, string> = {
+  TypeScript: '#3178c6',
+  JavaScript: '#f7df1e',
+  Rust: '#dea584',
+  Solidity: '#627eea',
+  Python: '#3776ab',
+  Go: '#00add8',
+  React: '#61dafb',
+  TS: '#3178c6',
+};
+
+export function formatCurrency(amount: number, token: RewardToken = 'FNDRY'): string {
+  const formatted = new Intl.NumberFormat('en-US', {
+    maximumFractionDigits: amount >= 100 ? 0 : 2,
+  }).format(amount);
+
+  return token === 'USDC' ? `$${formatted}` : `${formatted} ${token}`;
+}
+
+export function timeAgo(value: string | Date): string {
+  const date = value instanceof Date ? value : new Date(value);
+  const deltaSeconds = Math.floor((Date.now() - date.getTime()) / 1000);
+
+  if (!Number.isFinite(deltaSeconds)) return 'Unknown';
+  if (deltaSeconds < 60) return 'Just now';
+
+  const units: Array<[Intl.RelativeTimeFormatUnit, number]> = [
+    ['year', 31_536_000],
+    ['month', 2_592_000],
+    ['week', 604_800],
+    ['day', 86_400],
+    ['hour', 3_600],
+    ['minute', 60],
+  ];
+  const formatter = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
+
+  for (const [unit, secondsPerUnit] of units) {
+    const valueInUnit = Math.floor(deltaSeconds / secondsPerUnit);
+    if (valueInUnit >= 1) return formatter.format(-valueInUnit, unit);
+  }
+
+  return 'Just now';
+}
+
+export function timeLeft(value: string | Date): string {
+  const date = value instanceof Date ? value : new Date(value);
+  const deltaSeconds = Math.floor((date.getTime() - Date.now()) / 1000);
+
+  if (!Number.isFinite(deltaSeconds)) return 'Unknown';
+  if (deltaSeconds <= 0) return 'Expired';
+
+  const days = Math.floor(deltaSeconds / 86_400);
+  if (days >= 1) return `${days}d left`;
+
+  const hours = Math.floor(deltaSeconds / 3_600);
+  if (hours >= 1) return `${hours}h left`;
+
+  const minutes = Math.floor(deltaSeconds / 60);
+  if (minutes >= 1) return `${minutes}m left`;
+
+  return 'Less than 1m';
+}


### PR DESCRIPTION
﻿Adds a debounced search input to the `/bounties` grid so users can filter loaded bounties by title, description, repository metadata, category, and skill/tag text.Implementation details:- Adds a search field above the existing skill filters- Debounces search input before applying the filter- Keeps search compatible with the existing status and skill filters- Adds a clear-search button- Adds focused coverage for search filtering and reset behavior- Restores the shared frontend `lib` modules currently imported by the app, and narrows `.gitignore` so those source files are trackedVerification:- `npm.cmd run build`- `npm.cmd test -- src/__tests__/bounty-grid-search.test.tsx`Closes #823

Wallet: C2z3FWAacvSYVrrkfpk6nQyNhF4t3z7t9iXRW1xfZPy1