### PR TITLE
feat: add search bar to bounties page

### DIFF
--- a/frontend/src/components/bounty/BountyGrid.tsx
+++ b/frontend/src/components/bounty/BountyGrid.tsx
@@ -1,7 +1,7 @@
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { ChevronDown, Loader2, Plus } from 'lucide-react';
+import { ChevronDown, Loader2, Plus, Search, X } from 'lucide-react';
 import { BountyCard } from './BountyCard';
 import { useInfiniteBounties } from '../../hooks/useBounties';
 import { staggerContainer, staggerItem } from '../../lib/animations';
@@ -11,6 +11,16 @@ const FILTER_SKILLS = ['All', 'TypeScript', 'Rust', 'Solidity', 'Python', 'Go', 
 export function BountyGrid() {
   const [activeSkill, setActiveSkill] = useState<string>('All');
   const [statusFilter, setStatusFilter] = useState<string>('open');
+  const [searchInput, setSearchInput] = useState('');
+  const [searchQuery, setSearchQuery] = useState('');
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      setSearchQuery(searchInput.trim().toLowerCase());
+    }, 250);
+
+    return () => window.clearTimeout(timer);
+  }, [searchInput]);
 
   const params = {
     status: statusFilter,
@@ -21,6 +31,25 @@ export function BountyGrid() {
     useInfiniteBounties(params);
 
   const allBounties = data?.pages.flatMap((p) => p.items) ?? [];
+
+  const filteredBounties = useMemo(() => {
+    if (!searchQuery) return allBounties;
+
+    return allBounties.filter((bounty) => {
+      const haystack = [
+        bounty.title,
+        bounty.description,
+        bounty.category ?? '',
+        bounty.org_name ?? '',
+        bounty.repo_name ?? '',
+        ...(bounty.skills ?? []),
+      ]
+        .join(' ')
+        .toLowerCase();
+
+      return haystack.includes(searchQuery);
+    });
+  }, [allBounties, searchQuery]);
 
   return (
     <section id="bounties" className="py-16 md:py-24">
@@ -50,6 +79,29 @@ export function BountyGrid() {
               </select>
               <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-text-muted pointer-events-none" />
             </div>
+          </div>
+        </div>
+
+        {/* Search */}
+        <div className="mb-6">
+          <div className="relative max-w-xl">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted" />
+            <input
+              value={searchInput}
+              onChange={(e) => setSearchInput(e.target.value)}
+              placeholder="Search by title, description, or tags"
+              className="w-full bg-forge-800 border border-border rounded-lg pl-9 pr-10 py-2 text-sm text-text-secondary placeholder:text-text-muted focus:border-emerald outline-none transition-colors duration-150"
+            />
+            {searchInput && (
+              <button
+                type="button"
+                onClick={() => setSearchInput('')}
+                aria-label="Clear search"
+                className="absolute right-2 top-1/2 -translate-y-1/2 p-1 rounded-md text-text-muted hover:text-text-secondary hover:bg-forge-700 transition-colors"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            )}
           </div>
         </div>
 
@@ -93,17 +145,21 @@ export function BountyGrid() {
         )}
 
         {/* Empty state */}
-        {!isLoading && !isError && allBounties.length === 0 && (
+        {!isLoading && !isError && filteredBounties.length === 0 && (
           <div className="text-center py-16">
             <p className="text-text-muted text-lg mb-2">No bounties found</p>
             <p className="text-text-muted text-sm">
-              {activeSkill !== 'All' ? `Try a different language filter.` : 'Check back soon for new bounties.'}
+              {searchQuery
+                ? 'Try a different search term or clear filters.'
+                : activeSkill !== 'All'
+                  ? 'Try a different language filter.'
+                  : 'Check back soon for new bounties.'}
             </p>
           </div>
         )}
 
         {/* Bounty grid */}
-        {!isLoading && allBounties.length > 0 && (
+        {!isLoading && filteredBounties.length > 0 && (
           <motion.div
             variants={staggerContainer}
             initial="initial"
@@ -111,7 +167,7 @@ export function BountyGrid() {
             viewport={{ once: true, margin: '-50px' }}
             className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5"
           >
-            {allBounties.map((bounty) => (
+            {filteredBounties.map((bounty) => (
               <motion.div key={bounty.id} variants={staggerItem}>
                 <BountyCard bounty={bounty} />
               </motion.div>


### PR DESCRIPTION
## Summary
- add a search input above bounty filters on `/bounties`
- debounce user input (250ms) before applying filter
- filter bounty cards client-side by title, description, category, org/repo, and skills
- add clear button and improved empty-state message when search has no matches

## Why
Issue #823 asks for a bounties-page search bar that works with existing filters and supports title/description/tag matching.

## Acceptance mapping
- [x] Search bar visible on `/bounties`
- [x] Typing filters bounties in near real-time (debounced)
- [x] Works alongside existing status + language filters
- [x] Clear button resets search

Closes #823

## Validation
- Manual code-path verification for search/filter interaction in `BountyGrid`
- Attempted `npm run build` in `frontend`, but branch currently fails due to pre-existing missing `lib/animations` and `lib/utils` module resolution errors unrelated to this change.
