### PR TITLE
feat: add bounty countdown timer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ eggs/
 .eggs/
 lib/
 lib64/
+!frontend/src/lib/
+!frontend/src/lib/**
 parts/
 sdist/
 var/

--- a/frontend/src/__tests__/bounty-countdown.test.tsx
+++ b/frontend/src/__tests__/bounty-countdown.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BountyCountdown } from '../components/bounty/BountyCountdown';
+
+const now = new Date('2026-05-11T12:00:00Z');
+
+describe('BountyCountdown', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('shows days, hours, and minutes remaining', () => {
+    render(<BountyCountdown deadline="2026-05-13T14:30:00Z" />);
+
+    expect(screen.getByTestId('bounty-countdown')).toHaveTextContent('2d 2h 30m');
+    expect(screen.getByTestId('bounty-countdown')).toHaveAttribute('data-urgency', 'normal');
+  });
+
+  it('uses warning urgency when less than 24 hours remain', () => {
+    render(<BountyCountdown deadline="2026-05-12T10:00:00Z" />);
+
+    expect(screen.getByTestId('bounty-countdown')).toHaveTextContent('22h 0m');
+    expect(screen.getByTestId('bounty-countdown')).toHaveAttribute('data-urgency', 'warning');
+  });
+
+  it('uses urgent urgency when less than 1 hour remains', () => {
+    render(<BountyCountdown deadline="2026-05-11T12:45:00Z" />);
+
+    expect(screen.getByTestId('bounty-countdown')).toHaveTextContent('45m');
+    expect(screen.getByTestId('bounty-countdown')).toHaveAttribute('data-urgency', 'urgent');
+  });
+
+  it('shows expired when the deadline has passed', () => {
+    render(<BountyCountdown deadline="2026-05-11T11:59:00Z" />);
+
+    expect(screen.getByTestId('bounty-countdown')).toHaveTextContent('Expired');
+    expect(screen.getByTestId('bounty-countdown')).toHaveAttribute('data-urgency', 'expired');
+  });
+});

--- a/frontend/src/components/bounty/BountyCard.tsx
+++ b/frontend/src/components/bounty/BountyCard.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { GitPullRequest, Clock } from 'lucide-react';
+import { GitPullRequest } from 'lucide-react';
 import type { Bounty } from '../../types/bounty';
 import { cardHover } from '../../lib/animations';
-import { timeLeft, formatCurrency, LANG_COLORS } from '../../lib/utils';
+import { formatCurrency, LANG_COLORS } from '../../lib/utils';
+import { BountyCountdown } from './BountyCountdown';
 
 function TierBadge({ tier }: { tier: string }) {
   const styles: Record<string, string> = {
@@ -111,10 +112,7 @@ export function BountyCard({ bounty }: BountyCardProps) {
             {bounty.submission_count} PRs
           </span>
           {bounty.deadline && (
-            <span className="inline-flex items-center gap-1">
-              <Clock className="w-3.5 h-3.5" />
-              {timeLeft(bounty.deadline)}
-            </span>
+            <BountyCountdown deadline={bounty.deadline} compact />
           )}
         </div>
       </div>

--- a/frontend/src/components/bounty/BountyCountdown.tsx
+++ b/frontend/src/components/bounty/BountyCountdown.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Clock } from 'lucide-react';
+
+interface BountyCountdownProps {
+  deadline?: string | null;
+  compact?: boolean;
+}
+
+interface CountdownState {
+  label: string;
+  tone: 'normal' | 'warning' | 'urgent' | 'expired';
+}
+
+function getCountdownState(deadline?: string | null): CountdownState | null {
+  if (!deadline) return null;
+
+  const target = new Date(deadline).getTime();
+  const remainingMs = target - Date.now();
+
+  if (!Number.isFinite(target)) {
+    return { label: 'Unknown', tone: 'expired' };
+  }
+
+  if (remainingMs <= 0) {
+    return { label: 'Expired', tone: 'expired' };
+  }
+
+  const totalMinutes = Math.ceil(remainingMs / 60_000);
+  const days = Math.floor(totalMinutes / 1_440);
+  const hours = Math.floor((totalMinutes % 1_440) / 60);
+  const minutes = totalMinutes % 60;
+
+  const parts = [];
+  if (days > 0) parts.push(`${days}d`);
+  if (hours > 0 || days > 0) parts.push(`${hours}h`);
+  parts.push(`${minutes}m`);
+
+  return {
+    label: parts.join(' '),
+    tone: remainingMs < 3_600_000 ? 'urgent' : remainingMs < 86_400_000 ? 'warning' : 'normal',
+  };
+}
+
+const toneClasses: Record<CountdownState['tone'], string> = {
+  normal: 'text-text-muted border-border bg-forge-800/70',
+  warning: 'text-status-warning border-status-warning/30 bg-status-warning/10',
+  urgent: 'text-status-error border-status-error/30 bg-status-error/10',
+  expired: 'text-text-muted border-border bg-forge-800/50',
+};
+
+export function BountyCountdown({ deadline, compact = false }: BountyCountdownProps) {
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    if (!deadline) return undefined;
+
+    const interval = window.setInterval(() => {
+      setTick((value) => value + 1);
+    }, 60_000);
+
+    return () => window.clearInterval(interval);
+  }, [deadline]);
+
+  const countdown = useMemo(() => getCountdownState(deadline), [deadline, tick]);
+  if (!countdown) return null;
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-md border font-mono ${
+        compact ? 'px-1.5 py-0.5 text-xs' : 'px-2.5 py-1.5 text-sm'
+      } ${toneClasses[countdown.tone]}`}
+      aria-label={`Bounty deadline countdown: ${countdown.label}`}
+      data-testid="bounty-countdown"
+      data-urgency={countdown.tone}
+    >
+      <Clock className={compact ? 'w-3.5 h-3.5' : 'w-4 h-4'} />
+      {countdown.label}
+    </span>
+  );
+}

--- a/frontend/src/components/bounty/BountyDetail.tsx
+++ b/frontend/src/components/bounty/BountyDetail.tsx
@@ -3,10 +3,11 @@ import { Link, useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { ArrowLeft, Clock, GitPullRequest, ExternalLink, Loader2, Check, Copy } from 'lucide-react';
 import type { Bounty } from '../../types/bounty';
-import { timeLeft, timeAgo, formatCurrency, LANG_COLORS } from '../../lib/utils';
+import { timeAgo, formatCurrency, LANG_COLORS } from '../../lib/utils';
 import { useAuth } from '../../hooks/useAuth';
 import { SubmissionForm } from './SubmissionForm';
 import { fadeIn } from '../../lib/animations';
+import { BountyCountdown } from './BountyCountdown';
 
 interface BountyDetailProps {
   bounty: Bounty;
@@ -138,9 +139,7 @@ export function BountyDetail({ bounty }: BountyDetailProps) {
             {bounty.deadline && (
               <div className="flex items-center justify-between text-sm">
                 <span className="text-text-muted">Deadline</span>
-                <span className="font-mono text-status-warning inline-flex items-center gap-1">
-                  <Clock className="w-3.5 h-3.5" /> {timeLeft(bounty.deadline)}
-                </span>
+                <BountyCountdown deadline={bounty.deadline} />
               </div>
             )}
             <div className="flex items-center justify-between text-sm">

--- a/frontend/src/lib/animations.ts
+++ b/frontend/src/lib/animations.ts
@@ -1,0 +1,38 @@
+import type { Variants } from 'framer-motion';
+
+export const fadeIn: Variants = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.3, ease: 'easeOut' } },
+};
+
+export const pageTransition: Variants = {
+  initial: { opacity: 0, y: 16 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.35, ease: 'easeOut' } },
+  exit: { opacity: 0, y: -8, transition: { duration: 0.2, ease: 'easeIn' } },
+};
+
+export const staggerContainer: Variants = {
+  initial: {},
+  animate: { transition: { staggerChildren: 0.06 } },
+};
+
+export const staggerItem: Variants = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.25, ease: 'easeOut' } },
+};
+
+export const slideInRight: Variants = {
+  initial: { opacity: 0, x: 24 },
+  animate: { opacity: 1, x: 0, transition: { duration: 0.25, ease: 'easeOut' } },
+};
+
+export const cardHover: Variants = {
+  rest: { y: 0 },
+  hover: { y: -3, transition: { duration: 0.18, ease: 'easeOut' } },
+};
+
+export const buttonHover: Variants = {
+  rest: { scale: 1 },
+  hover: { scale: 1.03, transition: { duration: 0.15, ease: 'easeOut' } },
+  tap: { scale: 0.98 },
+};

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,64 @@
+import type { RewardToken } from '../types/bounty';
+
+export const LANG_COLORS: Record<string, string> = {
+  TypeScript: '#3178c6',
+  JavaScript: '#f7df1e',
+  Rust: '#dea584',
+  Solidity: '#627eea',
+  Python: '#3776ab',
+  Go: '#00add8',
+  React: '#61dafb',
+  TS: '#3178c6',
+};
+
+export function formatCurrency(amount: number, token: RewardToken = 'FNDRY'): string {
+  const formatted = new Intl.NumberFormat('en-US', {
+    maximumFractionDigits: amount >= 100 ? 0 : 2,
+  }).format(amount);
+
+  return token === 'USDC' ? `$${formatted}` : `${formatted} ${token}`;
+}
+
+export function timeAgo(value: string | Date): string {
+  const date = value instanceof Date ? value : new Date(value);
+  const deltaSeconds = Math.floor((Date.now() - date.getTime()) / 1000);
+
+  if (!Number.isFinite(deltaSeconds)) return 'Unknown';
+  if (deltaSeconds < 60) return 'Just now';
+
+  const units: Array<[Intl.RelativeTimeFormatUnit, number]> = [
+    ['year', 31_536_000],
+    ['month', 2_592_000],
+    ['week', 604_800],
+    ['day', 86_400],
+    ['hour', 3_600],
+    ['minute', 60],
+  ];
+  const formatter = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
+
+  for (const [unit, secondsPerUnit] of units) {
+    const valueInUnit = Math.floor(deltaSeconds / secondsPerUnit);
+    if (valueInUnit >= 1) return formatter.format(-valueInUnit, unit);
+  }
+
+  return 'Just now';
+}
+
+export function timeLeft(value: string | Date): string {
+  const date = value instanceof Date ? value : new Date(value);
+  const deltaSeconds = Math.floor((date.getTime() - Date.now()) / 1000);
+
+  if (!Number.isFinite(deltaSeconds)) return 'Unknown';
+  if (deltaSeconds <= 0) return 'Expired';
+
+  const days = Math.floor(deltaSeconds / 86_400);
+  if (days >= 1) return `${days}d left`;
+
+  const hours = Math.floor(deltaSeconds / 3_600);
+  if (hours >= 1) return `${hours}h left`;
+
+  const minutes = Math.floor(deltaSeconds / 60);
+  if (minutes >= 1) return `${minutes}m left`;
+
+  return 'Less than 1m';
+}


### PR DESCRIPTION
﻿Adds a reusable bounty countdown timer component for bounty deadlines.Implementation details:- Displays days, hours, and minutes remaining- Updates automatically once per minute without a page refresh- Shows warning styling below 24 hours and urgent styling below 1 hour- Shows `Expired` after the deadline passes- Renders on bounty cards and the bounty detail sidebar- Adds focused unit coverage for normal, warning, urgent, and expired states- Restores the shared frontend `lib` modules currently imported by the app, and narrows `.gitignore` so those source files are trackedVerification:- `npm.cmd run build`- `npm.cmd test -- src/__tests__/bounty-countdown.test.tsx`Closes #826

Wallet: C2z3FWAacvSYVrrkfpk6nQyNhF4t3z7t9iXRW1xfZPy1