### PR TITLE
Fix mobile responsive polish

### DIFF
--- a/frontend/src/components/home/HeroSection.tsx
+++ b/frontend/src/components/home/HeroSection.tsx
@@ -111,10 +111,10 @@ export function HeroSection() {
         </div>
 
         {/* Terminal body */}
-        <div className="p-5 font-mono text-sm leading-relaxed">
-          <div className="overflow-hidden">
+        <div className="p-3 sm:p-5 font-mono text-xs sm:text-sm leading-relaxed">
+          <div className="sm:overflow-hidden">
             <span className="text-emerald">$ </span>
-            <span className="text-text-secondary overflow-hidden whitespace-nowrap inline-block animate-typewriter">
+            <span className="text-text-secondary whitespace-normal break-words sm:overflow-hidden sm:whitespace-nowrap sm:inline-block sm:animate-typewriter">
               forge bounty --reward 100 --lang typescript --tier 2
             </span>
             {typewriterDone && (
@@ -211,7 +211,7 @@ export function HeroSection() {
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         transition={{ delay: 0.8, duration: 0.5 }}
-        className="flex items-center justify-center gap-6 mt-8 font-mono text-sm text-text-muted"
+        className="flex flex-wrap items-center justify-center gap-x-4 gap-y-2 mt-8 font-mono text-xs sm:text-sm text-text-muted"
       >
         <span>
           <span className="text-text-primary font-semibold">
@@ -219,14 +219,14 @@ export function HeroSection() {
           </span>
           {' '}open bounties
         </span>
-        <span className="text-text-muted">·</span>
+        <span className="hidden sm:inline text-text-muted">·</span>
         <span>
           <span className="text-text-primary font-semibold">
             $<CountUp target={stats?.total_paid_usdc ?? 24500} />
           </span>
           {' '}paid
         </span>
-        <span className="text-text-muted">·</span>
+        <span className="hidden sm:inline text-text-muted">·</span>
         <span>
           <span className="text-text-primary font-semibold">
             <CountUp target={stats?.total_contributors ?? 89} />

--- a/frontend/src/lib/animations.ts
+++ b/frontend/src/lib/animations.ts
@@ -1,0 +1,68 @@
+import type { Variants } from 'framer-motion';
+
+export const fadeIn: Variants = {
+  initial: { opacity: 0, y: 12 },
+  animate: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.35, ease: 'easeOut' },
+  },
+};
+
+export const pageTransition: Variants = {
+  initial: { opacity: 0 },
+  animate: {
+    opacity: 1,
+    transition: { duration: 0.25, ease: 'easeOut' },
+  },
+  exit: {
+    opacity: 0,
+    transition: { duration: 0.15, ease: 'easeIn' },
+  },
+};
+
+export const slideInRight: Variants = {
+  initial: { opacity: 0, x: 24 },
+  animate: {
+    opacity: 1,
+    x: 0,
+    transition: { duration: 0.25, ease: 'easeOut' },
+  },
+};
+
+export const staggerContainer: Variants = {
+  initial: {},
+  animate: {
+    transition: {
+      staggerChildren: 0.08,
+      delayChildren: 0.05,
+    },
+  },
+};
+
+export const staggerItem: Variants = {
+  initial: { opacity: 0, y: 12 },
+  animate: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.25, ease: 'easeOut' },
+  },
+};
+
+export const cardHover: Variants = {
+  rest: { y: 0, scale: 1 },
+  hover: {
+    y: -3,
+    scale: 1.01,
+    transition: { duration: 0.18, ease: 'easeOut' },
+  },
+};
+
+export const buttonHover: Variants = {
+  rest: { scale: 1 },
+  hover: {
+    scale: 1.03,
+    transition: { duration: 0.15, ease: 'easeOut' },
+  },
+  tap: { scale: 0.98 },
+};

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,57 @@
+import type { RewardToken } from '../types/bounty';
+
+export const LANG_COLORS: Record<string, string> = {
+  TypeScript: '#3178C6',
+  JavaScript: '#F7DF1E',
+  Rust: '#DEA584',
+  Solidity: '#AA6746',
+  Python: '#3776AB',
+  Go: '#00ADD8',
+  React: '#61DAFB',
+  Solana: '#14F195',
+};
+
+export function formatCurrency(amount: number, token: RewardToken | string = 'USDC') {
+  const formatted = new Intl.NumberFormat('en-US', {
+    maximumFractionDigits: amount >= 100 ? 0 : 2,
+  }).format(amount);
+
+  return token === 'USDC' ? `$${formatted}` : `${formatted} ${token}`;
+}
+
+export function timeAgo(date: string) {
+  const diffMs = Date.now() - new Date(date).getTime();
+  const diffMinutes = Math.max(0, Math.floor(diffMs / 60000));
+
+  if (diffMinutes < 1) return 'just now';
+  if (diffMinutes < 60) return `${diffMinutes}m ago`;
+
+  const diffHours = Math.floor(diffMinutes / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays < 30) return `${diffDays}d ago`;
+
+  const diffMonths = Math.floor(diffDays / 30);
+  if (diffMonths < 12) return `${diffMonths}mo ago`;
+
+  return `${Math.floor(diffMonths / 12)}y ago`;
+}
+
+export function timeLeft(date: string) {
+  const diffMs = new Date(date).getTime() - Date.now();
+
+  if (diffMs <= 0) return 'expired';
+
+  const diffMinutes = Math.ceil(diffMs / 60000);
+  if (diffMinutes < 60) return `${diffMinutes}m left`;
+
+  const diffHours = Math.ceil(diffMinutes / 60);
+  if (diffHours < 24) return `${diffHours}h left`;
+
+  const diffDays = Math.ceil(diffHours / 24);
+  if (diffDays < 30) return `${diffDays}d left`;
+
+  const diffMonths = Math.ceil(diffDays / 30);
+  return `${diffMonths}mo left`;
+}


### PR DESCRIPTION
## Summary

- Restore the shared frontend `lib` helpers required by the existing imports.
- Make the hero terminal readable at narrow widths by allowing the command to wrap on mobile.
- Let the hero stats strip wrap cleanly on small screens to avoid horizontal overflow.

## Verification

- `npm run build`
- Playwright responsive checks at 375px and 768px for `/` and `/bounties`
- Confirmed no horizontal scroll at both widths
- Confirmed bounty cards stack at 375px and render in two columns at 768px with mocked local API data

## Solana Wallet for Payout

Wallet: 2PuWnBEMV2aBCz95KEsajszUGHT6HyvHDxq6JTA3asQu

Addresses #833
