### PR TITLE
feat: add toast notification system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ eggs/
 .eggs/
 lib/
 lib64/
+!frontend/src/lib/
+!frontend/src/lib/**
 parts/
 sdist/
 var/

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import React, { Suspense } from 'react';
 import { Routes, Route } from 'react-router-dom';
 import { AuthGuard } from './components/auth/AuthGuard';
+import { ToastProvider } from './components/toast/ToastProvider';
 
 // Lazy load pages
 const HomePage = React.lazy(() => import('./pages/HomePage').then((m) => ({ default: m.HomePage })));
@@ -23,32 +24,34 @@ function PageLoader() {
 
 export default function App() {
   return (
-    <Suspense fallback={<PageLoader />}>
-      <Routes>
-        <Route path="/" element={<HomePage />} />
-        <Route path="/leaderboard" element={<LeaderboardPage />} />
-        <Route path="/how-it-works" element={<HowItWorksPage />} />
-        <Route
-          path="/profile"
-          element={
-            <AuthGuard>
-              <ProfilePage />
-            </AuthGuard>
-          }
-        />
-        <Route
-          path="/bounties/create"
-          element={
-            <AuthGuard>
-              <BountyCreatePage />
-            </AuthGuard>
-          }
-        />
-        <Route path="/bounties" element={<BountiesPage />} />
-        <Route path="/bounties/:id" element={<BountyDetailPage />} />
-        <Route path="/auth/github/callback" element={<GitHubCallbackPage />} />
-        <Route path="*" element={<NotFoundPage />} />
-      </Routes>
-    </Suspense>
+    <ToastProvider>
+      <Suspense fallback={<PageLoader />}>
+        <Routes>
+          <Route path="/" element={<HomePage />} />
+          <Route path="/leaderboard" element={<LeaderboardPage />} />
+          <Route path="/how-it-works" element={<HowItWorksPage />} />
+          <Route
+            path="/profile"
+            element={
+              <AuthGuard>
+                <ProfilePage />
+              </AuthGuard>
+            }
+          />
+          <Route
+            path="/bounties/create"
+            element={
+              <AuthGuard>
+                <BountyCreatePage />
+              </AuthGuard>
+            }
+          />
+          <Route path="/bounties" element={<BountiesPage />} />
+          <Route path="/bounties/:id" element={<BountyDetailPage />} />
+          <Route path="/auth/github/callback" element={<GitHubCallbackPage />} />
+          <Route path="*" element={<NotFoundPage />} />
+        </Routes>
+      </Suspense>
+    </ToastProvider>
   );
 }

--- a/frontend/src/__tests__/toast-provider.test.tsx
+++ b/frontend/src/__tests__/toast-provider.test.tsx
@@ -1,0 +1,98 @@
+import React, { type HTMLAttributes, type ReactNode } from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ToastProvider, useToast } from '../components/toast/ToastProvider';
+
+vi.mock('framer-motion', async () => {
+  const React = await import('react');
+
+  return {
+    AnimatePresence: ({ children }: { children: ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+    motion: {
+      div: ({
+        children,
+        initial,
+        animate,
+        exit,
+        transition,
+        ...props
+      }: HTMLAttributes<HTMLDivElement> & {
+        children?: ReactNode;
+        initial?: unknown;
+        animate?: unknown;
+        exit?: unknown;
+        transition?: unknown;
+      }) => React.createElement('div', props, children),
+    },
+  };
+});
+
+function ToastHarness() {
+  const toast = useToast();
+
+  return (
+    <div>
+      <button type="button" onClick={() => toast.success('Saved bounty')}>Success</button>
+      <button type="button" onClick={() => toast.error('Failed bounty')}>Error</button>
+      <button type="button" onClick={() => toast.warning('Check bounty')}>Warning</button>
+      <button type="button" onClick={() => toast.info('Loaded bounty')}>Info</button>
+    </div>
+  );
+}
+
+function renderHarness() {
+  render(
+    <ToastProvider>
+      <ToastHarness />
+    </ToastProvider>,
+  );
+}
+
+describe('ToastProvider', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders accessible stacked toast notifications', () => {
+    renderHarness();
+
+    fireEvent.click(screen.getByRole('button', { name: /success/i }));
+    fireEvent.click(screen.getByRole('button', { name: /error/i }));
+    fireEvent.click(screen.getByRole('button', { name: /warning/i }));
+    fireEvent.click(screen.getByRole('button', { name: /info/i }));
+
+    const alerts = screen.getAllByRole('alert');
+    expect(alerts).toHaveLength(4);
+    expect(screen.getByText('Saved bounty')).toBeInTheDocument();
+    expect(screen.getByText('Failed bounty')).toBeInTheDocument();
+    expect(screen.getByText('Check bounty')).toBeInTheDocument();
+    expect(screen.getByText('Loaded bounty')).toBeInTheDocument();
+  });
+
+  it('dismisses a toast manually', () => {
+    renderHarness();
+
+    fireEvent.click(screen.getByRole('button', { name: /success/i }));
+    fireEvent.click(screen.getByRole('button', { name: /dismiss notification/i }));
+
+    expect(screen.queryByText('Saved bounty')).not.toBeInTheDocument();
+  });
+
+  it('auto-dismisses a toast after five seconds', () => {
+    renderHarness();
+
+    fireEvent.click(screen.getByRole('button', { name: /success/i }));
+    expect(screen.getByText('Saved bounty')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(5_000);
+    });
+
+    expect(screen.queryByText('Saved bounty')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/bounty/BountyDetail.tsx
+++ b/frontend/src/components/bounty/BountyDetail.tsx
@@ -7,6 +7,7 @@ import { timeLeft, timeAgo, formatCurrency, LANG_COLORS } from '../../lib/utils'
 import { useAuth } from '../../hooks/useAuth';
 import { SubmissionForm } from './SubmissionForm';
 import { fadeIn } from '../../lib/animations';
+import { useToast } from '../toast/ToastProvider';
 
 interface BountyDetailProps {
   bounty: Bounty;
@@ -14,13 +15,17 @@ interface BountyDetailProps {
 
 export function BountyDetail({ bounty }: BountyDetailProps) {
   const { isAuthenticated } = useAuth();
+  const toast = useToast();
   const [submitting, setSubmitting] = useState(false);
   const [copied, setCopied] = useState(false);
 
   const copyLink = () => {
     navigator.clipboard.writeText(window.location.href).then(() => {
       setCopied(true);
+      toast.success('Bounty link copied.');
       setTimeout(() => setCopied(false), 2000);
+    }).catch(() => {
+      toast.error('Could not copy bounty link.');
     });
   };
 

--- a/frontend/src/components/bounty/SubmissionForm.tsx
+++ b/frontend/src/components/bounty/SubmissionForm.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Loader2, Check, Copy } from 'lucide-react';
 import type { Bounty } from '../../types/bounty';
 import { createSubmission, getReviewFee, verifyReviewFee } from '../../api/bounties';
+import { useToast } from '../toast/ToastProvider';
 
 interface SubmissionFormProps {
   bounty: Bounty;
@@ -9,6 +10,7 @@ interface SubmissionFormProps {
 }
 
 export function SubmissionForm({ bounty, onSuccess }: SubmissionFormProps) {
+  const toast = useToast();
   const hasRepo = bounty.has_repo ?? !!bounty.github_repo_url;
   const [url, setUrl] = useState('');
   const [description, setDescription] = useState('');
@@ -38,19 +40,32 @@ export function SubmissionForm({ bounty, onSuccess }: SubmissionFormProps) {
       const result = await verifyReviewFee({ bounty_id: bounty.id, tx_signature: txSig });
       if (result.verified) {
         setFeeVerified(true);
+        toast.success('Review fee verified.');
       } else {
-        setError(result.error ?? 'Fee verification failed. Check your transaction signature.');
+        const message = result.error ?? 'Fee verification failed. Check your transaction signature.';
+        setError(message);
+        toast.error(message);
       }
     } catch {
-      setError('Fee verification failed. Try again.');
+      const message = 'Fee verification failed. Try again.';
+      setError(message);
+      toast.error(message);
     } finally {
       setVerifying(false);
     }
   };
 
   const handleSubmit = async () => {
-    if (!url.trim()) { setError('URL is required.'); return; }
-    if (!feeVerified) { setError('Verify your FNDRY review fee first.'); return; }
+    if (!url.trim()) {
+      setError('URL is required.');
+      toast.warning('Add a PR or repository URL before submitting.');
+      return;
+    }
+    if (!feeVerified) {
+      setError('Verify your FNDRY review fee first.');
+      toast.warning('Verify your FNDRY review fee before submitting.');
+      return;
+    }
     setSubmitting(true);
     setError(null);
     try {
@@ -61,9 +76,12 @@ export function SubmissionForm({ bounty, onSuccess }: SubmissionFormProps) {
         tx_signature: txSig,
       });
       setSuccess(true);
+      toast.success('Submission received. AI review will begin shortly.');
       onSuccess?.();
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : 'Submission failed. Try again.');
+      const message = e instanceof Error ? e.message : 'Submission failed. Try again.';
+      setError(message);
+      toast.error(message);
     } finally {
       setSubmitting(false);
     }
@@ -72,7 +90,10 @@ export function SubmissionForm({ bounty, onSuccess }: SubmissionFormProps) {
   const copyTreasury = () => {
     navigator.clipboard.writeText(TREASURY).then(() => {
       setCopied(true);
+      toast.info('Treasury address copied.');
       setTimeout(() => setCopied(false), 2000);
+    }).catch(() => {
+      toast.error('Could not copy treasury address.');
     });
   };
 

--- a/frontend/src/components/toast/ToastProvider.tsx
+++ b/frontend/src/components/toast/ToastProvider.tsx
@@ -1,0 +1,113 @@
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { AlertTriangle, CheckCircle2, Info, X, XCircle } from 'lucide-react';
+
+type ToastVariant = 'success' | 'error' | 'warning' | 'info';
+
+interface Toast {
+  id: string;
+  message: string;
+  variant: ToastVariant;
+}
+
+interface ToastContextValue {
+  showToast: (message: string, variant?: ToastVariant) => string;
+  dismissToast: (id: string) => void;
+  success: (message: string) => string;
+  error: (message: string) => string;
+  warning: (message: string) => string;
+  info: (message: string) => string;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+const iconByVariant = {
+  success: CheckCircle2,
+  error: XCircle,
+  warning: AlertTriangle,
+  info: Info,
+};
+
+const classByVariant: Record<ToastVariant, string> = {
+  success: 'border-emerald/30 bg-emerald/10 text-emerald',
+  error: 'border-status-error/30 bg-status-error/10 text-status-error',
+  warning: 'border-status-warning/30 bg-status-warning/10 text-status-warning',
+  info: 'border-status-info/30 bg-status-info/10 text-status-info',
+};
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const dismissToast = useCallback((id: string) => {
+    setToasts((current) => current.filter((toast) => toast.id !== id));
+  }, []);
+
+  const showToast = useCallback(
+    (message: string, variant: ToastVariant = 'info') => {
+      const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      setToasts((current) => [...current, { id, message, variant }]);
+      window.setTimeout(() => dismissToast(id), 5_000);
+      return id;
+    },
+    [dismissToast],
+  );
+
+  const value = useMemo<ToastContextValue>(
+    () => ({
+      showToast,
+      dismissToast,
+      success: (message) => showToast(message, 'success'),
+      error: (message) => showToast(message, 'error'),
+      warning: (message) => showToast(message, 'warning'),
+      info: (message) => showToast(message, 'info'),
+    }),
+    [dismissToast, showToast],
+  );
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <div
+        className="fixed right-4 top-4 z-50 flex w-[min(24rem,calc(100vw-2rem))] flex-col gap-3"
+        aria-live="polite"
+        aria-relevant="additions removals"
+      >
+        <AnimatePresence>
+          {toasts.map((toast) => {
+            const Icon = iconByVariant[toast.variant];
+            return (
+              <motion.div
+                key={toast.id}
+                role="alert"
+                initial={{ opacity: 0, x: 32, y: -8 }}
+                animate={{ opacity: 1, x: 0, y: 0 }}
+                exit={{ opacity: 0, x: 32, transition: { duration: 0.18 } }}
+                className={`flex items-start gap-3 rounded-lg border px-4 py-3 shadow-xl shadow-black/30 backdrop-blur-sm ${classByVariant[toast.variant]}`}
+                data-testid="toast"
+              >
+                <Icon className="mt-0.5 h-4 w-4 flex-shrink-0" />
+                <p className="min-w-0 flex-1 text-sm font-medium leading-5">{toast.message}</p>
+                <button
+                  type="button"
+                  onClick={() => dismissToast(toast.id)}
+                  className="rounded-md p-0.5 opacity-70 transition-opacity hover:opacity-100"
+                  aria-label="Dismiss notification"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </motion.div>
+            );
+          })}
+        </AnimatePresence>
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error('useToast must be used within ToastProvider');
+  }
+  return context;
+}

--- a/frontend/src/lib/animations.ts
+++ b/frontend/src/lib/animations.ts
@@ -1,0 +1,38 @@
+import type { Variants } from 'framer-motion';
+
+export const fadeIn: Variants = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.3, ease: 'easeOut' } },
+};
+
+export const pageTransition: Variants = {
+  initial: { opacity: 0, y: 16 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.35, ease: 'easeOut' } },
+  exit: { opacity: 0, y: -8, transition: { duration: 0.2, ease: 'easeIn' } },
+};
+
+export const staggerContainer: Variants = {
+  initial: {},
+  animate: { transition: { staggerChildren: 0.06 } },
+};
+
+export const staggerItem: Variants = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.25, ease: 'easeOut' } },
+};
+
+export const slideInRight: Variants = {
+  initial: { opacity: 0, x: 24 },
+  animate: { opacity: 1, x: 0, transition: { duration: 0.25, ease: 'easeOut' } },
+};
+
+export const cardHover: Variants = {
+  rest: { y: 0 },
+  hover: { y: -3, transition: { duration: 0.18, ease: 'easeOut' } },
+};
+
+export const buttonHover: Variants = {
+  rest: { scale: 1 },
+  hover: { scale: 1.03, transition: { duration: 0.15, ease: 'easeOut' } },
+  tap: { scale: 0.98 },
+};

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,64 @@
+import type { RewardToken } from '../types/bounty';
+
+export const LANG_COLORS: Record<string, string> = {
+  TypeScript: '#3178c6',
+  JavaScript: '#f7df1e',
+  Rust: '#dea584',
+  Solidity: '#627eea',
+  Python: '#3776ab',
+  Go: '#00add8',
+  React: '#61dafb',
+  TS: '#3178c6',
+};
+
+export function formatCurrency(amount: number, token: RewardToken = 'FNDRY'): string {
+  const formatted = new Intl.NumberFormat('en-US', {
+    maximumFractionDigits: amount >= 100 ? 0 : 2,
+  }).format(amount);
+
+  return token === 'USDC' ? `$${formatted}` : `${formatted} ${token}`;
+}
+
+export function timeAgo(value: string | Date): string {
+  const date = value instanceof Date ? value : new Date(value);
+  const deltaSeconds = Math.floor((Date.now() - date.getTime()) / 1000);
+
+  if (!Number.isFinite(deltaSeconds)) return 'Unknown';
+  if (deltaSeconds < 60) return 'Just now';
+
+  const units: Array<[Intl.RelativeTimeFormatUnit, number]> = [
+    ['year', 31_536_000],
+    ['month', 2_592_000],
+    ['week', 604_800],
+    ['day', 86_400],
+    ['hour', 3_600],
+    ['minute', 60],
+  ];
+  const formatter = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
+
+  for (const [unit, secondsPerUnit] of units) {
+    const valueInUnit = Math.floor(deltaSeconds / secondsPerUnit);
+    if (valueInUnit >= 1) return formatter.format(-valueInUnit, unit);
+  }
+
+  return 'Just now';
+}
+
+export function timeLeft(value: string | Date): string {
+  const date = value instanceof Date ? value : new Date(value);
+  const deltaSeconds = Math.floor((date.getTime() - Date.now()) / 1000);
+
+  if (!Number.isFinite(deltaSeconds)) return 'Unknown';
+  if (deltaSeconds <= 0) return 'Expired';
+
+  const days = Math.floor(deltaSeconds / 86_400);
+  if (days >= 1) return `${days}d left`;
+
+  const hours = Math.floor(deltaSeconds / 3_600);
+  if (hours >= 1) return `${hours}h left`;
+
+  const minutes = Math.floor(deltaSeconds / 60);
+  if (minutes >= 1) return `${minutes}m left`;
+
+  return 'Less than 1m';
+}

--- a/frontend/src/pages/GitHubCallbackPage.tsx
+++ b/frontend/src/pages/GitHubCallbackPage.tsx
@@ -5,11 +5,13 @@ import { useAuth } from '../hooks/useAuth';
 import { exchangeGitHubCode } from '../api/auth';
 import { setAuthToken } from '../services/apiClient';
 import { fadeIn } from '../lib/animations';
+import { useToast } from '../components/toast/ToastProvider';
 
 export function GitHubCallbackPage() {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const { login } = useAuth();
+  const toast = useToast();
   const didRun = useRef(false);
 
   useEffect(() => {
@@ -21,6 +23,7 @@ export function GitHubCallbackPage() {
     const error = searchParams.get('error');
 
     if (error || !code) {
+      toast.error('GitHub sign-in was cancelled or failed.');
       navigate('/', { replace: true });
       return;
     }
@@ -35,12 +38,14 @@ export function GitHubCallbackPage() {
         if (response.refresh_token) {
           localStorage.setItem('sf_refresh_token', response.refresh_token);
         }
+        toast.success('Signed in with GitHub.');
         navigate('/', { replace: true });
       })
       .catch(() => {
+        toast.error('Could not complete GitHub sign-in.');
         navigate('/', { replace: true });
       });
-  }, []);
+  }, [login, navigate, searchParams, toast]);
 
   return (
     <div className="min-h-screen bg-forge-950 flex items-center justify-center">


### PR DESCRIPTION
﻿Adds a reusable toast notification system for app actions.Implementation details:- Adds success, error, warning, and info variants- Auto-dismisses toasts after 5 seconds- Adds manual dismiss controls- Animates toasts in from the top-right- Stacks multiple toasts- Uses role=alert and aria-live for accessibility- Wires toasts into submission, fee verification, clipboard, and GitHub sign-in flows- Adds focused coverage for stacked toasts, manual dismiss, and auto-dismiss behavior- Restores the shared frontend lib modules currently imported by the app, and narrows .gitignore so those source files are trackedVerification:- npm.cmd run build- npm.cmd test -- src/__tests__/toast-provider.test.tsxCloses #825

Wallet: C2z3FWAacvSYVrrkfpk6nQyNhF4t3z7t9iXRW1xfZPy1