### PR TITLE
feat: add loading skeleton animations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ eggs/
 .eggs/
 lib/
 lib64/
+!frontend/src/lib/
+!frontend/src/lib/**
 parts/
 sdist/
 var/

--- a/frontend/src/__tests__/loading-skeletons.test.tsx
+++ b/frontend/src/__tests__/loading-skeletons.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import {
+  BountyDetailSkeleton,
+  BountyGridSkeleton,
+  LeaderboardSkeleton,
+  ProfileBountiesSkeleton,
+} from '../components/ui/Skeleton';
+
+describe('loading skeletons', () => {
+  it('renders shaped bounty card skeletons with shimmer animation', () => {
+    const { container } = render(<BountyGridSkeleton count={3} />);
+
+    expect(screen.getByRole('status', { name: /loading bounties/i })).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getAllByTestId('bounty-card-skeleton')).toHaveLength(3);
+    expect(container.querySelector('.animate-shimmer')).toBeInTheDocument();
+  });
+
+  it('renders leaderboard podium and row skeletons', () => {
+    render(<LeaderboardSkeleton />);
+
+    expect(screen.getByRole('status', { name: /loading leaderboard/i })).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getAllByTestId('leaderboard-podium-skeleton')).toHaveLength(3);
+    expect(screen.getAllByTestId('leaderboard-row-skeleton')).toHaveLength(5);
+  });
+
+  it('renders profile bounty row skeletons', () => {
+    render(<ProfileBountiesSkeleton />);
+
+    expect(screen.getByRole('status', { name: /loading profile bounties/i })).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getAllByTestId('profile-bounty-skeleton')).toHaveLength(4);
+  });
+
+  it('renders the bounty detail skeleton shell', () => {
+    render(<BountyDetailSkeleton />);
+
+    expect(screen.getByRole('status', { name: /loading bounty details/i })).toHaveAttribute('aria-busy', 'true');
+  });
+});

--- a/frontend/src/components/bounty/BountyGrid.tsx
+++ b/frontend/src/components/bounty/BountyGrid.tsx
@@ -5,6 +5,7 @@ import { ChevronDown, Loader2, Plus } from 'lucide-react';
 import { BountyCard } from './BountyCard';
 import { useInfiniteBounties } from '../../hooks/useBounties';
 import { staggerContainer, staggerItem } from '../../lib/animations';
+import { BountyGridSkeleton } from '../ui/Skeleton';
 
 const FILTER_SKILLS = ['All', 'TypeScript', 'Rust', 'Solidity', 'Python', 'Go', 'JavaScript'];
 
@@ -71,18 +72,7 @@ export function BountyGrid() {
         </div>
 
         {/* Loading state */}
-        {isLoading && (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
-            {Array.from({ length: 6 }).map((_, i) => (
-              <div
-                key={i}
-                className="h-52 rounded-xl border border-border bg-forge-900 overflow-hidden"
-              >
-                <div className="h-full bg-gradient-to-r from-forge-900 via-forge-800 to-forge-900 bg-[length:200%_100%] animate-shimmer" />
-              </div>
-            ))}
-          </div>
-        )}
+        {isLoading && <BountyGridSkeleton count={6} />}
 
         {/* Error state */}
         {isError && !isLoading && (

--- a/frontend/src/components/home/FeaturedBounties.tsx
+++ b/frontend/src/components/home/FeaturedBounties.tsx
@@ -5,6 +5,7 @@ import { ArrowRight } from 'lucide-react';
 import { staggerContainer, staggerItem } from '../../lib/animations';
 import { useBounties } from '../../hooks/useBounties';
 import { BountyCard } from '../bounty/BountyCard';
+import { BountyGridSkeleton } from '../ui/Skeleton';
 
 export function FeaturedBounties() {
   const { data, isLoading, isError } = useBounties({ limit: 4, status: 'open' });
@@ -37,11 +38,11 @@ export function FeaturedBounties() {
         </motion.div>
 
         {isLoading && (
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-            {Array.from({ length: 4 }).map((_, i) => (
-              <div key={i} className="rounded-xl border border-border bg-forge-900 h-48 animate-pulse" />
-            ))}
-          </div>
+          <BountyGridSkeleton
+            count={4}
+            compact
+            columns="grid-cols-1 sm:grid-cols-2 lg:grid-cols-4"
+          />
         )}
 
         {isError && (

--- a/frontend/src/components/profile/ProfileDashboard.tsx
+++ b/frontend/src/components/profile/ProfileDashboard.tsx
@@ -6,6 +6,7 @@ import { useAuth } from '../../hooks/useAuth';
 import { useBounties } from '../../hooks/useBounties';
 import { timeAgo, formatCurrency } from '../../lib/utils';
 import { fadeIn, staggerContainer, staggerItem } from '../../lib/animations';
+import { ProfileBountiesSkeleton, SkeletonBlock } from '../ui/Skeleton';
 import type { Bounty } from '../../types/bounty';
 
 const TABS = ['My Bounties', 'My Submissions', 'Earnings', 'Settings'] as const;
@@ -35,7 +36,7 @@ function BountyStatusBadge({ status }: { status: string }) {
 
 function MyBountiesTab({ bounties, loading }: { bounties: Bounty[]; loading: boolean }) {
   if (loading) {
-    return <div className="text-text-muted text-sm py-8 text-center">Loading...</div>;
+    return <ProfileBountiesSkeleton />;
   }
   if (!bounties.length) {
     return (
@@ -175,8 +176,13 @@ export function ProfileDashboard() {
           )}
           <div className="flex-1">
             <h1 className="font-sans text-2xl font-semibold text-text-primary">{user.username}</h1>
-            <p className="mt-1 font-mono text-sm text-text-muted">
-              Joined {joinDate} · {myBounties.length} bounties created
+            <p className="mt-1 flex items-center gap-2 font-mono text-sm text-text-muted">
+              <span>Joined {joinDate} ·</span>
+              {isLoading ? (
+                <SkeletonBlock className="h-4 w-32" />
+              ) : (
+                <span>{myBounties.length} bounties created</span>
+              )}
             </p>
           </div>
         </div>

--- a/frontend/src/components/ui/Skeleton.tsx
+++ b/frontend/src/components/ui/Skeleton.tsx
@@ -1,0 +1,240 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+interface SkeletonBlockProps {
+  className?: string;
+}
+
+export function SkeletonBlock({ className = '' }: SkeletonBlockProps) {
+  return (
+    <div className={`overflow-hidden rounded-md bg-forge-800/80 ${className}`} aria-hidden="true">
+      <div className="h-full w-full bg-gradient-to-r from-transparent via-white/[0.07] to-transparent bg-[length:200%_100%] animate-shimmer" />
+    </div>
+  );
+}
+
+function SkeletonDot({ className = '' }: SkeletonBlockProps) {
+  return <SkeletonBlock className={`rounded-full ${className}`} />;
+}
+
+export function BountyCardSkeleton({ compact = false }: { compact?: boolean }) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.25, ease: 'easeOut' }}
+      className={`relative rounded-xl border border-border bg-forge-900 p-5 overflow-hidden ${compact ? 'min-h-48' : 'min-h-52'}`}
+      data-testid="bounty-card-skeleton"
+      aria-hidden="true"
+    >
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <SkeletonDot className="h-5 w-5 flex-shrink-0" />
+          <SkeletonBlock className="h-3 w-36 max-w-[70%]" />
+        </div>
+        <SkeletonBlock className="h-5 w-10 rounded-full" />
+      </div>
+
+      <div className="mt-4 space-y-2">
+        <SkeletonBlock className="h-4 w-full" />
+        <SkeletonBlock className="h-4 w-4/5" />
+      </div>
+
+      <div className="mt-4 flex items-center gap-3">
+        {[0, 1, 2].map((item) => (
+          <div key={item} className="flex items-center gap-1.5">
+            <SkeletonDot className="h-2.5 w-2.5" />
+            <SkeletonBlock className="h-3 w-14" />
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-5 border-t border-border/50" />
+
+      <div className="mt-4 flex items-center justify-between gap-4">
+        <SkeletonBlock className="h-5 w-24" />
+        <div className="flex items-center gap-3">
+          <SkeletonBlock className="h-3 w-12" />
+          <SkeletonBlock className="h-3 w-14" />
+        </div>
+      </div>
+
+      <SkeletonBlock className="absolute bottom-4 right-5 h-3 w-16" />
+    </motion.div>
+  );
+}
+
+export function BountyGridSkeleton({
+  count = 6,
+  columns = 'grid-cols-1 md:grid-cols-2 lg:grid-cols-3',
+  compact = false,
+}: {
+  count?: number;
+  columns?: string;
+  compact?: boolean;
+}) {
+  return (
+    <div role="status" aria-busy="true" aria-label="Loading bounties" className={`grid ${columns} gap-5`}>
+      <span className="sr-only">Loading bounties</span>
+      {Array.from({ length: count }).map((_, index) => (
+        <BountyCardSkeleton key={index} compact={compact} />
+      ))}
+    </div>
+  );
+}
+
+function PodiumCardSkeleton({ featured = false }: { featured?: boolean }) {
+  return (
+    <div
+      className={`relative flex min-w-[140px] flex-col items-center rounded-xl border border-border bg-forge-900 px-6 ${
+        featured ? 'py-8' : 'py-6'
+      }`}
+      data-testid="leaderboard-podium-skeleton"
+      aria-hidden="true"
+    >
+      <SkeletonBlock className="absolute -top-3 h-4 w-8" />
+      <SkeletonDot className={`${featured ? 'h-14 w-14' : 'h-12 w-12'} border border-border`} />
+      <SkeletonBlock className="mt-4 h-3 w-24" />
+      <SkeletonBlock className="mt-2 h-3 w-20" />
+      <SkeletonBlock className="mt-3 h-5 w-24" />
+    </div>
+  );
+}
+
+function LeaderboardRowSkeleton() {
+  return (
+    <div className="flex items-center border-b border-border/30 px-4 py-3 last:border-b-0" data-testid="leaderboard-row-skeleton">
+      <div className="w-[60px]">
+        <SkeletonBlock className="mx-auto h-4 w-8" />
+      </div>
+      <div className="flex min-w-0 flex-1 items-center gap-3">
+        <SkeletonDot className="h-6 w-6 flex-shrink-0" />
+        <div className="min-w-0 space-y-1.5">
+          <SkeletonBlock className="h-3 w-28" />
+          <div className="flex items-center gap-1">
+            {[0, 1, 2, 3].map((item) => (
+              <SkeletonDot key={item} className="h-2.5 w-2.5" />
+            ))}
+          </div>
+        </div>
+      </div>
+      <div className="w-[100px]">
+        <SkeletonBlock className="mx-auto h-4 w-10" />
+      </div>
+      <div className="w-[120px]">
+        <SkeletonBlock className="ml-auto h-4 w-20" />
+      </div>
+      <div className="hidden w-[80px] sm:block">
+        <SkeletonBlock className="mx-auto h-4 w-10" />
+      </div>
+    </div>
+  );
+}
+
+export function LeaderboardSkeleton() {
+  return (
+    <motion.div
+      role="status"
+      aria-busy="true"
+      aria-label="Loading leaderboard"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.25, ease: 'easeOut' }}
+    >
+      <span className="sr-only">Loading leaderboard</span>
+      <div className="mb-12 flex items-end justify-center gap-4 md:gap-6">
+        <PodiumCardSkeleton />
+        <PodiumCardSkeleton featured />
+        <PodiumCardSkeleton />
+      </div>
+
+      <div className="mx-auto mt-6 max-w-4xl overflow-hidden rounded-xl border border-border bg-forge-900">
+        <div className="flex items-center border-b border-border/50 px-4 py-3">
+          <SkeletonBlock className="mx-auto h-3 w-10" />
+          <SkeletonBlock className="ml-4 h-3 flex-1" />
+          <SkeletonBlock className="ml-4 h-3 w-[100px]" />
+          <SkeletonBlock className="ml-4 h-3 w-[120px]" />
+          <SkeletonBlock className="ml-4 hidden h-3 w-[80px] sm:block" />
+        </div>
+        {Array.from({ length: 5 }).map((_, index) => (
+          <LeaderboardRowSkeleton key={index} />
+        ))}
+      </div>
+    </motion.div>
+  );
+}
+
+export function ProfileBountiesSkeleton() {
+  return (
+    <motion.div
+      role="status"
+      aria-busy="true"
+      aria-label="Loading profile bounties"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.25, ease: 'easeOut' }}
+      className="space-y-2"
+    >
+      <span className="sr-only">Loading profile bounties</span>
+      {Array.from({ length: 4 }).map((_, index) => (
+        <div key={index} className="flex items-center gap-4 rounded-lg border border-border bg-forge-900 px-4 py-3" data-testid="profile-bounty-skeleton">
+          <div className="min-w-0 flex-1 space-y-2">
+            <SkeletonBlock className="h-4 w-3/4" />
+            <SkeletonBlock className="h-3 w-24" />
+          </div>
+          <SkeletonBlock className="h-4 w-20" />
+          <SkeletonBlock className="h-5 w-16 rounded-full" />
+          <SkeletonBlock className="h-4 w-10" />
+        </div>
+      ))}
+    </motion.div>
+  );
+}
+
+export function BountyDetailSkeleton() {
+  return (
+    <motion.div
+      role="status"
+      aria-busy="true"
+      aria-label="Loading bounty details"
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.25, ease: 'easeOut' }}
+      className="mx-auto max-w-4xl px-4 py-8"
+    >
+      <span className="sr-only">Loading bounty details</span>
+      <div className="rounded-xl border border-border bg-forge-900 p-6">
+        <div className="flex items-center justify-between gap-4">
+          <SkeletonBlock className="h-4 w-28" />
+          <SkeletonBlock className="h-8 w-24 rounded-lg" />
+        </div>
+        <div className="mt-6 space-y-3">
+          <SkeletonBlock className="h-8 w-4/5" />
+          <SkeletonBlock className="h-4 w-full" />
+          <SkeletonBlock className="h-4 w-11/12" />
+        </div>
+        <div className="mt-6 flex flex-wrap items-center gap-3">
+          {[0, 1, 2].map((item) => (
+            <SkeletonBlock key={item} className="h-7 w-24 rounded-full" />
+          ))}
+        </div>
+        <div className="mt-8 grid gap-4 sm:grid-cols-3">
+          {[0, 1, 2].map((item) => (
+            <div key={item} className="rounded-lg border border-border bg-forge-850 p-4">
+              <SkeletonBlock className="h-3 w-20" />
+              <SkeletonBlock className="mt-3 h-5 w-28" />
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="mt-6 rounded-xl border border-border bg-forge-900 p-6">
+        <SkeletonBlock className="h-5 w-32" />
+        <div className="mt-4 space-y-2">
+          <SkeletonBlock className="h-4 w-full" />
+          <SkeletonBlock className="h-4 w-full" />
+          <SkeletonBlock className="h-4 w-2/3" />
+        </div>
+      </div>
+    </motion.div>
+  );
+}

--- a/frontend/src/lib/animations.ts
+++ b/frontend/src/lib/animations.ts
@@ -1,0 +1,47 @@
+import type { Variants } from 'framer-motion';
+
+export const fadeIn: Variants = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.35, ease: 'easeOut' } },
+};
+
+export const pageTransition: Variants = {
+  initial: { opacity: 0 },
+  animate: { opacity: 1, transition: { duration: 0.3, ease: 'easeOut' } },
+  exit: { opacity: 0, transition: { duration: 0.2, ease: 'easeIn' } },
+};
+
+export const staggerContainer: Variants = {
+  initial: {},
+  animate: {
+    transition: {
+      staggerChildren: 0.06,
+    },
+  },
+};
+
+export const staggerItem: Variants = {
+  initial: { opacity: 0, y: 10 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.3, ease: 'easeOut' } },
+};
+
+export const slideInRight: Variants = {
+  initial: { opacity: 0, x: 24 },
+  animate: { opacity: 1, x: 0, transition: { duration: 0.3, ease: 'easeOut' } },
+  exit: { opacity: 0, x: 24, transition: { duration: 0.2, ease: 'easeIn' } },
+};
+
+export const cardHover: Variants = {
+  rest: { y: 0, borderColor: '#1E1E2E' },
+  hover: {
+    y: -4,
+    borderColor: '#2E2E42',
+    transition: { duration: 0.2, ease: 'easeOut' },
+  },
+};
+
+export const buttonHover: Variants = {
+  rest: { scale: 1 },
+  hover: { scale: 1.02, transition: { duration: 0.15, ease: 'easeOut' } },
+  tap: { scale: 0.98 },
+};

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,75 @@
+export const LANG_COLORS: Record<string, string> = {
+  TypeScript: '#3178C6',
+  JavaScript: '#F7DF1E',
+  Python: '#3776AB',
+  Rust: '#DEA584',
+  Go: '#00ADD8',
+  Solidity: '#363636',
+  Java: '#B07219',
+  C: '#555555',
+  'C++': '#F34B7D',
+  Ruby: '#CC342D',
+  Swift: '#FA7343',
+  Kotlin: '#A97BFF',
+  Shell: '#89E051',
+};
+
+export function formatCurrency(amount?: number | string | null, token = 'USDC') {
+  const numericAmount = Number(amount ?? 0);
+  const formattedAmount = Number.isFinite(numericAmount)
+    ? numericAmount.toLocaleString(undefined, { maximumFractionDigits: 2 })
+    : '0';
+
+  if (token.toUpperCase() === 'USDC' || token === '$') {
+    return `$${formattedAmount}`;
+  }
+
+  return `${formattedAmount} ${token}`;
+}
+
+export function timeAgo(value?: string | Date | null) {
+  if (!value) return 'recently';
+
+  const date = value instanceof Date ? value : new Date(value);
+  const timestamp = date.getTime();
+  if (Number.isNaN(timestamp)) return 'recently';
+
+  const seconds = Math.max(0, Math.floor((Date.now() - timestamp) / 1000));
+  const units: Array<[Intl.RelativeTimeFormatUnit, number]> = [
+    ['year', 60 * 60 * 24 * 365],
+    ['month', 60 * 60 * 24 * 30],
+    ['week', 60 * 60 * 24 * 7],
+    ['day', 60 * 60 * 24],
+    ['hour', 60 * 60],
+    ['minute', 60],
+  ];
+
+  for (const [unit, size] of units) {
+    const count = Math.floor(seconds / size);
+    if (count >= 1) {
+      return new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' }).format(-count, unit);
+    }
+  }
+
+  return 'just now';
+}
+
+export function timeLeft(value?: string | Date | null) {
+  if (!value) return 'No deadline';
+
+  const date = value instanceof Date ? value : new Date(value);
+  const timestamp = date.getTime();
+  if (Number.isNaN(timestamp)) return 'No deadline';
+
+  const seconds = Math.floor((timestamp - Date.now()) / 1000);
+  if (seconds <= 0) return 'Expired';
+
+  const days = Math.floor(seconds / (60 * 60 * 24));
+  if (days >= 1) return `${days}d left`;
+
+  const hours = Math.floor(seconds / (60 * 60));
+  if (hours >= 1) return `${hours}h left`;
+
+  const minutes = Math.max(1, Math.floor(seconds / 60));
+  return `${minutes}m left`;
+}

--- a/frontend/src/pages/BountyDetailPage.tsx
+++ b/frontend/src/pages/BountyDetailPage.tsx
@@ -2,9 +2,8 @@ import React from 'react';
 import { useParams } from 'react-router-dom';
 import { PageLayout } from '../components/layout/PageLayout';
 import { BountyDetail } from '../components/bounty/BountyDetail';
+import { BountyDetailSkeleton } from '../components/ui/Skeleton';
 import { useBounty } from '../hooks/useBounties';
-import { fadeIn } from '../lib/animations';
-import { motion } from 'framer-motion';
 
 export function BountyDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -12,15 +11,7 @@ export function BountyDetailPage() {
 
   return (
     <PageLayout>
-      {isLoading && (
-        <div className="max-w-4xl mx-auto px-4 py-8 space-y-4">
-          {[1, 2, 3].map((i) => (
-            <div key={i} className="h-32 rounded-xl border border-border bg-forge-900 overflow-hidden">
-              <div className="h-full bg-gradient-to-r from-forge-900 via-forge-800 to-forge-900 bg-[length:200%_100%] animate-shimmer" />
-            </div>
-          ))}
-        </div>
-      )}
+      {isLoading && <BountyDetailSkeleton />}
 
       {isError && !isLoading && (
         <div className="max-w-4xl mx-auto px-4 py-16 text-center">

--- a/frontend/src/pages/LeaderboardPage.tsx
+++ b/frontend/src/pages/LeaderboardPage.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import { PageLayout } from '../components/layout/PageLayout';
 import { PodiumCards } from '../components/leaderboard/PodiumCards';
 import { LeaderboardTable } from '../components/leaderboard/LeaderboardTable';
+import { LeaderboardSkeleton } from '../components/ui/Skeleton';
 import { useLeaderboard } from '../hooks/useLeaderboard';
 import type { TimePeriod } from '../types/leaderboard';
 import { fadeIn } from '../lib/animations';
@@ -46,11 +47,7 @@ export function LeaderboardPage() {
         </div>
 
         {/* Loading */}
-        {isLoading && (
-          <div className="flex justify-center py-16">
-            <div className="w-8 h-8 rounded-full border-2 border-emerald border-t-transparent animate-spin" />
-          </div>
-        )}
+        {isLoading && <LeaderboardSkeleton />}
 
         {/* Error */}
         {isError && !isLoading && (


### PR DESCRIPTION
﻿Adds shimmer skeleton loading states across the main data-loading frontend surfaces.Implementation details:- Adds reusable skeleton primitives and shaped skeleton layouts- Adds bounty card skeletons for bounty grids and featured bounties- Adds leaderboard podium and row skeletons- Adds profile bounty row and profile count skeletons- Adds bounty detail page skeletons that match the final page structure- Uses shimmer animation and accessible status regions with aria-busy- Replaces generic spinners/plain loading text on the API-backed content surfaces- Restores the shared frontend lib modules currently imported by the app, and narrows .gitignore so those source files are trackedVerification:- npm.cmd run build- npm.cmd test -- src/__tests__/loading-skeletons.test.tsxCloses #827

Wallet: C2z3FWAacvSYVrrkfpk6nQyNhF4t3z7t9iXRW1xfZPy1