### PR TITLE
feat: wire activity feed to api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ eggs/
 .eggs/
 lib/
 lib64/
+!frontend/src/lib/
+!frontend/src/lib/**
 parts/
 sdist/
 var/

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -178,6 +178,7 @@ All tasks are started in the FastAPI lifespan handler and cancelled on shutdown.
 - `GET /api/bounties/{id}` — Bounty detail
 - `GET /api/leaderboard` — Contributor rankings
 - `GET /api/stats` — Platform statistics
+- `GET /api/analytics/activity` — Recent bounty completions, PR submissions, and payouts for the home activity feed
 - `GET /api/contributors/{username}` — Contributor profile
 
 ### Authenticated

--- a/frontend/src/__tests__/activity-feed-api.test.tsx
+++ b/frontend/src/__tests__/activity-feed-api.test.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getActivityEvents } from '../api/activity';
+import { ActivityFeed } from '../components/home/ActivityFeed';
+
+const mockFetch = vi.fn();
+
+function jsonResponse(data: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(data), {
+    status: init.status ?? 200,
+    statusText: init.statusText ?? 'OK',
+    headers: {
+      'content-type': 'application/json',
+      ...(init.headers as Record<string, string> | undefined),
+    },
+  });
+}
+
+function renderWithClient(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      {ui}
+    </QueryClientProvider>,
+  );
+}
+
+describe('activity feed API integration', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('fetches and normalizes activity events from /api/activity', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({
+      events: [
+        {
+          id: 'evt-1',
+          type: 'reward_paid',
+          actor: { login: 'alice', avatar_url: 'https://example.com/avatar.png' },
+          amount: 500,
+          reward_token: 'USDC',
+          created_at: '2026-05-11T10:00:00.000Z',
+        },
+      ],
+    }));
+
+    const events = await getActivityEvents({ limit: 4 });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/activity?limit=4'),
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(events).toEqual([
+      {
+        id: 'evt-1',
+        type: 'payout',
+        username: 'alice',
+        avatar_url: 'https://example.com/avatar.png',
+        detail: '500 USDC',
+        timestamp: '2026-05-11T10:00:00.000Z',
+      },
+    ]);
+  });
+
+  it('renders real API activity in the home feed', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse([
+      {
+        id: 'evt-2',
+        type: 'pr_submitted',
+        username: 'builder',
+        detail: 'PR to Bounty #822',
+        timestamp: new Date().toISOString(),
+      },
+    ]));
+
+    renderWithClient(<ActivityFeed />);
+
+    expect(await screen.findByText('builder')).toBeInTheDocument();
+    expect(screen.getByText(/submitted/i)).toBeInTheDocument();
+    expect(screen.getByText('PR to Bounty #822')).toBeInTheDocument();
+  });
+
+  it('shows an empty state when the API has no recent activity', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ events: [] }));
+
+    renderWithClient(<ActivityFeed />);
+
+    expect(await screen.findByText(/no recent activity/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/activity-feed-api.test.tsx
+++ b/frontend/src/__tests__/activity-feed-api.test.tsx
@@ -1,8 +1,9 @@
+
 import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { getActivityEvents } from '../api/activity';
+import { ACTIVITY_FEED_ENDPOINT, getActivityEvents } from '../api/activity';
 import { ActivityFeed } from '../components/home/ActivityFeed';
 
 const mockFetch = vi.fn();
@@ -40,7 +41,7 @@ describe('activity feed API integration', () => {
     vi.unstubAllGlobals();
   });
 
-  it('fetches and normalizes activity events from /api/activity', async () => {
+  it('fetches and normalizes activity events from the documented analytics endpoint', async () => {
     mockFetch.mockResolvedValueOnce(jsonResponse({
       events: [
         {
@@ -57,7 +58,7 @@ describe('activity feed API integration', () => {
     const events = await getActivityEvents({ limit: 4 });
 
     expect(mockFetch).toHaveBeenCalledWith(
-      expect.stringContaining('/api/activity?limit=4'),
+      expect.stringContaining(`${ACTIVITY_FEED_ENDPOINT}?limit=4`),
       expect.objectContaining({ method: 'GET' }),
     );
     expect(events).toEqual([

--- a/frontend/src/api/activity.ts
+++ b/frontend/src/api/activity.ts
@@ -1,9 +1,12 @@
+
 import { apiClient } from '../services/apiClient';
 import type { ActivityEvent, ActivityEventType } from '../types/activity';
 
 interface ActivityListParams {
   limit?: number;
 }
+
+export const ACTIVITY_FEED_ENDPOINT = '/api/analytics/activity';
 
 type RawActivityEvent = Record<string, unknown>;
 type ActivityApiResponse =
@@ -105,7 +108,7 @@ function getEventsFromResponse(response: ActivityApiResponse): RawActivityEvent[
 }
 
 export async function getActivityEvents(params: ActivityListParams = {}): Promise<ActivityEvent[]> {
-  const response = await apiClient<ActivityApiResponse>('/api/activity', {
+  const response = await apiClient<ActivityApiResponse>(ACTIVITY_FEED_ENDPOINT, {
     params: { limit: params.limit ?? 8 },
   });
   return getEventsFromResponse(response).map(normalizeActivityEvent);

--- a/frontend/src/api/activity.ts
+++ b/frontend/src/api/activity.ts
@@ -1,0 +1,112 @@
+import { apiClient } from '../services/apiClient';
+import type { ActivityEvent, ActivityEventType } from '../types/activity';
+
+interface ActivityListParams {
+  limit?: number;
+}
+
+type RawActivityEvent = Record<string, unknown>;
+type ActivityApiResponse =
+  | RawActivityEvent[]
+  | {
+      items?: RawActivityEvent[];
+      events?: RawActivityEvent[];
+      activity?: RawActivityEvent[];
+      data?: RawActivityEvent[];
+    };
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined;
+}
+
+function readNestedString(value: unknown, key: string): string | undefined {
+  if (typeof value !== 'object' || value === null) return undefined;
+  return readString((value as Record<string, unknown>)[key]);
+}
+
+function normalizeType(type: unknown): ActivityEventType {
+  const normalized = readString(type)?.toLowerCase().replace(/[-\s]/g, '_');
+
+  if (normalized === 'completed' || normalized === 'completion' || normalized === 'bounty_completed') {
+    return 'completed';
+  }
+  if (normalized === 'submitted' || normalized === 'submission' || normalized === 'pr_submitted') {
+    return 'submitted';
+  }
+  if (normalized === 'payout' || normalized === 'paid' || normalized === 'reward_paid') {
+    return 'payout';
+  }
+  if (normalized === 'posted' || normalized === 'created' || normalized === 'bounty_posted') {
+    return 'posted';
+  }
+  if (normalized === 'review' || normalized === 'ai_review' || normalized === 'review_passed') {
+    return 'review';
+  }
+
+  return 'posted';
+}
+
+function buildDetail(raw: RawActivityEvent, type: ActivityEventType): string {
+  const explicitDetail =
+    readString(raw.detail) ??
+    readString(raw.message) ??
+    readString(raw.description) ??
+    readString(raw.title) ??
+    readString(raw.bounty_title);
+
+  if (explicitDetail) return explicitDetail;
+
+  const issueNumber = raw.issue_number ?? raw.bounty_number ?? raw.bounty_id;
+  const amount = raw.amount ?? raw.reward_amount ?? raw.payout_amount;
+  const token = readString(raw.token) ?? readString(raw.reward_token) ?? 'USDC';
+
+  if (type === 'payout' && amount !== undefined) {
+    return `${Number(amount).toLocaleString()} ${token}`;
+  }
+  if (issueNumber !== undefined) {
+    return `Bounty #${String(issueNumber)}`;
+  }
+
+  return type === 'submitted' ? 'a pull request' : 'a bounty';
+}
+
+function normalizeActivityEvent(raw: RawActivityEvent, index: number): ActivityEvent {
+  const type = normalizeType(raw.type ?? raw.event_type ?? raw.kind);
+  const actor = raw.actor ?? raw.user ?? raw.contributor ?? raw.creator;
+  const timestamp =
+    readString(raw.timestamp) ??
+    readString(raw.created_at) ??
+    readString(raw.updated_at) ??
+    new Date().toISOString();
+
+  return {
+    id: readString(raw.id) ?? readString(raw.event_id) ?? `${type}-${timestamp}-${index}`,
+    type,
+    username:
+      readString(raw.username) ??
+      readString(raw.actor_username) ??
+      readNestedString(actor, 'username') ??
+      readNestedString(actor, 'login') ??
+      readNestedString(actor, 'name') ??
+      'Someone',
+    avatar_url:
+      readString(raw.avatar_url) ??
+      readString(raw.actor_avatar_url) ??
+      readNestedString(actor, 'avatar_url') ??
+      null,
+    detail: buildDetail(raw, type),
+    timestamp,
+  };
+}
+
+function getEventsFromResponse(response: ActivityApiResponse): RawActivityEvent[] {
+  if (Array.isArray(response)) return response;
+  return response.items ?? response.events ?? response.activity ?? response.data ?? [];
+}
+
+export async function getActivityEvents(params: ActivityListParams = {}): Promise<ActivityEvent[]> {
+  const response = await apiClient<ActivityApiResponse>('/api/activity', {
+    params: { limit: params.limit ?? 8 },
+  });
+  return getEventsFromResponse(response).map(normalizeActivityEvent);
+}

--- a/frontend/src/components/home/ActivityFeed.tsx
+++ b/frontend/src/components/home/ActivityFeed.tsx
@@ -1,53 +1,15 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { slideInRight } from '../../lib/animations';
 import { timeAgo } from '../../lib/utils';
-
-interface ActivityEvent {
-  id: string;
-  type: 'completed' | 'submitted' | 'posted' | 'review';
-  username: string;
-  avatar_url?: string | null;
-  detail: string;
-  timestamp: string;
-}
-
-// Mock events for when API doesn't return activity
-const MOCK_EVENTS: ActivityEvent[] = [
-  {
-    id: '1',
-    type: 'completed',
-    username: 'devbuilder',
-    detail: '$500 USDC from Bounty #42',
-    timestamp: new Date(Date.now() - 3 * 60 * 1000).toISOString(),
-  },
-  {
-    id: '2',
-    type: 'submitted',
-    username: 'KodeSage',
-    detail: 'PR to Bounty #38',
-    timestamp: new Date(Date.now() - 15 * 60 * 1000).toISOString(),
-  },
-  {
-    id: '3',
-    type: 'posted',
-    username: 'SolanaLabs',
-    detail: 'Bounty #145 — $3,500 USDC',
-    timestamp: new Date(Date.now() - 45 * 60 * 1000).toISOString(),
-  },
-  {
-    id: '4',
-    type: 'review',
-    username: 'AI Review',
-    detail: 'Bounty #42 — 8.5/10',
-    timestamp: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
-  },
-];
+import { useActivityFeed } from '../../hooks/useActivityFeed';
+import type { ActivityEvent } from '../../types/activity';
 
 function getActionText(type: ActivityEvent['type']) {
   switch (type) {
     case 'completed': return 'earned';
     case 'submitted': return 'submitted';
+    case 'payout': return 'paid out';
     case 'posted': return 'posted';
     case 'review': return 'AI Review passed for';
     default: return 'updated';
@@ -62,7 +24,7 @@ function EventItem({ event }: { event: ActivityEvent }) {
         <img src={event.avatar_url} className="w-6 h-6 rounded-full flex-shrink-0" alt="" />
       ) : (
         <div className="w-6 h-6 rounded-full bg-forge-700 flex-shrink-0 flex items-center justify-center">
-          <span className="font-mono text-xs text-text-muted">{event.username[0]?.toUpperCase()}</span>
+          <span className="font-mono text-xs text-text-muted">{event.username[0]?.toUpperCase() ?? '?'}</span>
         </div>
       )}
       <p className="text-sm text-text-secondary flex-1 truncate">
@@ -75,13 +37,42 @@ function EventItem({ event }: { event: ActivityEvent }) {
   );
 }
 
-export function ActivityFeed({ events }: { events?: ActivityEvent[] }) {
-  const displayEvents = events?.length ? events.slice(0, 4) : MOCK_EVENTS;
-  const [visibleEvents, setVisibleEvents] = useState<ActivityEvent[]>(displayEvents.slice(0, 4));
+function ActivityFeedMessage({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-border bg-forge-900 px-3 py-4 text-center">
+      <p className="text-sm text-text-muted">{children}</p>
+    </div>
+  );
+}
 
-  useEffect(() => {
-    setVisibleEvents(displayEvents.slice(0, 4));
-  }, [events]);
+function ActivityFeedSkeleton() {
+  return (
+    <div role="status" aria-busy="true" aria-label="Loading recent activity" className="space-y-1">
+      <span className="sr-only">Loading recent activity</span>
+      {Array.from({ length: 4 }).map((_, index) => (
+        <div key={index} className="flex items-center gap-3 rounded-lg px-3 py-2">
+          <div className="h-6 w-6 flex-shrink-0 overflow-hidden rounded-full bg-forge-700">
+            <div className="h-full w-full bg-gradient-to-r from-transparent via-white/[0.07] to-transparent bg-[length:200%_100%] animate-shimmer" />
+          </div>
+          <div className="h-4 flex-1 overflow-hidden rounded bg-forge-800">
+            <div className="h-full w-full bg-gradient-to-r from-transparent via-white/[0.07] to-transparent bg-[length:200%_100%] animate-shimmer" />
+          </div>
+          <div className="h-3 w-16 flex-shrink-0 overflow-hidden rounded bg-forge-800">
+            <div className="h-full w-full bg-gradient-to-r from-transparent via-white/[0.07] to-transparent bg-[length:200%_100%] animate-shimmer" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function ActivityFeed({ events }: { events?: ActivityEvent[] }) {
+  const hasProvidedEvents = events !== undefined;
+  const { data: apiEvents = [], isError, isFetching, isLoading } = useActivityFeed(8, !hasProvidedEvents);
+  const visibleEvents = (hasProvidedEvents ? events ?? [] : apiEvents).slice(0, 4);
+  const showLoading = isLoading && !hasProvidedEvents && visibleEvents.length === 0;
+  const showError = isError && !hasProvidedEvents && visibleEvents.length === 0;
+  const showEmpty = !showLoading && !showError && visibleEvents.length === 0;
 
   return (
     <section className="w-full border-y border-border bg-forge-900/50 py-4 overflow-hidden">
@@ -89,22 +80,30 @@ export function ActivityFeed({ events }: { events?: ActivityEvent[] }) {
         <div className="flex items-center gap-3 mb-3">
           <span className="w-2 h-2 rounded-full bg-emerald animate-pulse-glow" />
           <span className="font-mono text-xs text-text-muted uppercase tracking-wider">Recent Activity</span>
+          {isFetching && !showLoading && !hasProvidedEvents && (
+            <span className="font-mono text-[10px] uppercase tracking-wider text-emerald">Updating</span>
+          )}
         </div>
-        <div className="space-y-1">
-          <AnimatePresence mode="popLayout">
-            {visibleEvents.map((event) => (
-              <motion.div
-                key={event.id}
-                variants={slideInRight}
-                initial="initial"
-                animate="animate"
-                exit={{ opacity: 0, x: -20, transition: { duration: 0.2 } }}
-                layout
-              >
-                <EventItem event={event} />
-              </motion.div>
-            ))}
-          </AnimatePresence>
+        <div className="space-y-1" aria-live="polite">
+          {showLoading && <ActivityFeedSkeleton />}
+          {showError && <ActivityFeedMessage>Activity feed is temporarily unavailable.</ActivityFeedMessage>}
+          {showEmpty && <ActivityFeedMessage>No recent activity</ActivityFeedMessage>}
+          {!showLoading && !showError && !showEmpty && (
+            <AnimatePresence mode="popLayout">
+              {visibleEvents.map((event) => (
+                <motion.div
+                  key={event.id}
+                  variants={slideInRight}
+                  initial="initial"
+                  animate="animate"
+                  exit={{ opacity: 0, x: -20, transition: { duration: 0.2 } }}
+                  layout
+                >
+                  <EventItem event={event} />
+                </motion.div>
+              ))}
+            </AnimatePresence>
+          )}
         </div>
       </div>
     </section>

--- a/frontend/src/hooks/useActivityFeed.ts
+++ b/frontend/src/hooks/useActivityFeed.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+import { getActivityEvents } from '../api/activity';
+
+export function useActivityFeed(limit = 8, enabled = true) {
+  return useQuery({
+    queryKey: ['activity-feed', limit],
+    queryFn: () => getActivityEvents({ limit }),
+    enabled,
+    staleTime: 15_000,
+    refetchInterval: 30_000,
+    retry: 1,
+  });
+}

--- a/frontend/src/lib/animations.ts
+++ b/frontend/src/lib/animations.ts
@@ -1,0 +1,47 @@
+import type { Variants } from 'framer-motion';
+
+export const fadeIn: Variants = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.35, ease: 'easeOut' } },
+};
+
+export const pageTransition: Variants = {
+  initial: { opacity: 0 },
+  animate: { opacity: 1, transition: { duration: 0.3, ease: 'easeOut' } },
+  exit: { opacity: 0, transition: { duration: 0.2, ease: 'easeIn' } },
+};
+
+export const staggerContainer: Variants = {
+  initial: {},
+  animate: {
+    transition: {
+      staggerChildren: 0.06,
+    },
+  },
+};
+
+export const staggerItem: Variants = {
+  initial: { opacity: 0, y: 10 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.3, ease: 'easeOut' } },
+};
+
+export const slideInRight: Variants = {
+  initial: { opacity: 0, x: 24 },
+  animate: { opacity: 1, x: 0, transition: { duration: 0.3, ease: 'easeOut' } },
+  exit: { opacity: 0, x: 24, transition: { duration: 0.2, ease: 'easeIn' } },
+};
+
+export const cardHover: Variants = {
+  rest: { y: 0, borderColor: '#1E1E2E' },
+  hover: {
+    y: -4,
+    borderColor: '#2E2E42',
+    transition: { duration: 0.2, ease: 'easeOut' },
+  },
+};
+
+export const buttonHover: Variants = {
+  rest: { scale: 1 },
+  hover: { scale: 1.02, transition: { duration: 0.15, ease: 'easeOut' } },
+  tap: { scale: 0.98 },
+};

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,75 @@
+export const LANG_COLORS: Record<string, string> = {
+  TypeScript: '#3178C6',
+  JavaScript: '#F7DF1E',
+  Python: '#3776AB',
+  Rust: '#DEA584',
+  Go: '#00ADD8',
+  Solidity: '#363636',
+  Java: '#B07219',
+  C: '#555555',
+  'C++': '#F34B7D',
+  Ruby: '#CC342D',
+  Swift: '#FA7343',
+  Kotlin: '#A97BFF',
+  Shell: '#89E051',
+};
+
+export function formatCurrency(amount?: number | string | null, token = 'USDC') {
+  const numericAmount = Number(amount ?? 0);
+  const formattedAmount = Number.isFinite(numericAmount)
+    ? numericAmount.toLocaleString(undefined, { maximumFractionDigits: 2 })
+    : '0';
+
+  if (token.toUpperCase() === 'USDC' || token === '$') {
+    return `$${formattedAmount}`;
+  }
+
+  return `${formattedAmount} ${token}`;
+}
+
+export function timeAgo(value?: string | Date | null) {
+  if (!value) return 'recently';
+
+  const date = value instanceof Date ? value : new Date(value);
+  const timestamp = date.getTime();
+  if (Number.isNaN(timestamp)) return 'recently';
+
+  const seconds = Math.max(0, Math.floor((Date.now() - timestamp) / 1000));
+  const units: Array<[Intl.RelativeTimeFormatUnit, number]> = [
+    ['year', 60 * 60 * 24 * 365],
+    ['month', 60 * 60 * 24 * 30],
+    ['week', 60 * 60 * 24 * 7],
+    ['day', 60 * 60 * 24],
+    ['hour', 60 * 60],
+    ['minute', 60],
+  ];
+
+  for (const [unit, size] of units) {
+    const count = Math.floor(seconds / size);
+    if (count >= 1) {
+      return new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' }).format(-count, unit);
+    }
+  }
+
+  return 'just now';
+}
+
+export function timeLeft(value?: string | Date | null) {
+  if (!value) return 'No deadline';
+
+  const date = value instanceof Date ? value : new Date(value);
+  const timestamp = date.getTime();
+  if (Number.isNaN(timestamp)) return 'No deadline';
+
+  const seconds = Math.floor((timestamp - Date.now()) / 1000);
+  if (seconds <= 0) return 'Expired';
+
+  const days = Math.floor(seconds / (60 * 60 * 24));
+  if (days >= 1) return `${days}d left`;
+
+  const hours = Math.floor(seconds / (60 * 60));
+  if (hours >= 1) return `${hours}h left`;
+
+  const minutes = Math.max(1, Math.floor(seconds / 60));
+  return `${minutes}m left`;
+}

--- a/frontend/src/types/activity.ts
+++ b/frontend/src/types/activity.ts
@@ -1,0 +1,10 @@
+export type ActivityEventType = 'completed' | 'submitted' | 'posted' | 'review' | 'payout';
+
+export interface ActivityEvent {
+  id: string;
+  type: ActivityEventType;
+  username: string;
+  avatar_url?: string | null;
+  detail: string;
+  timestamp: string;
+}


### PR DESCRIPTION
﻿Wires the home page activity feed to backend activity data instead of hardcoded mock events.Implementation details:- Adds a typed activity event model- Adds /api/activity fetching with response-shape normalization- Supports bounty completions, PR submissions, posted bounties, AI reviews, and payouts- Adds a React Query hook that auto-refreshes every 30 seconds- Replaces mock feed fallback with loading, empty, and unavailable states- Shows No recent activity when the API returns an empty feed- Keeps optional provided events support for controlled rendering- Restores the shared frontend lib modules currently imported by the app, and narrows .gitignore so those source files are tracked- Adds focused coverage for API normalization, live feed rendering, and empty-state behaviorVerification:- npm.cmd run build- npm.cmd test -- src/__tests__/activity-feed-api.test.tsxCloses #822

Wallet: C2z3FWAacvSYVrrkfpk6nQyNhF4t3z7t9iXRW1xfZPy1