### PR TITLE
feat: add toast notification system for key bounty actions

### DIFF
--- a/frontend/src/components/bounty/BountyCreateWizard.tsx
+++ b/frontend/src/components/bounty/BountyCreateWizard.tsx
@@ -5,6 +5,7 @@ import { Check, ChevronRight, Loader2, Copy } from 'lucide-react';
 import type { BountyCreatePayload } from '../../types/bounty';
 import { createBounty, getTreasuryDepositInfo, verifyEscrowDeposit } from '../../api/bounties';
 import { pageTransition } from '../../lib/animations';
+import { useToast } from '../../contexts/ToastContext';
 
 const PRESET_AMOUNTS = [10, 20, 50, 100, 200];
 const PLATFORM_FEE_PCT = 0.05;
@@ -263,12 +264,14 @@ function Step3({
   onBack,
   onSubmit,
   creating,
+  pushToast,
 }: {
   state: WizardState;
   onChange: (k: keyof WizardState, v: unknown) => void;
   onBack: () => void;
   onSubmit: () => void;
   creating: boolean;
+  pushToast: (toast: { title: string; message?: string; variant?: 'success' | 'error' | 'warning' | 'info' }) => void;
 }) {
   const [verifying, setVerifying] = useState(false);
   const [verifyError, setVerifyError] = useState<string | null>(null);
@@ -280,6 +283,7 @@ function Step3({
     if (!state.treasury_address) return;
     navigator.clipboard.writeText(state.treasury_address).then(() => {
       setCopiedAddr(true);
+      pushToast({ title: 'Address copied', message: 'Treasury address copied to clipboard.', variant: 'success' });
       setTimeout(() => setCopiedAddr(false), 2000);
     });
   };
@@ -292,11 +296,15 @@ function Step3({
       const result = await verifyEscrowDeposit({ bounty_id: state.bounty_id, tx_signature: state.tx_signature });
       if (result.verified) {
         onChange('verified', true);
+        pushToast({ title: 'Payment verified', message: 'Escrow deposit was confirmed.', variant: 'success' });
       } else {
-        setVerifyError(result.error ?? 'Verification failed. Check your transaction signature.');
+        const msg = result.error ?? 'Verification failed. Check your transaction signature.';
+        setVerifyError(msg);
+        pushToast({ title: 'Verification failed', message: msg, variant: 'error' });
       }
     } catch {
       setVerifyError('Verification failed. Try again.');
+      pushToast({ title: 'Verification failed', message: 'Please try again in a moment.', variant: 'error' });
     } finally {
       setVerifying(false);
     }
@@ -380,6 +388,7 @@ function Step3({
 
 export function BountyCreateWizard() {
   const navigate = useNavigate();
+  const { pushToast } = useToast();
   const [step, setStep] = useState(0);
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -418,12 +427,15 @@ export function BountyCreateWizard() {
       };
       const bounty = await createBounty(payload);
       const depositInfo = await getTreasuryDepositInfo(bounty.id);
+      pushToast({ title: 'Draft bounty created', message: 'Now fund escrow to publish it.', variant: 'info' });
       onChange('bounty_id', bounty.id);
       onChange('treasury_address', depositInfo.treasury_address);
       onChange('total_to_fund', depositInfo.total_to_fund);
       setStep(2);
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : 'Failed to create bounty. Try again.');
+      const msg = e instanceof Error ? e.message : 'Failed to create bounty. Try again.';
+      setError(msg);
+      pushToast({ title: 'Create failed', message: msg, variant: 'error' });
     } finally {
       setCreating(false);
     }
@@ -436,8 +448,11 @@ export function BountyCreateWizard() {
     try {
       await verifyEscrowDeposit({ bounty_id: state.bounty_id, tx_signature: state.tx_signature });
       setSuccess(true);
+      pushToast({ title: 'Bounty published', message: 'Your bounty is now live.', variant: 'success' });
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : 'Failed to publish bounty. Try again.');
+      const msg = e instanceof Error ? e.message : 'Failed to publish bounty. Try again.';
+      setError(msg);
+      pushToast({ title: 'Publish failed', message: msg, variant: 'error' });
     } finally {
       setCreating(false);
     }
@@ -476,7 +491,7 @@ export function BountyCreateWizard() {
         >
           {step === 0 && <Step1 state={state} onChange={onChange} onNext={handleStep1Next} />}
           {step === 1 && <Step2 state={state} onChange={onChange} onNext={handleStep2Next} onBack={() => setStep(0)} />}
-          {step === 2 && <Step3 state={state} onChange={onChange} onBack={() => setStep(1)} onSubmit={handlePublish} creating={creating} />}
+          {step === 2 && <Step3 state={state} onChange={onChange} onBack={() => setStep(1)} onSubmit={handlePublish} creating={creating} pushToast={pushToast} />}
         </motion.div>
       </AnimatePresence>
     </div>

--- a/frontend/src/components/bounty/BountyDetail.tsx
+++ b/frontend/src/components/bounty/BountyDetail.tsx
@@ -7,6 +7,7 @@ import { timeLeft, timeAgo, formatCurrency, LANG_COLORS } from '../../lib/utils'
 import { useAuth } from '../../hooks/useAuth';
 import { SubmissionForm } from './SubmissionForm';
 import { fadeIn } from '../../lib/animations';
+import { useToast } from '../../contexts/ToastContext';
 
 interface BountyDetailProps {
   bounty: Bounty;
@@ -14,12 +15,14 @@ interface BountyDetailProps {
 
 export function BountyDetail({ bounty }: BountyDetailProps) {
   const { isAuthenticated } = useAuth();
+  const { pushToast } = useToast();
   const [submitting, setSubmitting] = useState(false);
   const [copied, setCopied] = useState(false);
 
   const copyLink = () => {
     navigator.clipboard.writeText(window.location.href).then(() => {
       setCopied(true);
+      pushToast({ title: 'Link copied', message: 'Bounty link copied to clipboard.', variant: 'success' });
       setTimeout(() => setCopied(false), 2000);
     });
   };

--- a/frontend/src/contexts/ToastContext.tsx
+++ b/frontend/src/contexts/ToastContext.tsx
@@ -1,0 +1,104 @@
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { CheckCircle2, AlertCircle, AlertTriangle, Info, X } from 'lucide-react';
+
+type ToastVariant = 'success' | 'error' | 'warning' | 'info';
+
+interface ToastItem {
+  id: string;
+  title: string;
+  message?: string;
+  variant: ToastVariant;
+}
+
+interface ToastInput {
+  title: string;
+  message?: string;
+  variant?: ToastVariant;
+}
+
+interface ToastContextValue {
+  pushToast: (toast: ToastInput) => void;
+  removeToast: (id: string) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+const variantStyles: Record<ToastVariant, string> = {
+  success: 'border-emerald/40 bg-emerald-bg text-emerald',
+  error: 'border-status-error/40 bg-status-error/10 text-status-error',
+  warning: 'border-status-warning/40 bg-status-warning/10 text-status-warning',
+  info: 'border-status-info/40 bg-status-info/10 text-status-info',
+};
+
+const variantIcon: Record<ToastVariant, React.ReactNode> = {
+  success: <CheckCircle2 className="w-4 h-4" />,
+  error: <AlertCircle className="w-4 h-4" />,
+  warning: <AlertTriangle className="w-4 h-4" />,
+  info: <Info className="w-4 h-4" />,
+};
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+
+  const removeToast = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const pushToast = useCallback((toast: ToastInput) => {
+    const id = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const item: ToastItem = {
+      id,
+      title: toast.title,
+      message: toast.message,
+      variant: toast.variant ?? 'info',
+    };
+
+    setToasts((prev) => [...prev, item]);
+    window.setTimeout(() => removeToast(id), 5000);
+  }, [removeToast]);
+
+  const value = useMemo(() => ({ pushToast, removeToast }), [pushToast, removeToast]);
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <div className="fixed top-4 right-4 z-[100] flex w-[min(92vw,360px)] flex-col gap-2">
+        <AnimatePresence>
+          {toasts.map((toast) => (
+            <motion.div
+              key={toast.id}
+              role="alert"
+              initial={{ opacity: 0, x: 32, y: -8 }}
+              animate={{ opacity: 1, x: 0, y: 0 }}
+              exit={{ opacity: 0, x: 32 }}
+              transition={{ duration: 0.18 }}
+              className={`rounded-lg border px-3 py-2.5 shadow-lg backdrop-blur-sm ${variantStyles[toast.variant]}`}
+            >
+              <div className="flex items-start gap-2">
+                <span className="mt-0.5">{variantIcon[toast.variant]}</span>
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm font-semibold leading-tight">{toast.title}</p>
+                  {toast.message && <p className="mt-1 text-xs text-text-secondary">{toast.message}</p>}
+                </div>
+                <button
+                  onClick={() => removeToast(toast.id)}
+                  className="text-text-muted hover:text-text-primary transition-colors"
+                  aria-label="Close notification"
+                >
+                  <X className="w-4 h-4" />
+                </button>
+              </div>
+            </motion.div>
+          ))}
+        </AnimatePresence>
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error('useToast must be used within ToastProvider');
+  return ctx;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { AuthProvider } from './contexts/AuthContext';
 import { queryClient } from './services/queryClient';
+import { ToastProvider } from './contexts/ToastContext';
 import App from './App';
 import './index.css';
 
@@ -15,7 +16,9 @@ createRoot(root).render(
     <BrowserRouter>
       <QueryClientProvider client={queryClient}>
         <AuthProvider>
-          <App />
+          <ToastProvider>
+            <App />
+          </ToastProvider>
         </AuthProvider>
       </QueryClientProvider>
     </BrowserRouter>


### PR DESCRIPTION
## Summary
- add a global toast notification system with context + hook
- support `success`, `error`, `warning`, `info` variants
- auto-dismiss toasts after 5 seconds with manual close
- stack multiple toasts in top-right with slide-in animation
- add `role="alert"` for accessibility
- wire key bounty actions to toasts:
  - create bounty success/failure
  - verify payment success/failure
  - publish bounty success/failure
  - copy treasury address and bounty link

## Why
Issue #825 requests a toast system for status changes, errors, and success messages with stacking and accessibility.

## Acceptance mapping
- [x] Toast notifications appear for key actions
- [x] Auto-dismiss with manual close option
- [x] Multiple toasts stack properly
- [x] Slide-in animation from top-right
- [x] Accessible via `role="alert"`

Closes #825

## Validation
- Manual flow verification through bounty create + detail interactions
- `npm run build` in `frontend` currently fails due to pre-existing missing modules (`lib/animations`, `lib/utils`) unrelated to this change

## Wallet
Wallet: 74jSPYaxEJcGEuW4jr6bqQdg2iuLChyLEuEmC8QhcQVW
