### PR TITLE
feat: add 5 SolFoundry social media templates

### DIFF
--- a/assets/social-templates/README.md
+++ b/assets/social-templates/README.md
@@ -1,0 +1,22 @@
+# SolFoundry Social Media Templates (Bounty #829)
+
+Five editable SVG templates for SolFoundry social posts.
+
+## Files
+- `template-01-launch.svg` — New bounty announcement
+- `template-02-creator-call.svg` — Creator call-to-action
+- `template-03-review-trust.svg` — AI review trust signal
+- `template-04-contributor-win.svg` — Contributor spotlight
+- `template-05-weekly-roundup.svg` — Weekly metrics summary
+
+## Suggested usage
+- Format: 1200x675 (works for X/Twitter and most social preview cards)
+- Edit text directly in Figma/Illustrator/Canva (SVG import)
+- Export as PNG for posting
+
+## Brand notes
+Palette follows SolFoundry theme:
+- Emerald `#00E676`
+- Purple `#7C3AED`
+- Magenta `#E040FB`
+- Forge dark backgrounds `#050505` / `#0A0A0F`

--- a/assets/social-templates/template-01-launch.svg
+++ b/assets/social-templates/template-01-launch.svg
@@ -1,0 +1,22 @@
+<svg width="1200" height="675" viewBox="0 0 1200 675" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="675">
+      <stop offset="0" stop-color="#050505"/>
+      <stop offset="1" stop-color="#1E1E2A"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="130" y1="90" x2="990" y2="620">
+      <stop offset="0" stop-color="#00E676"/>
+      <stop offset="0.5" stop-color="#7C3AED"/>
+      <stop offset="1" stop-color="#E040FB"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="675" fill="url(#bg)"/>
+  <rect x="70" y="70" width="1060" height="535" rx="28" stroke="url(#accent)" stroke-opacity="0.65" stroke-width="2"/>
+  <text x="130" y="190" fill="#A0A0B8" font-family="Inter,Arial,sans-serif" font-size="34">NEW BOUNTY LIVE</text>
+  <text x="130" y="290" fill="#F0F0F5" font-family="Orbitron,Inter,Arial,sans-serif" font-size="72" font-weight="700">SHIP CODE.</text>
+  <text x="130" y="365" fill="#00E676" font-family="Orbitron,Inter,Arial,sans-serif" font-size="72" font-weight="700">EARN FNDRY.</text>
+  <text x="130" y="462" fill="#A0A0B8" font-family="JetBrains Mono,monospace" font-size="30">solfoundry.org/bounties</text>
+  <circle cx="980" cy="168" r="56" fill="#00E676" fill-opacity="0.15"/>
+  <circle cx="1038" cy="224" r="38" fill="#E040FB" fill-opacity="0.15"/>
+  <circle cx="930" cy="248" r="30" fill="#7C3AED" fill-opacity="0.15"/>
+</svg>

--- a/assets/social-templates/template-02-creator-call.svg
+++ b/assets/social-templates/template-02-creator-call.svg
@@ -1,0 +1,17 @@
+<svg width="1200" height="675" viewBox="0 0 1200 675" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="bg2" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(250 140) rotate(28) scale(1050 760)">
+      <stop stop-color="#1A1033"/>
+      <stop offset="1" stop-color="#050505"/>
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="675" fill="url(#bg2)"/>
+  <rect x="120" y="120" width="960" height="435" rx="22" fill="#0A0A0F" stroke="#2E2E42"/>
+  <text x="170" y="205" fill="#E040FB" font-family="Inter,Arial,sans-serif" font-size="28" font-weight="600">FOR OPEN-SOURCE CREATORS</text>
+  <text x="170" y="295" fill="#F0F0F5" font-family="Orbitron,Inter,Arial,sans-serif" font-size="64" font-weight="700">TURN IDEAS</text>
+  <text x="170" y="363" fill="#F0F0F5" font-family="Orbitron,Inter,Arial,sans-serif" font-size="64" font-weight="700">INTO BOUNTIES</text>
+  <text x="170" y="438" fill="#A0A0B8" font-family="Inter,Arial,sans-serif" font-size="30">Post. Fund. Review. Reward.</text>
+  <text x="170" y="494" fill="#00E676" font-family="JetBrains Mono,monospace" font-size="30">Create at /bounties/create</text>
+  <rect x="805" y="420" width="225" height="74" rx="37" fill="#00E676" fill-opacity="0.14" stroke="#00E676"/>
+  <text x="853" y="468" fill="#00E676" font-family="Inter,Arial,sans-serif" font-size="29" font-weight="700">START NOW</text>
+</svg>

--- a/assets/social-templates/template-03-review-trust.svg
+++ b/assets/social-templates/template-03-review-trust.svg
@@ -1,0 +1,15 @@
+<svg width="1200" height="675" viewBox="0 0 1200 675" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1200" height="675" fill="#050505"/>
+  <rect x="70" y="70" width="1060" height="535" rx="24" fill="#0A0A0F" stroke="#1E1E2E"/>
+  <text x="130" y="178" fill="#40C4FF" font-family="Inter,Arial,sans-serif" font-size="30" font-weight="600">AI + HUMAN QUALITY GATE</text>
+  <text x="130" y="276" fill="#F0F0F5" font-family="Orbitron,Inter,Arial,sans-serif" font-size="66" font-weight="700">BUILD FAST</text>
+  <text x="130" y="346" fill="#F0F0F5" font-family="Orbitron,Inter,Arial,sans-serif" font-size="66" font-weight="700">REVIEW SMART</text>
+  <text x="130" y="443" fill="#A0A0B8" font-family="Inter,Arial,sans-serif" font-size="30">Clean PRs. Transparent scoring. Instant feedback.</text>
+  <g transform="translate(760,205)">
+    <rect width="280" height="210" rx="18" fill="#111120" stroke="#2E2E42"/>
+    <text x="26" y="44" fill="#A0A0B8" font-family="JetBrains Mono,monospace" font-size="20">Review Status</text>
+    <text x="26" y="98" fill="#00E676" font-family="JetBrains Mono,monospace" font-size="24">✓ Checks passed</text>
+    <text x="26" y="142" fill="#40C4FF" font-family="JetBrains Mono,monospace" font-size="24">✓ Wallet valid</text>
+    <text x="26" y="186" fill="#E040FB" font-family="JetBrains Mono,monospace" font-size="24">✓ Ready to merge</text>
+  </g>
+</svg>

--- a/assets/social-templates/template-04-contributor-win.svg
+++ b/assets/social-templates/template-04-contributor-win.svg
@@ -1,0 +1,21 @@
+<svg width="1200" height="675" viewBox="0 0 1200 675" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="g4" x1="0" y1="0" x2="1200" y2="675">
+      <stop stop-color="#0A0A0F"/>
+      <stop offset="1" stop-color="#120A1F"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="675" fill="url(#g4)"/>
+  <text x="118" y="158" fill="#A0A0B8" font-family="Inter,Arial,sans-serif" font-size="30">CONTRIBUTOR SPOTLIGHT</text>
+  <text x="118" y="257" fill="#F0F0F5" font-family="Orbitron,Inter,Arial,sans-serif" font-size="64" font-weight="700">FROM ISSUE</text>
+  <text x="118" y="325" fill="#00E676" font-family="Orbitron,Inter,Arial,sans-serif" font-size="64" font-weight="700">TO PAYOUT</text>
+  <text x="118" y="402" fill="#A0A0B8" font-family="Inter,Arial,sans-serif" font-size="30">Share your winning PR and inspire builders.</text>
+  <rect x="118" y="456" width="420" height="84" rx="14" fill="#00E676" fill-opacity="0.1" stroke="#00E676"/>
+  <text x="150" y="507" fill="#00E676" font-family="JetBrains Mono,monospace" font-size="30">#BuildEarnOwn</text>
+  <rect x="700" y="140" width="400" height="390" rx="20" fill="#0F0F18" stroke="#2E2E42"/>
+  <text x="748" y="214" fill="#E040FB" font-family="Inter,Arial,sans-serif" font-size="28" font-weight="700">WINNING CHECKLIST</text>
+  <text x="748" y="272" fill="#F0F0F5" font-family="Inter,Arial,sans-serif" font-size="28">1) Pick a bounty</text>
+  <text x="748" y="322" fill="#F0F0F5" font-family="Inter,Arial,sans-serif" font-size="28">2) Ship high-quality PR</text>
+  <text x="748" y="372" fill="#F0F0F5" font-family="Inter,Arial,sans-serif" font-size="28">3) Pass AI review</text>
+  <text x="748" y="422" fill="#F0F0F5" font-family="Inter,Arial,sans-serif" font-size="28">4) Receive FNDRY</text>
+</svg>

--- a/assets/social-templates/template-05-weekly-roundup.svg
+++ b/assets/social-templates/template-05-weekly-roundup.svg
@@ -1,0 +1,16 @@
+<svg width="1200" height="675" viewBox="0 0 1200 675" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1200" height="675" fill="#050505"/>
+  <rect x="95" y="95" width="1010" height="485" rx="28" fill="#0A0A0F" stroke="#2E2E42"/>
+  <text x="150" y="180" fill="#00E676" font-family="Inter,Arial,sans-serif" font-size="29" font-weight="700">WEEKLY ROUNDUP</text>
+  <text x="150" y="264" fill="#F0F0F5" font-family="Orbitron,Inter,Arial,sans-serif" font-size="60" font-weight="700">SOLFOUNDRY</text>
+  <text x="150" y="332" fill="#F0F0F5" font-family="Orbitron,Inter,Arial,sans-serif" font-size="60" font-weight="700">IN NUMBERS</text>
+  <rect x="150" y="382" width="295" height="140" rx="16" fill="#00E676" fill-opacity="0.08" stroke="#00E676"/>
+  <rect x="470" y="382" width="295" height="140" rx="16" fill="#7C3AED" fill-opacity="0.09" stroke="#7C3AED"/>
+  <rect x="790" y="382" width="265" height="140" rx="16" fill="#E040FB" fill-opacity="0.09" stroke="#E040FB"/>
+  <text x="182" y="430" fill="#A0A0B8" font-family="Inter,Arial,sans-serif" font-size="24">Bounties Open</text>
+  <text x="182" y="485" fill="#00E676" font-family="JetBrains Mono,monospace" font-size="44">142</text>
+  <text x="500" y="430" fill="#A0A0B8" font-family="Inter,Arial,sans-serif" font-size="24">USDC Paid</text>
+  <text x="500" y="485" fill="#7C3AED" font-family="JetBrains Mono,monospace" font-size="44">$24.5K</text>
+  <text x="820" y="430" fill="#A0A0B8" font-family="Inter,Arial,sans-serif" font-size="24">Builders</text>
+  <text x="820" y="485" fill="#E040FB" font-family="JetBrains Mono,monospace" font-size="44">89</text>
+</svg>


### PR DESCRIPTION
## Summary
- add 5 original social media templates under `assets/social-templates/`
- include campaign-focused variants:
  - new bounty launch
  - creator call-to-action
  - AI review trust
  - contributor spotlight
  - weekly roundup metrics
- provide usage + brand palette guidance in `assets/social-templates/README.md`
- all templates are editable SVG at 1200x675 for easy export to PNG

## Why
Issue #829 asks for social media template designs. This PR delivers five ready-to-edit branded templates aligned to SolFoundry colors and messaging.

## Acceptance mapping
- [x] 5 social media designs delivered
- [x] Reusable/editable source assets included
- [x] Consistent SolFoundry visual style

Closes #829

## Wallet
Wallet: 74jSPYaxEJcGEuW4jr6bqQdg2iuLChyLEuEmC8QhcQVW
