### PR TITLE
feat: add SolFoundry sticker pack (10 SVG stickers)

### DIFF
--- a/assets/sticker-pack-835/README.md
+++ b/assets/sticker-pack-835/README.md
@@ -1,0 +1,19 @@
+# SolFoundry Sticker Pack (Bounty #835)
+
+10 square sticker assets (SVG, 512x512) for community use.
+
+## Files
+- sticker-01.svg
+- sticker-02.svg
+- sticker-03.svg
+- sticker-04.svg
+- sticker-05.svg
+- sticker-06.svg
+- sticker-07.svg
+- sticker-08.svg
+- sticker-09.svg
+- sticker-10.svg
+
+## Notes
+- Vector format for easy editing/export
+- Uses SolFoundry palette: emerald / purple / magenta on forge-dark background

--- a/assets/sticker-pack-835/sticker-01.svg
+++ b/assets/sticker-pack-835/sticker-01.svg
@@ -1,0 +1,14 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="g" x1="24" y1="24" x2="488" y2="488">
+      <stop offset="0" stop-color="#00E676"/>
+      <stop offset="0.5" stop-color="#7C3AED"/>
+      <stop offset="1" stop-color="#E040FB"/>
+    </linearGradient>
+  </defs>
+  <rect x="18" y="18" width="476" height="476" rx="96" fill="#0A0A0F" stroke="url(#g)" stroke-width="14"/>
+  <circle cx="256" cy="188" r="68" fill="#111120" stroke="#2E2E42" stroke-width="8"/>
+  <text x="256" y="206" fill="#00E676" font-family="JetBrains Mono,monospace" font-size="40" font-weight="700" text-anchor="middle">SF</text>
+  <rect x="88" y="286" width="336" height="94" rx="47" fill="#111120" stroke="#2E2E42" stroke-width="8"/>
+  <text x="256" y="344" fill="#F0F0F5" font-family="Inter,Arial,sans-serif" font-size="33" font-weight="700" text-anchor="middle">SHIP IT</text>
+</svg>

--- a/assets/sticker-pack-835/sticker-02.svg
+++ b/assets/sticker-pack-835/sticker-02.svg
@@ -1,0 +1,14 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="g" x1="24" y1="24" x2="488" y2="488">
+      <stop offset="0" stop-color="#00E676"/>
+      <stop offset="0.5" stop-color="#7C3AED"/>
+      <stop offset="1" stop-color="#E040FB"/>
+    </linearGradient>
+  </defs>
+  <rect x="18" y="18" width="476" height="476" rx="96" fill="#0A0A0F" stroke="url(#g)" stroke-width="14"/>
+  <circle cx="256" cy="188" r="68" fill="#111120" stroke="#2E2E42" stroke-width="8"/>
+  <text x="256" y="206" fill="#00E676" font-family="JetBrains Mono,monospace" font-size="40" font-weight="700" text-anchor="middle">SF</text>
+  <rect x="88" y="286" width="336" height="94" rx="47" fill="#111120" stroke="#2E2E42" stroke-width="8"/>
+  <text x="256" y="344" fill="#F0F0F5" font-family="Inter,Arial,sans-serif" font-size="33" font-weight="700" text-anchor="middle">BOUNTY</text>
+</svg>

--- a/assets/sticker-pack-835/sticker-03.svg
+++ b/assets/sticker-pack-835/sticker-03.svg
@@ -1,0 +1,14 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="g" x1="24" y1="24" x2="488" y2="488">
+      <stop offset="0" stop-color="#00E676"/>
+      <stop offset="0.5" stop-color="#7C3AED"/>
+      <stop offset="1" stop-color="#E040FB"/>
+    </linearGradient>
+  </defs>
+  <rect x="18" y="18" width="476" height="476" rx="96" fill="#0A0A0F" stroke="url(#g)" stroke-width="14"/>
+  <circle cx="256" cy="188" r="68" fill="#111120" stroke="#2E2E42" stroke-width="8"/>
+  <text x="256" y="206" fill="#00E676" font-family="JetBrains Mono,monospace" font-size="40" font-weight="700" text-anchor="middle">SF</text>
+  <rect x="88" y="286" width="336" height="94" rx="47" fill="#111120" stroke="#2E2E42" stroke-width="8"/>
+  <text x="256" y="344" fill="#F0F0F5" font-family="Inter,Arial,sans-serif" font-size="33" font-weight="700" text-anchor="middle">MERGED</text>
+</svg>

--- a/assets/sticker-pack-835/sticker-04.svg
+++ b/assets/sticker-pack-835/sticker-04.svg
@@ -1,0 +1,14 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="g" x1="24" y1="24" x2="488" y2="488">
+      <stop offset="0" stop-color="#00E676"/>
+      <stop offset="0.5" stop-color="#7C3AED"/>
+      <stop offset="1" stop-color="#E040FB"/>
+    </linearGradient>
+  </defs>
+  <rect x="18" y="18" width="476" height="476" rx="96" fill="#0A0A0F" stroke="url(#g)" stroke-width="14"/>
+  <circle cx="256" cy="188" r="68" fill="#111120" stroke="#2E2E42" stroke-width="8"/>
+  <text x="256" y="206" fill="#00E676" font-family="JetBrains Mono,monospace" font-size="40" font-weight="700" text-anchor="middle">SF</text>
+  <rect x="88" y="286" width="336" height="94" rx="47" fill="#111120" stroke="#2E2E42" stroke-width="8"/>
+  <text x="256" y="344" fill="#F0F0F5" font-family="Inter,Arial,sans-serif" font-size="33" font-weight="700" text-anchor="middle">AI REVIEW</text>
+</svg>

--- a/assets/sticker-pack-835/sticker-05.svg
+++ b/assets/sticker-pack-835/sticker-05.svg
@@ -1,0 +1,14 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="g" x1="24" y1="24" x2="488" y2="488">
+      <stop offset="0" stop-color="#00E676"/>
+      <stop offset="0.5" stop-color="#7C3AED"/>
+      <stop offset="1" stop-color="#E040FB"/>
+    </linearGradient>
+  </defs>
+  <rect x="18" y="18" width="476" height="476" rx="96" fill="#0A0A0F" stroke="url(#g)" stroke-width="14"/>
+  <circle cx="256" cy="188" r="68" fill="#111120" stroke="#2E2E42" stroke-width="8"/>
+  <text x="256" y="206" fill="#00E676" font-family="JetBrains Mono,monospace" font-size="40" font-weight="700" text-anchor="middle">SF</text>
+  <rect x="88" y="286" width="336" height="94" rx="47" fill="#111120" stroke="#2E2E42" stroke-width="8"/>
+  <text x="256" y="344" fill="#F0F0F5" font-family="Inter,Arial,sans-serif" font-size="33" font-weight="700" text-anchor="middle">BUILD</text>
+</svg>

--- a/assets/sticker-pack-835/sticker-06.svg
+++ b/assets/sticker-pack-835/sticker-06.svg
@@ -1,0 +1,14 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="g" x1="24" y1="24" x2="488" y2="488">
+      <stop offset="0" stop-color="#00E676"/>
+      <stop offset="0.5" stop-color="#7C3AED"/>
+      <stop offset="1" stop-color="#E040FB"/>
+    </linearGradient>
+  </defs>
+  <rect x="18" y="18" width="476" height="476" rx="96" fill="#0A0A0F" stroke="url(#g)" stroke-width="14"/>
+  <circle cx="256" cy="188" r="68" fill="#111120" stroke="#2E2E42" stroke-width="8"/>
+  <text x="256" y="206" fill="#00E676" font-family="JetBrains Mono,monospace" font-size="40" font-weight="700" text-anchor="middle">SF</text>
+  <rect x="88" y="286" width="336" height="94" rx="47" fill="#111120" stroke="#2E2E42" stroke-width="8"/>
+  <text x="256" y="344" fill="#F0F0F5" font-family="Inter,Arial,sans-serif" font-size="33" font-weight="700" text-anchor="middle">EARN</text>
+</svg>

--- a/assets/sticker-pack-835/sticker-07.svg
+++ b/assets/sticker-pack-835/sticker-07.svg
@@ -1,0 +1,14 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="g" x1="24" y1="24" x2="488" y2="488">
+      <stop offset="0" stop-color="#00E676"/>
+      <stop offset="0.5" stop-color="#7C3AED"/>
+      <stop offset="1" stop-color="#E040FB"/>
+    </linearGradient>
+  </defs>
+  <rect x="18" y="18" width="476" height="476" rx="96" fill="#0A0A0F" stroke="url(#g)" stroke-width="14"/>
+  <circle cx="256" cy="188" r="68" fill="#111120" stroke="#2E2E42" stroke-width="8"/>
+  <text x="256" y="206" fill="#00E676" font-family="JetBrains Mono,monospace" font-size="40" font-weight="700" text-anchor="middle">SF</text>
+  <rect x="88" y="286" width="336" height="94" rx="47" fill="#111120" stroke="#2E2E42" stroke-width="8"/>
+  <text x="256" y="344" fill="#F0F0F5" font-family="Inter,Arial,sans-serif" font-size="33" font-weight="700" text-anchor="middle">ON-CHAIN</text>
+</svg>

--- a/assets/sticker-pack-835/sticker-08.svg
+++ b/assets/sticker-pack-835/sticker-08.svg
@@ -1,0 +1,14 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="g" x1="24" y1="24" x2="488" y2="488">
+      <stop offset="0" stop-color="#00E676"/>
+      <stop offset="0.5" stop-color="#7C3AED"/>
+      <stop offset="1" stop-color="#E040FB"/>
+    </linearGradient>
+  </defs>
+  <rect x="18" y="18" width="476" height="476" rx="96" fill="#0A0A0F" stroke="url(#g)" stroke-width="14"/>
+  <circle cx="256" cy="188" r="68" fill="#111120" stroke="#2E2E42" stroke-width="8"/>
+  <text x="256" y="206" fill="#00E676" font-family="JetBrains Mono,monospace" font-size="40" font-weight="700" text-anchor="middle">SF</text>
+  <rect x="88" y="286" width="336" height="94" rx="47" fill="#111120" stroke="#2E2E42" stroke-width="8"/>
+  <text x="256" y="344" fill="#F0F0F5" font-family="Inter,Arial,sans-serif" font-size="33" font-weight="700" text-anchor="middle">FNDRY</text>
+</svg>

--- a/assets/sticker-pack-835/sticker-09.svg
+++ b/assets/sticker-pack-835/sticker-09.svg
@@ -1,0 +1,14 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="g" x1="24" y1="24" x2="488" y2="488">
+      <stop offset="0" stop-color="#00E676"/>
+      <stop offset="0.5" stop-color="#7C3AED"/>
+      <stop offset="1" stop-color="#E040FB"/>
+    </linearGradient>
+  </defs>
+  <rect x="18" y="18" width="476" height="476" rx="96" fill="#0A0A0F" stroke="url(#g)" stroke-width="14"/>
+  <circle cx="256" cy="188" r="68" fill="#111120" stroke="#2E2E42" stroke-width="8"/>
+  <text x="256" y="206" fill="#00E676" font-family="JetBrains Mono,monospace" font-size="40" font-weight="700" text-anchor="middle">SF</text>
+  <rect x="88" y="286" width="336" height="94" rx="47" fill="#111120" stroke="#2E2E42" stroke-width="8"/>
+  <text x="256" y="344" fill="#F0F0F5" font-family="Inter,Arial,sans-serif" font-size="33" font-weight="700" text-anchor="middle">SOLFOUNDRY</text>
+</svg>

--- a/assets/sticker-pack-835/sticker-10.svg
+++ b/assets/sticker-pack-835/sticker-10.svg
@@ -1,0 +1,14 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="g" x1="24" y1="24" x2="488" y2="488">
+      <stop offset="0" stop-color="#00E676"/>
+      <stop offset="0.5" stop-color="#7C3AED"/>
+      <stop offset="1" stop-color="#E040FB"/>
+    </linearGradient>
+  </defs>
+  <rect x="18" y="18" width="476" height="476" rx="96" fill="#0A0A0F" stroke="url(#g)" stroke-width="14"/>
+  <circle cx="256" cy="188" r="68" fill="#111120" stroke="#2E2E42" stroke-width="8"/>
+  <text x="256" y="206" fill="#00E676" font-family="JetBrains Mono,monospace" font-size="40" font-weight="700" text-anchor="middle">SF</text>
+  <rect x="88" y="286" width="336" height="94" rx="47" fill="#111120" stroke="#2E2E42" stroke-width="8"/>
+  <text x="256" y="344" fill="#F0F0F5" font-family="Inter,Arial,sans-serif" font-size="33" font-weight="700" text-anchor="middle">LFG</text>
+</svg>


### PR DESCRIPTION
## Summary
- add a new sticker pack folder: `assets/sticker-pack-835/`
- deliver 10 editable SVG stickers (512x512)
- include short README with usage + palette notes
- each sticker uses SolFoundry visual identity and different headline text

## Why
Issue #835 requests a SolFoundry sticker pack deliverable.

## Acceptance mapping
- [x] 10 sticker assets provided
- [x] Reusable source files (SVG)
- [x] Consistent SolFoundry branding

Closes #835

## Wallet
Wallet: 74jSPYaxEJcGEuW4jr6bqQdg2iuLChyLEuEmC8QhcQVW
