### PR TITLE
feat: add SolFoundry sticker pack (10 circular SVG badges)

### DIFF
--- a/assets/sticker-pack-832/README.md
+++ b/assets/sticker-pack-832/README.md
@@ -1,0 +1,11 @@
+# SolFoundry Sticker Pack (Bounty #832)
+
+10 circular badge-style SVG stickers (512x512).
+
+## Files
+- sticker-01.svg ... sticker-10.svg
+
+## Style
+- Circular badge motif
+- SolFoundry emerald / purple / magenta accents
+- Editable vector format for export to PNG/WebP

--- a/assets/sticker-pack-832/sticker-01.svg
+++ b/assets/sticker-pack-832/sticker-01.svg
@@ -1,0 +1,8 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+<defs><linearGradient id="g" x1="64" y1="64" x2="448" y2="448"><stop offset="0" stop-color="#7C3AED"/><stop offset="1" stop-color="#E040FB"/></linearGradient></defs>
+<circle cx="256" cy="256" r="220" fill="#0A0A0F" stroke="url(#g)" stroke-width="16"/>
+<circle cx="256" cy="256" r="172" fill="#111120" stroke="#2E2E42" stroke-width="8"/>
+<text x="256" y="230" fill="#F0F0F5" font-family="Inter,Arial,sans-serif" font-size="36" font-weight="700" text-anchor="middle">SOLFOUNDRY</text>
+<text x="256" y="286" fill="#7C3AED" font-family="JetBrains Mono,monospace" font-size="46" font-weight="700" text-anchor="middle">FOUNDRY</text>
+<text x="256" y="336" fill="#A0A0B8" font-family="Inter,Arial,sans-serif" font-size="22" text-anchor="middle">BUILD • EARN • OWN</text>
+</svg>

--- a/assets/sticker-pack-832/sticker-02.svg
+++ b/assets/sticker-pack-832/sticker-02.svg
@@ -1,0 +1,8 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+<defs><linearGradient id="g" x1="64" y1="64" x2="448" y2="448"><stop offset="0" stop-color="#E040FB"/><stop offset="1" stop-color="#00E676"/></linearGradient></defs>
+<circle cx="256" cy="256" r="220" fill="#0A0A0F" stroke="url(#g)" stroke-width="16"/>
+<circle cx="256" cy="256" r="172" fill="#111120" stroke="#2E2E42" stroke-width="8"/>
+<text x="256" y="230" fill="#F0F0F5" font-family="Inter,Arial,sans-serif" font-size="36" font-weight="700" text-anchor="middle">SOLFOUNDRY</text>
+<text x="256" y="286" fill="#E040FB" font-family="JetBrains Mono,monospace" font-size="46" font-weight="700" text-anchor="middle">BOUNTY</text>
+<text x="256" y="336" fill="#A0A0B8" font-family="Inter,Arial,sans-serif" font-size="22" text-anchor="middle">BUILD • EARN • OWN</text>
+</svg>

--- a/assets/sticker-pack-832/sticker-03.svg
+++ b/assets/sticker-pack-832/sticker-03.svg
@@ -1,0 +1,8 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+<defs><linearGradient id="g" x1="64" y1="64" x2="448" y2="448"><stop offset="0" stop-color="#40C4FF"/><stop offset="1" stop-color="#7C3AED"/></linearGradient></defs>
+<circle cx="256" cy="256" r="220" fill="#0A0A0F" stroke="url(#g)" stroke-width="16"/>
+<circle cx="256" cy="256" r="172" fill="#111120" stroke="#2E2E42" stroke-width="8"/>
+<text x="256" y="230" fill="#F0F0F5" font-family="Inter,Arial,sans-serif" font-size="36" font-weight="700" text-anchor="middle">SOLFOUNDRY</text>
+<text x="256" y="286" fill="#40C4FF" font-family="JetBrains Mono,monospace" font-size="46" font-weight="700" text-anchor="middle">EARN</text>
+<text x="256" y="336" fill="#A0A0B8" font-family="Inter,Arial,sans-serif" font-size="22" text-anchor="middle">BUILD • EARN • OWN</text>
+</svg>

--- a/assets/sticker-pack-832/sticker-04.svg
+++ b/assets/sticker-pack-832/sticker-04.svg
@@ -1,0 +1,8 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+<defs><linearGradient id="g" x1="64" y1="64" x2="448" y2="448"><stop offset="0" stop-color="#00E676"/><stop offset="1" stop-color="#E040FB"/></linearGradient></defs>
+<circle cx="256" cy="256" r="220" fill="#0A0A0F" stroke="url(#g)" stroke-width="16"/>
+<circle cx="256" cy="256" r="172" fill="#111120" stroke="#2E2E42" stroke-width="8"/>
+<text x="256" y="230" fill="#F0F0F5" font-family="Inter,Arial,sans-serif" font-size="36" font-weight="700" text-anchor="middle">SOLFOUNDRY</text>
+<text x="256" y="286" fill="#00E676" font-family="JetBrains Mono,monospace" font-size="46" font-weight="700" text-anchor="middle">MERGE</text>
+<text x="256" y="336" fill="#A0A0B8" font-family="Inter,Arial,sans-serif" font-size="22" text-anchor="middle">BUILD • EARN • OWN</text>
+</svg>

--- a/assets/sticker-pack-832/sticker-05.svg
+++ b/assets/sticker-pack-832/sticker-05.svg
@@ -1,0 +1,8 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+<defs><linearGradient id="g" x1="64" y1="64" x2="448" y2="448"><stop offset="0" stop-color="#00E676"/><stop offset="1" stop-color="#7C3AED"/></linearGradient></defs>
+<circle cx="256" cy="256" r="220" fill="#0A0A0F" stroke="url(#g)" stroke-width="16"/>
+<circle cx="256" cy="256" r="172" fill="#111120" stroke="#2E2E42" stroke-width="8"/>
+<text x="256" y="230" fill="#F0F0F5" font-family="Inter,Arial,sans-serif" font-size="36" font-weight="700" text-anchor="middle">SOLFOUNDRY</text>
+<text x="256" y="286" fill="#00E676" font-family="JetBrains Mono,monospace" font-size="46" font-weight="700" text-anchor="middle">REVIEW</text>
+<text x="256" y="336" fill="#A0A0B8" font-family="Inter,Arial,sans-serif" font-size="22" text-anchor="middle">BUILD • EARN • OWN</text>
+</svg>

--- a/assets/sticker-pack-832/sticker-06.svg
+++ b/assets/sticker-pack-832/sticker-06.svg
@@ -1,0 +1,8 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+<defs><linearGradient id="g" x1="64" y1="64" x2="448" y2="448"><stop offset="0" stop-color="#7C3AED"/><stop offset="1" stop-color="#E040FB"/></linearGradient></defs>
+<circle cx="256" cy="256" r="220" fill="#0A0A0F" stroke="url(#g)" stroke-width="16"/>
+<circle cx="256" cy="256" r="172" fill="#111120" stroke="#2E2E42" stroke-width="8"/>
+<text x="256" y="230" fill="#F0F0F5" font-family="Inter,Arial,sans-serif" font-size="36" font-weight="700" text-anchor="middle">SOLFOUNDRY</text>
+<text x="256" y="286" fill="#7C3AED" font-family="JetBrains Mono,monospace" font-size="46" font-weight="700" text-anchor="middle">BUILD</text>
+<text x="256" y="336" fill="#A0A0B8" font-family="Inter,Arial,sans-serif" font-size="22" text-anchor="middle">BUILD • EARN • OWN</text>
+</svg>

--- a/assets/sticker-pack-832/sticker-07.svg
+++ b/assets/sticker-pack-832/sticker-07.svg
@@ -1,0 +1,8 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+<defs><linearGradient id="g" x1="64" y1="64" x2="448" y2="448"><stop offset="0" stop-color="#E040FB"/><stop offset="1" stop-color="#00E676"/></linearGradient></defs>
+<circle cx="256" cy="256" r="220" fill="#0A0A0F" stroke="url(#g)" stroke-width="16"/>
+<circle cx="256" cy="256" r="172" fill="#111120" stroke="#2E2E42" stroke-width="8"/>
+<text x="256" y="230" fill="#F0F0F5" font-family="Inter,Arial,sans-serif" font-size="36" font-weight="700" text-anchor="middle">SOLFOUNDRY</text>
+<text x="256" y="286" fill="#E040FB" font-family="JetBrains Mono,monospace" font-size="46" font-weight="700" text-anchor="middle">SHIP</text>
+<text x="256" y="336" fill="#A0A0B8" font-family="Inter,Arial,sans-serif" font-size="22" text-anchor="middle">BUILD • EARN • OWN</text>
+</svg>

--- a/assets/sticker-pack-832/sticker-08.svg
+++ b/assets/sticker-pack-832/sticker-08.svg
@@ -1,0 +1,8 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+<defs><linearGradient id="g" x1="64" y1="64" x2="448" y2="448"><stop offset="0" stop-color="#40C4FF"/><stop offset="1" stop-color="#7C3AED"/></linearGradient></defs>
+<circle cx="256" cy="256" r="220" fill="#0A0A0F" stroke="url(#g)" stroke-width="16"/>
+<circle cx="256" cy="256" r="172" fill="#111120" stroke="#2E2E42" stroke-width="8"/>
+<text x="256" y="230" fill="#F0F0F5" font-family="Inter,Arial,sans-serif" font-size="36" font-weight="700" text-anchor="middle">SOLFOUNDRY</text>
+<text x="256" y="286" fill="#40C4FF" font-family="JetBrains Mono,monospace" font-size="46" font-weight="700" text-anchor="middle">SOLANA</text>
+<text x="256" y="336" fill="#A0A0B8" font-family="Inter,Arial,sans-serif" font-size="22" text-anchor="middle">BUILD • EARN • OWN</text>
+</svg>

--- a/assets/sticker-pack-832/sticker-09.svg
+++ b/assets/sticker-pack-832/sticker-09.svg
@@ -1,0 +1,8 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+<defs><linearGradient id="g" x1="64" y1="64" x2="448" y2="448"><stop offset="0" stop-color="#00E676"/><stop offset="1" stop-color="#E040FB"/></linearGradient></defs>
+<circle cx="256" cy="256" r="220" fill="#0A0A0F" stroke="url(#g)" stroke-width="16"/>
+<circle cx="256" cy="256" r="172" fill="#111120" stroke="#2E2E42" stroke-width="8"/>
+<text x="256" y="230" fill="#F0F0F5" font-family="Inter,Arial,sans-serif" font-size="36" font-weight="700" text-anchor="middle">SOLFOUNDRY</text>
+<text x="256" y="286" fill="#00E676" font-family="JetBrains Mono,monospace" font-size="46" font-weight="700" text-anchor="middle">FNDRY</text>
+<text x="256" y="336" fill="#A0A0B8" font-family="Inter,Arial,sans-serif" font-size="22" text-anchor="middle">BUILD • EARN • OWN</text>
+</svg>

--- a/assets/sticker-pack-832/sticker-10.svg
+++ b/assets/sticker-pack-832/sticker-10.svg
@@ -1,0 +1,8 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+<defs><linearGradient id="g" x1="64" y1="64" x2="448" y2="448"><stop offset="0" stop-color="#00E676"/><stop offset="1" stop-color="#7C3AED"/></linearGradient></defs>
+<circle cx="256" cy="256" r="220" fill="#0A0A0F" stroke="url(#g)" stroke-width="16"/>
+<circle cx="256" cy="256" r="172" fill="#111120" stroke="#2E2E42" stroke-width="8"/>
+<text x="256" y="230" fill="#F0F0F5" font-family="Inter,Arial,sans-serif" font-size="36" font-weight="700" text-anchor="middle">SOLFOUNDRY</text>
+<text x="256" y="286" fill="#00E676" font-family="JetBrains Mono,monospace" font-size="46" font-weight="700" text-anchor="middle">AGENT</text>
+<text x="256" y="336" fill="#A0A0B8" font-family="Inter,Arial,sans-serif" font-size="22" text-anchor="middle">BUILD • EARN • OWN</text>
+</svg>


### PR DESCRIPTION
## Summary
- add a new 10-design sticker pack under `assets/sticker-pack-832/`
- deliver circular badge-style editable SVG stickers (512x512)
- include README with style and usage notes

## Why
Issue #832 asks for a SolFoundry sticker pack (10 stickers). This PR provides a full branded set in vector format.

## Acceptance mapping
- [x] 10 sticker designs delivered
- [x] Editable source assets included
- [x] Consistent SolFoundry branding

Closes #832

## Wallet
Wallet: 74jSPYaxEJcGEuW4jr6bqQdg2iuLChyLEuEmC8QhcQVW
