### PR TITLE
feat: expand loading skeleton animations across key pages

### DIFF
--- a/frontend/src/components/home/FeaturedBounties.tsx
+++ b/frontend/src/components/home/FeaturedBounties.tsx
@@ -39,7 +39,9 @@ export function FeaturedBounties() {
         {isLoading && (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
             {Array.from({ length: 4 }).map((_, i) => (
-              <div key={i} className="rounded-xl border border-border bg-forge-900 h-48 animate-pulse" />
+              <div key={i} className="rounded-xl border border-border bg-forge-900 p-4 h-56 overflow-hidden">
+                <div className="h-full bg-gradient-to-r from-forge-900 via-forge-800 to-forge-900 bg-[length:200%_100%] animate-shimmer" />
+              </div>
             ))}
           </div>
         )}

--- a/frontend/src/components/profile/ProfileDashboard.tsx
+++ b/frontend/src/components/profile/ProfileDashboard.tsx
@@ -35,7 +35,15 @@ function BountyStatusBadge({ status }: { status: string }) {
 
 function MyBountiesTab({ bounties, loading }: { bounties: Bounty[]; loading: boolean }) {
   if (loading) {
-    return <div className="text-text-muted text-sm py-8 text-center">Loading...</div>;
+    return (
+      <div className="space-y-2">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="h-16 rounded-lg border border-border bg-forge-900 overflow-hidden">
+            <div className="h-full bg-gradient-to-r from-forge-900 via-forge-800 to-forge-900 bg-[length:200%_100%] animate-shimmer" />
+          </div>
+        ))}
+      </div>
+    );
   }
   if (!bounties.length) {
     return (

--- a/frontend/src/pages/LeaderboardPage.tsx
+++ b/frontend/src/pages/LeaderboardPage.tsx
@@ -47,8 +47,17 @@ export function LeaderboardPage() {
 
         {/* Loading */}
         {isLoading && (
-          <div className="flex justify-center py-16">
-            <div className="w-8 h-8 rounded-full border-2 border-emerald border-t-transparent animate-spin" />
+          <div className="space-y-4 py-6">
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <div key={i} className="h-32 rounded-xl border border-border bg-forge-900 overflow-hidden">
+                  <div className="h-full bg-gradient-to-r from-forge-900 via-forge-800 to-forge-900 bg-[length:200%_100%] animate-shimmer" />
+                </div>
+              ))}
+            </div>
+            <div className="h-72 rounded-xl border border-border bg-forge-900 overflow-hidden">
+              <div className="h-full bg-gradient-to-r from-forge-900 via-forge-800 to-forge-900 bg-[length:200%_100%] animate-shimmer" />
+            </div>
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- expand shimmer skeleton coverage to additional loading states
- improve Home `FeaturedBounties` loading cards with structured shimmer placeholders
- add leaderboard page skeleton layout (podium + table placeholders)
- replace profile "Loading..." text with stacked shimmer rows in `MyBountiesTab`

## Why
Issue #827 requests loading skeleton animations across all major data-loading surfaces with smooth transition to real content.

## Acceptance mapping
- [x] Skeletons visible on key pages during loading
- [x] Skeletons match actual content layout patterns
- [x] Uses existing shimmer animation style for consistency

Closes #827

## Validation
- Manual verification by inspecting all touched loading branches/components
- `npm run build` in `frontend` remains blocked by pre-existing missing module paths (`lib/animations`, `lib/utils`) unrelated to this PR

## Wallet
Wallet: 74jSPYaxEJcGEuW4jr6bqQdg2iuLChyLEuEmC8QhcQVW
