### PR TITLE
fix: harden GitHub OAuth sign-in state/callback handling

### DIFF
--- a/frontend/src/components/home/HeroSection.tsx
+++ b/frontend/src/components/home/HeroSection.tsx
@@ -80,6 +80,12 @@ export function HeroSection() {
   const handleSignIn = async () => {
     try {
       const url = await getGitHubAuthorizeUrl();
+      try {
+        const state = new URL(url).searchParams.get('state');
+        if (state) sessionStorage.setItem('sf_oauth_state', state);
+      } catch {
+        // ignore parse errors
+      }
       window.location.href = url;
     } catch {
       window.location.href = '/api/auth/github/authorize';

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -36,6 +36,12 @@ export function Navbar() {
   const handleGitHubSignIn = async () => {
     try {
       const url = await getGitHubAuthorizeUrl();
+      try {
+        const state = new URL(url).searchParams.get('state');
+        if (state) sessionStorage.setItem('sf_oauth_state', state);
+      } catch {
+        // ignore parse errors
+      }
       window.location.href = url;
     } catch {
       // Fallback: direct to backend authorize endpoint

--- a/frontend/src/pages/GitHubCallbackPage.tsx
+++ b/frontend/src/pages/GitHubCallbackPage.tsx
@@ -19,8 +19,15 @@ export function GitHubCallbackPage() {
     const code = searchParams.get('code');
     const state = searchParams.get('state');
     const error = searchParams.get('error');
+    const expectedState = sessionStorage.getItem('sf_oauth_state');
 
     if (error || !code) {
+      navigate('/', { replace: true });
+      return;
+    }
+
+    if (expectedState && state && expectedState !== state) {
+      sessionStorage.removeItem('sf_oauth_state');
       navigate('/', { replace: true });
       return;
     }
@@ -29,15 +36,13 @@ export function GitHubCallbackPage() {
       .then((response) => {
         // Store tokens + user in auth context
         const authUser = { ...response.user, wallet_verified: false };
-        login(response.access_token, response.refresh_token ?? '', authUser);
+        login(response.access_token, response.refresh_token, authUser);
         setAuthToken(response.access_token);
-        // Store refresh token for future use
-        if (response.refresh_token) {
-          localStorage.setItem('sf_refresh_token', response.refresh_token);
-        }
+        sessionStorage.removeItem('sf_oauth_state');
         navigate('/', { replace: true });
       })
       .catch(() => {
+        sessionStorage.removeItem('sf_oauth_state');
         navigate('/', { replace: true });
       });
   }, []);


### PR DESCRIPTION
## Summary
- persist OAuth state from GitHub authorize URL before redirect
- validate callback `state` against stored expected value
- clear stored OAuth state after success/failure paths
- keep token storage flow consistent in callback login path

## Why
Issue #821 requires robust GitHub OAuth sign-in flow. This patch strengthens CSRF/state integrity and callback handling for reliable end-to-end sign-in.

## Acceptance mapping
- [x] Sign-in redirects through GitHub authorize with tracked state
- [x] Callback validates state and avoids invalid-session continuation
- [x] Successful callback logs in user and stores tokens/session

Closes #821

## Wallet
Wallet: 74jSPYaxEJcGEuW4jr6bqQdg2iuLChyLEuEmC8QhcQVW
