### PR TITLE
feat: add live bounty countdown component with urgency states

### DIFF
--- a/frontend/src/components/bounty/BountyCard.tsx
+++ b/frontend/src/components/bounty/BountyCard.tsx
@@ -4,7 +4,8 @@ import { motion } from 'framer-motion';
 import { GitPullRequest, Clock } from 'lucide-react';
 import type { Bounty } from '../../types/bounty';
 import { cardHover } from '../../lib/animations';
-import { timeLeft, formatCurrency, LANG_COLORS } from '../../lib/utils';
+import { formatCurrency, LANG_COLORS } from '../../lib/utils';
+import { BountyCountdown } from './BountyCountdown';
 
 function TierBadge({ tier }: { tier: string }) {
   const styles: Record<string, string> = {
@@ -113,7 +114,7 @@ export function BountyCard({ bounty }: BountyCardProps) {
           {bounty.deadline && (
             <span className="inline-flex items-center gap-1">
               <Clock className="w-3.5 h-3.5" />
-              {timeLeft(bounty.deadline)}
+              <BountyCountdown deadline={bounty.deadline} />
             </span>
           )}
         </div>

--- a/frontend/src/components/bounty/BountyCountdown.tsx
+++ b/frontend/src/components/bounty/BountyCountdown.tsx
@@ -1,0 +1,41 @@
+import React, { useEffect, useMemo, useState } from 'react';
+
+function formatRemaining(target: number): { text: string; urgent: boolean; warning: boolean; expired: boolean } {
+  const now = Date.now();
+  const diff = target - now;
+  if (diff <= 0) return { text: 'Expired', urgent: false, warning: false, expired: true };
+
+  const totalMin = Math.floor(diff / 60000);
+  const days = Math.floor(totalMin / 1440);
+  const hours = Math.floor((totalMin % 1440) / 60);
+  const mins = totalMin % 60;
+
+  if (days > 0) return { text: `${days}d ${hours}h ${mins}m`, urgent: false, warning: false, expired: false };
+  return {
+    text: `${hours}h ${mins}m`,
+    urgent: diff < 60 * 60 * 1000,
+    warning: diff < 24 * 60 * 60 * 1000,
+    expired: false,
+  };
+}
+
+export function BountyCountdown({ deadline, className = '' }: { deadline: string; className?: string }) {
+  const target = useMemo(() => new Date(deadline).getTime(), [deadline]);
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    const timer = window.setInterval(() => setTick((v) => v + 1), 30000);
+    return () => window.clearInterval(timer);
+  }, []);
+
+  const remaining = formatRemaining(target + tick * 0);
+  const tone = remaining.expired
+    ? 'text-status-error'
+    : remaining.urgent
+      ? 'text-status-error'
+      : remaining.warning
+        ? 'text-status-warning'
+        : 'text-text-muted';
+
+  return <span className={`${tone} ${className}`}>{remaining.text}</span>;
+}

--- a/frontend/src/components/bounty/BountyDetail.tsx
+++ b/frontend/src/components/bounty/BountyDetail.tsx
@@ -3,9 +3,10 @@ import { Link, useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { ArrowLeft, Clock, GitPullRequest, ExternalLink, Loader2, Check, Copy } from 'lucide-react';
 import type { Bounty } from '../../types/bounty';
-import { timeLeft, timeAgo, formatCurrency, LANG_COLORS } from '../../lib/utils';
+import { timeAgo, formatCurrency, LANG_COLORS } from '../../lib/utils';
 import { useAuth } from '../../hooks/useAuth';
 import { SubmissionForm } from './SubmissionForm';
+import { BountyCountdown } from './BountyCountdown';
 import { fadeIn } from '../../lib/animations';
 
 interface BountyDetailProps {
@@ -139,7 +140,7 @@ export function BountyDetail({ bounty }: BountyDetailProps) {
               <div className="flex items-center justify-between text-sm">
                 <span className="text-text-muted">Deadline</span>
                 <span className="font-mono text-status-warning inline-flex items-center gap-1">
-                  <Clock className="w-3.5 h-3.5" /> {timeLeft(bounty.deadline)}
+                  <Clock className="w-3.5 h-3.5" /> <BountyCountdown deadline={bounty.deadline} />
                 </span>
               </div>
             )}


### PR DESCRIPTION
## Summary
- add reusable `BountyCountdown` component for live deadline display
- update countdown every 30 seconds without page refresh
- show urgency states:
  - `< 24h`: warning tone
  - `< 1h`: urgent/error tone
  - expired: `Expired`
- wire countdown into bounty card and bounty detail sidebar

## Why
Issue #826 requests a countdown component with real-time updates and urgency handling for bounty deadlines.

## Acceptance mapping
- [x] Shows remaining time clearly
- [x] Updates in real-time without refresh
- [x] Color/tone changes for warning/urgent windows
- [x] Shows `Expired` after deadline
- [x] Displays on both card and detail views

Closes #826

## Wallet
Wallet: 74jSPYaxEJcGEuW4jr6bqQdg2iuLChyLEuEmC8QhcQVW
