### PR TITLE
feat: wire activity feed API with empty state and auto-refresh

### DIFF
--- a/frontend/src/api/activity.ts
+++ b/frontend/src/api/activity.ts
@@ -1,0 +1,43 @@
+import { apiClient } from '../services/apiClient';
+
+export interface ActivityEvent {
+  id: string;
+  type: 'completed' | 'submitted' | 'posted' | 'review';
+  username: string;
+  avatar_url?: string | null;
+  detail: string;
+  timestamp: string;
+}
+
+type RawActivity = Record<string, unknown>;
+
+function mapType(raw: string): ActivityEvent['type'] {
+  const value = raw.toLowerCase();
+  if (value.includes('complete') || value.includes('payout')) return 'completed';
+  if (value.includes('submit') || value.includes('pr')) return 'submitted';
+  if (value.includes('review')) return 'review';
+  return 'posted';
+}
+
+function mapItem(item: RawActivity, index: number): ActivityEvent {
+  const actor = (item.username ?? item.user ?? item.actor ?? item.author ?? 'Unknown') as string;
+  const detail = (item.detail ?? item.message ?? item.description ?? item.title ?? 'Activity update') as string;
+  const typeRaw = (item.type ?? item.event_type ?? item.kind ?? 'posted') as string;
+  const timestamp = (item.timestamp ?? item.created_at ?? item.time ?? new Date().toISOString()) as string;
+  const id = String(item.id ?? item.event_id ?? `${typeRaw}-${actor}-${index}-${timestamp}`);
+
+  return {
+    id,
+    type: mapType(typeRaw),
+    username: String(actor),
+    avatar_url: (item.avatar_url ?? item.avatar ?? null) as string | null,
+    detail: String(detail),
+    timestamp: String(timestamp),
+  };
+}
+
+export async function listActivity(): Promise<ActivityEvent[]> {
+  const response = await apiClient<RawActivity[] | { items?: RawActivity[]; events?: RawActivity[] }>('/api/activity');
+  const rows = Array.isArray(response) ? response : (response.items ?? response.events ?? []);
+  return rows.map((item, i) => mapItem(item, i));
+}

--- a/frontend/src/components/home/ActivityFeed.tsx
+++ b/frontend/src/components/home/ActivityFeed.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { slideInRight } from '../../lib/animations';
 import { timeAgo } from '../../lib/utils';
+import { useActivity } from '../../hooks/useActivity';
 
 interface ActivityEvent {
   id: string;
@@ -76,12 +77,15 @@ function EventItem({ event }: { event: ActivityEvent }) {
 }
 
 export function ActivityFeed({ events }: { events?: ActivityEvent[] }) {
-  const displayEvents = events?.length ? events.slice(0, 4) : MOCK_EVENTS;
+  const { data: apiEvents, isError } = useActivity();
+  const displayEvents = events?.length
+    ? events.slice(0, 4)
+    : (apiEvents?.length ? apiEvents.slice(0, 4) : (isError ? MOCK_EVENTS : []));
   const [visibleEvents, setVisibleEvents] = useState<ActivityEvent[]>(displayEvents.slice(0, 4));
 
   useEffect(() => {
     setVisibleEvents(displayEvents.slice(0, 4));
-  }, [events]);
+  }, [events, apiEvents, isError]);
 
   return (
     <section className="w-full border-y border-border bg-forge-900/50 py-4 overflow-hidden">
@@ -90,22 +94,26 @@ export function ActivityFeed({ events }: { events?: ActivityEvent[] }) {
           <span className="w-2 h-2 rounded-full bg-emerald animate-pulse-glow" />
           <span className="font-mono text-xs text-text-muted uppercase tracking-wider">Recent Activity</span>
         </div>
-        <div className="space-y-1">
-          <AnimatePresence mode="popLayout">
-            {visibleEvents.map((event) => (
-              <motion.div
-                key={event.id}
-                variants={slideInRight}
-                initial="initial"
-                animate="animate"
-                exit={{ opacity: 0, x: -20, transition: { duration: 0.2 } }}
-                layout
-              >
-                <EventItem event={event} />
-              </motion.div>
-            ))}
-          </AnimatePresence>
-        </div>
+        {visibleEvents.length === 0 ? (
+          <p className="px-3 py-2 text-sm text-text-muted">No recent activity</p>
+        ) : (
+          <div className="space-y-1">
+            <AnimatePresence mode="popLayout">
+              {visibleEvents.map((event) => (
+                <motion.div
+                  key={event.id}
+                  variants={slideInRight}
+                  initial="initial"
+                  animate="animate"
+                  exit={{ opacity: 0, x: -20, transition: { duration: 0.2 } }}
+                  layout
+                >
+                  <EventItem event={event} />
+                </motion.div>
+              ))}
+            </AnimatePresence>
+          </div>
+        )}
       </div>
     </section>
   );

--- a/frontend/src/hooks/useActivity.ts
+++ b/frontend/src/hooks/useActivity.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { listActivity } from '../api/activity';
+
+export function useActivity() {
+  return useQuery({
+    queryKey: ['activity-feed'],
+    queryFn: listActivity,
+    staleTime: 20_000,
+    refetchInterval: 30_000,
+  });
+}


### PR DESCRIPTION
## Summary
- wire homepage activity feed to real API data (`/api/activity`)
- add resilient mapper for multiple backend response shapes
- refresh events automatically every 30 seconds
- show explicit `No recent activity` empty state
- keep graceful mock fallback when API is unavailable

## Why
Issue #822 requires real activity feed integration with auto-refresh and robust fallback behavior.

## Acceptance mapping
- [x] Activity feed shows real events from API
- [x] Events update without page refresh
- [x] Shows "No recent activity" when empty
- [x] Graceful fallback when API is unavailable

Closes #822

## Wallet
Wallet: 74jSPYaxEJcGEuW4jr6bqQdg2iuLChyLEuEmC8QhcQVW
