### PR TITLE
feat: add toast notifications to submission flow

### DIFF
--- a/frontend/src/components/bounty/SubmissionForm.tsx
+++ b/frontend/src/components/bounty/SubmissionForm.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Loader2, Check, Copy } from 'lucide-react';
 import type { Bounty } from '../../types/bounty';
 import { createSubmission, getReviewFee, verifyReviewFee } from '../../api/bounties';
+import { useToast } from '../../contexts/ToastContext';
 
 interface SubmissionFormProps {
   bounty: Bounty;
@@ -9,6 +10,7 @@ interface SubmissionFormProps {
 }
 
 export function SubmissionForm({ bounty, onSuccess }: SubmissionFormProps) {
+  const { pushToast } = useToast();
   const hasRepo = bounty.has_repo ?? !!bounty.github_repo_url;
   const [url, setUrl] = useState('');
   const [description, setDescription] = useState('');
@@ -38,11 +40,15 @@ export function SubmissionForm({ bounty, onSuccess }: SubmissionFormProps) {
       const result = await verifyReviewFee({ bounty_id: bounty.id, tx_signature: txSig });
       if (result.verified) {
         setFeeVerified(true);
+        pushToast({ title: 'Fee verified', message: 'FNDRY review fee confirmed.', variant: 'success' });
       } else {
-        setError(result.error ?? 'Fee verification failed. Check your transaction signature.');
+        const msg = result.error ?? 'Fee verification failed. Check your transaction signature.';
+        setError(msg);
+        pushToast({ title: 'Verification failed', message: msg, variant: 'error' });
       }
     } catch {
       setError('Fee verification failed. Try again.');
+      pushToast({ title: 'Verification failed', message: 'Please try again shortly.', variant: 'error' });
     } finally {
       setVerifying(false);
     }
@@ -61,9 +67,12 @@ export function SubmissionForm({ bounty, onSuccess }: SubmissionFormProps) {
         tx_signature: txSig,
       });
       setSuccess(true);
+      pushToast({ title: 'Submission received', message: 'AI review will start shortly.', variant: 'success' });
       onSuccess?.();
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : 'Submission failed. Try again.');
+      const msg = e instanceof Error ? e.message : 'Submission failed. Try again.';
+      setError(msg);
+      pushToast({ title: 'Submission failed', message: msg, variant: 'error' });
     } finally {
       setSubmitting(false);
     }
@@ -72,6 +81,7 @@ export function SubmissionForm({ bounty, onSuccess }: SubmissionFormProps) {
   const copyTreasury = () => {
     navigator.clipboard.writeText(TREASURY).then(() => {
       setCopied(true);
+      pushToast({ title: 'Address copied', message: 'Treasury address copied to clipboard.', variant: 'success' });
       setTimeout(() => setCopied(false), 2000);
     });
   };

--- a/frontend/src/contexts/ToastContext.tsx
+++ b/frontend/src/contexts/ToastContext.tsx
@@ -1,0 +1,93 @@
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { CheckCircle2, AlertCircle, AlertTriangle, Info, X } from 'lucide-react';
+
+type ToastVariant = 'success' | 'error' | 'warning' | 'info';
+
+interface ToastItem {
+  id: string;
+  title: string;
+  message?: string;
+  variant: ToastVariant;
+}
+
+interface ToastInput {
+  title: string;
+  message?: string;
+  variant?: ToastVariant;
+}
+
+interface ToastContextValue {
+  pushToast: (toast: ToastInput) => void;
+  removeToast: (id: string) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+const variantStyles: Record<ToastVariant, string> = {
+  success: 'border-emerald/40 bg-emerald-bg text-emerald',
+  error: 'border-status-error/40 bg-status-error/10 text-status-error',
+  warning: 'border-status-warning/40 bg-status-warning/10 text-status-warning',
+  info: 'border-status-info/40 bg-status-info/10 text-status-info',
+};
+
+const variantIcon: Record<ToastVariant, React.ReactNode> = {
+  success: <CheckCircle2 className="w-4 h-4" />,
+  error: <AlertCircle className="w-4 h-4" />,
+  warning: <AlertTriangle className="w-4 h-4" />,
+  info: <Info className="w-4 h-4" />,
+};
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+
+  const removeToast = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const pushToast = useCallback((toast: ToastInput) => {
+    const id = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    setToasts((prev) => [...prev, { id, title: toast.title, message: toast.message, variant: toast.variant ?? 'info' }]);
+    window.setTimeout(() => removeToast(id), 5000);
+  }, [removeToast]);
+
+  const value = useMemo(() => ({ pushToast, removeToast }), [pushToast, removeToast]);
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <div className="fixed top-4 right-4 z-[100] flex w-[min(92vw,360px)] flex-col gap-2">
+        <AnimatePresence>
+          {toasts.map((toast) => (
+            <motion.div
+              key={toast.id}
+              role="alert"
+              initial={{ opacity: 0, x: 32, y: -8 }}
+              animate={{ opacity: 1, x: 0, y: 0 }}
+              exit={{ opacity: 0, x: 32 }}
+              transition={{ duration: 0.18 }}
+              className={`rounded-lg border px-3 py-2.5 shadow-lg backdrop-blur-sm ${variantStyles[toast.variant]}`}
+            >
+              <div className="flex items-start gap-2">
+                <span className="mt-0.5">{variantIcon[toast.variant]}</span>
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm font-semibold leading-tight">{toast.title}</p>
+                  {toast.message && <p className="mt-1 text-xs text-text-secondary">{toast.message}</p>}
+                </div>
+                <button onClick={() => removeToast(toast.id)} className="text-text-muted hover:text-text-primary transition-colors" aria-label="Close notification">
+                  <X className="w-4 h-4" />
+                </button>
+              </div>
+            </motion.div>
+          ))}
+        </AnimatePresence>
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error('useToast must be used within ToastProvider');
+  return ctx;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { AuthProvider } from './contexts/AuthContext';
 import { queryClient } from './services/queryClient';
+import { ToastProvider } from './contexts/ToastContext';
 import App from './App';
 import './index.css';
 
@@ -15,7 +16,9 @@ createRoot(root).render(
     <BrowserRouter>
       <QueryClientProvider client={queryClient}>
         <AuthProvider>
-          <App />
+          <ToastProvider>
+            <App />
+          </ToastProvider>
         </AuthProvider>
       </QueryClientProvider>
     </BrowserRouter>


### PR DESCRIPTION
## Summary
- add global toast notification provider and UI container
- support success/error/warning/info toast variants with auto-dismiss and manual close
- wire to bounty submission flow events:
  - review fee verify success/failure
  - submission success/failure
  - treasury address copy success
- keep `role="alert"` accessibility semantics

## Why
Issue #825 asks for toast notifications on key status/error/success actions. This extends coverage into the submission path.

## Acceptance mapping
- [x] Toast notifications appear for key actions
- [x] Auto-dismiss with manual close option
- [x] Multiple toasts stack properly
- [x] Slide-in top-right style
- [x] Accessibility via `role="alert"`

Closes #825

## Wallet
Wallet: 74jSPYaxEJcGEuW4jr6bqQdg2iuLChyLEuEmC8QhcQVW
