### PR TITLE
fix: remove duplicated top padding on bounties page

### DIFF
--- a/frontend/src/pages/BountiesPage.tsx
+++ b/frontend/src/pages/BountiesPage.tsx
@@ -12,7 +12,6 @@ export function BountiesPage() {
         initial="initial"
         animate="animate"
         exit="exit"
-        className="pt-16"
       >
         <BountyGrid />
       </motion.div>


### PR DESCRIPTION
## Summary
- remove duplicate top spacing on `/bounties` page by dropping extra `pt-16` wrapper padding
- keep navbar offset only in shared `PageLayout` to avoid oversized top gap on mobile

## Why
Issue #833 (mobile responsive polish) — bounties page had stacked top padding on small screens, wasting above-the-fold space.

## Acceptance mapping
- [x] Mobile vertical spacing improved
- [x] Layout no longer has duplicated navbar offset on `/bounties`

Closes #833

## Wallet
Wallet: 74jSPYaxEJcGEuW4jr6bqQdg2iuLChyLEuEmC8QhcQVW
