### PR TITLE
fix: polish mobile nav menu behavior and scroll lock

### DIFF
--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -33,6 +33,20 @@ export function Navbar() {
     return () => window.removeEventListener('scroll', onScroll);
   }, []);
 
+  useEffect(() => {
+    setMenuOpen(false);
+    setDropdownOpen(false);
+  }, [location.pathname]);
+
+  useEffect(() => {
+    const prev = document.body.style.overflow;
+    if (menuOpen) document.body.style.overflow = 'hidden';
+    else document.body.style.overflow = '';
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [menuOpen]);
+
   const handleGitHubSignIn = async () => {
     try {
       const url = await getGitHubAuthorizeUrl();
@@ -168,6 +182,7 @@ export function Navbar() {
           {/* Mobile hamburger */}
           <button
             onClick={() => setMenuOpen(!menuOpen)}
+            aria-label={menuOpen ? 'Close menu' : 'Open menu'}
             className="md:hidden p-2 rounded-lg hover:bg-forge-800 transition-colors text-text-secondary"
           >
             {menuOpen ? <X className="w-5 h-5" /> : <Menu className="w-5 h-5" />}


### PR DESCRIPTION
## Summary
- improve mobile navigation UX by preventing background scroll when menu is open
- auto-close mobile menu and user dropdown on route changes
- add hamburger `aria-label` for better accessibility

## Why
Issue #824 (mobile responsive polish): mobile navigation felt rough during menu interactions and could leave overlays open after navigation.

## Acceptance mapping
- [x] Mobile nav interaction polish
- [x] Better overlay/menu state handling on route transitions
- [x] Accessibility label added for menu toggle

Closes #824

## Wallet
Wallet: 74jSPYaxEJcGEuW4jr6bqQdg2iuLChyLEuEmC8QhcQVW
