### PR TITLE
fix: improve github oauth callback error recovery

### DIFF
--- a/frontend/src/pages/GitHubCallbackPage.tsx
+++ b/frontend/src/pages/GitHubCallbackPage.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { motion } from 'framer-motion';
+import { AlertCircle } from 'lucide-react';
 import { useAuth } from '../hooks/useAuth';
 import { exchangeGitHubCode } from '../api/auth';
 import { setAuthToken } from '../services/apiClient';
@@ -11,6 +12,7 @@ export function GitHubCallbackPage() {
   const navigate = useNavigate();
   const { login } = useAuth();
   const didRun = useRef(false);
+  const [authError, setAuthError] = React.useState<string | null>(null);
 
   useEffect(() => {
     if (didRun.current) return;
@@ -21,7 +23,7 @@ export function GitHubCallbackPage() {
     const error = searchParams.get('error');
 
     if (error || !code) {
-      navigate('/', { replace: true });
+      setAuthError('GitHub sign-in was cancelled or invalid. Please try again.');
       return;
     }
 
@@ -38,9 +40,42 @@ export function GitHubCallbackPage() {
         navigate('/', { replace: true });
       })
       .catch(() => {
-        navigate('/', { replace: true });
+        setAuthError('GitHub sign-in failed during callback exchange. Please retry.');
       });
   }, []);
+
+  if (authError) {
+    return (
+      <div className="min-h-screen bg-forge-950 flex items-center justify-center px-4">
+        <motion.div
+          variants={fadeIn}
+          initial="initial"
+          animate="animate"
+          className="max-w-md w-full rounded-xl border border-status-error/30 bg-forge-900 p-6 text-center"
+        >
+          <div className="mx-auto mb-4 flex h-11 w-11 items-center justify-center rounded-full bg-status-error/15 text-status-error">
+            <AlertCircle className="h-5 w-5" />
+          </div>
+          <h1 className="text-lg font-semibold text-text-primary mb-2">Sign-in failed</h1>
+          <p className="text-sm text-text-secondary mb-5">{authError}</p>
+          <div className="flex items-center justify-center gap-2">
+            <button
+              onClick={() => navigate('/', { replace: true })}
+              className="px-4 py-2 rounded-lg border border-border text-text-secondary hover:text-text-primary hover:border-border-hover transition-colors"
+            >
+              Back Home
+            </button>
+            <a
+              href="/api/auth/github/authorize"
+              className="px-4 py-2 rounded-lg bg-emerald text-text-inverse font-medium hover:bg-emerald-light transition-colors"
+            >
+              Try Again
+            </a>
+          </div>
+        </motion.div>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-forge-950 flex items-center justify-center">


### PR DESCRIPTION
## Summary
- improve `/auth/github/callback` failure behavior instead of silent redirect
- show clear error card when callback is invalid/cancelled or code exchange fails
- add explicit `Back Home` and `Try Again` actions to reduce auth dead-ends

## Why
Issue #821 asks to harden GitHub OAuth sign-in flow. This patch improves callback resilience and user recovery path when OAuth fails.

## Acceptance mapping
- [x] Callback no longer fails silently
- [x] User gets actionable retry path
- [x] Better UX for OAuth cancellation/error cases

Closes #821

## Wallet
Wallet: 74jSPYaxEJcGEuW4jr6bqQdg2iuLChyLEuEmC8QhcQVW
