### PR TITLE
feat(profile): contributor stats dashboard (#836)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,11 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
 lib64/
+# (intentionally not ignoring `lib/` repo-wide — that catches frontend/src/lib too;
+# limit the Python ignore to the venv-style directories that actually contain it)
+**/venv/lib/
+**/.venv/lib/
 parts/
 sdist/
 var/

--- a/frontend/src/__tests__/github-activity.test.ts
+++ b/frontend/src/__tests__/github-activity.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { fetchGitHubActivity } from '../api/github';
+
+const FIXED_NOW = new Date('2026-05-12T12:00:00.000Z');
+
+function eventOnDay(offsetDays: number, type: string, commitCount?: number) {
+  const d = new Date(FIXED_NOW);
+  d.setUTCDate(d.getUTCDate() - offsetDays);
+  return {
+    id: `${type}-${offsetDays}`,
+    type,
+    created_at: d.toISOString(),
+    payload: commitCount ? { commits: Array.from({ length: commitCount }, (_, i) => ({ sha: `sha${i}` })) } : {},
+  };
+}
+
+describe('fetchGitHubActivity', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('returns an empty series when username is empty', async () => {
+    const result = await fetchGitHubActivity('');
+    expect(result.counts.total).toBe(0);
+    expect(result.daily).toHaveLength(90);
+    expect(result.currentStreak).toBe(0);
+  });
+
+  it('aggregates events by type and weighs PushEvents by commit count', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => [
+        eventOnDay(0, 'PushEvent', 3),
+        eventOnDay(0, 'PullRequestEvent'),
+        eventOnDay(1, 'IssuesEvent'),
+        eventOnDay(2, 'PullRequestReviewEvent'),
+        eventOnDay(2, 'WatchEvent'), // ignored
+      ],
+    }).mockResolvedValue({ ok: true, json: async () => [] });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await fetchGitHubActivity('alice', 30);
+
+    expect(result.counts.commits).toBe(3);
+    expect(result.counts.pullRequests).toBe(1);
+    expect(result.counts.issues).toBe(1);
+    expect(result.counts.reviews).toBe(1);
+    expect(result.counts.total).toBe(6);
+    expect(result.daily).toHaveLength(30);
+    expect(result.daily.at(-1)?.count).toBe(4); // today: 3 commits + 1 PR
+    expect(result.daily.at(-2)?.count).toBe(1); // yesterday: 1 issue
+  });
+
+  it('computes current and longest streaks from consecutive active days', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => [
+        eventOnDay(0, 'PushEvent', 1),
+        eventOnDay(1, 'PushEvent', 1),
+        eventOnDay(2, 'PushEvent', 1),
+        // gap on day 3
+        eventOnDay(4, 'PushEvent', 1),
+        eventOnDay(5, 'PushEvent', 1),
+      ],
+    }).mockResolvedValue({ ok: true, json: async () => [] });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await fetchGitHubActivity('bob', 14);
+    expect(result.currentStreak).toBe(3);
+    expect(result.longestStreak).toBe(3);
+  });
+
+  it('returns zeros when the GitHub API returns a non-OK response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 404, json: async () => [] }));
+    const result = await fetchGitHubActivity('ghost', 14);
+    expect(result.counts.total).toBe(0);
+    expect(result.daily).toHaveLength(14);
+  });
+});

--- a/frontend/src/__tests__/utils.test.ts
+++ b/frontend/src/__tests__/utils.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { formatCurrency, formatCompactNumber, timeAgo } from '../lib/utils';
+
+describe('formatCompactNumber', () => {
+  it('returns short form for thousands', () => {
+    expect(formatCompactNumber(1_000)).toBe('1K');
+    expect(formatCompactNumber(2_500)).toBe('2.5K');
+  });
+  it('returns short form for millions', () => {
+    expect(formatCompactNumber(1_000_000)).toBe('1M');
+    expect(formatCompactNumber(1_200_000)).toBe('1.2M');
+  });
+  it('returns plain number under 1000', () => {
+    expect(formatCompactNumber(123)).toBe('123');
+  });
+});
+
+describe('formatCurrency', () => {
+  it('formats USDC as dollars', () => {
+    expect(formatCurrency(250, 'USDC')).toBe('$250');
+  });
+  it('formats FNDRY with compact suffix', () => {
+    expect(formatCurrency(100_000, 'FNDRY')).toBe('100K FNDRY');
+  });
+});
+
+describe('timeAgo', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-12T12:00:00.000Z'));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+  it('returns "just now" for very recent timestamps', () => {
+    expect(timeAgo('2026-05-12T11:59:30.000Z')).toBe('just now');
+  });
+  it('returns minutes for the last hour', () => {
+    expect(timeAgo('2026-05-12T11:45:00.000Z')).toBe('15m ago');
+  });
+  it('returns empty string for null/invalid', () => {
+    expect(timeAgo(null)).toBe('');
+    expect(timeAgo('not-a-date')).toBe('');
+  });
+});

--- a/frontend/src/api/bounties.ts
+++ b/frontend/src/api/bounties.ts
@@ -58,6 +58,25 @@ export async function listSubmissions(bountyId: string): Promise<Submission[]> {
   return apiClient<Submission[]>(`/api/bounties/${bountyId}/submissions`);
 }
 
+/**
+ * List the current authenticated user's submissions. Returns an empty array
+ * if the backend does not yet expose this endpoint, so callers can render a
+ * "no submissions yet" state instead of an error toast.
+ */
+export async function listMySubmissions(): Promise<Submission[]> {
+  try {
+    const response = await apiClient<Submission[] | { items: Submission[] }>(
+      '/api/users/me/submissions',
+    );
+    if (Array.isArray(response)) return response;
+    return response.items ?? [];
+  } catch (err) {
+    const status = (err as { status?: number } | null)?.status;
+    if (status === 404 || status === 501) return [];
+    throw err;
+  }
+}
+
 export async function createSubmission(
   bountyId: string,
   payload: { repo_url?: string; pr_url?: string; description?: string; tx_signature?: string }

--- a/frontend/src/api/github.ts
+++ b/frontend/src/api/github.ts
@@ -1,0 +1,165 @@
+/**
+ * GitHub public-API client used for contributor activity widgets.
+ *
+ * Uses the unauthenticated REST endpoints — the public `events` feed gives the
+ * last ~90 days of a user's activity, which is enough to derive a daily
+ * activity heatmap, current/longest streaks, and per-type counts (commits,
+ * pull requests, issues).
+ */
+
+const GITHUB_API = 'https://api.github.com';
+
+interface GitHubEvent {
+  id: string;
+  type: string;
+  created_at: string;
+  payload?: {
+    commits?: Array<{ sha: string }>;
+    action?: string;
+  };
+}
+
+export interface ActivityCounts {
+  commits: number;
+  pullRequests: number;
+  issues: number;
+  reviews: number;
+  total: number;
+}
+
+export interface DailyActivity {
+  date: string;
+  count: number;
+}
+
+export interface GitHubActivity {
+  username: string;
+  counts: ActivityCounts;
+  daily: DailyActivity[];
+  currentStreak: number;
+  longestStreak: number;
+  rangeDays: number;
+}
+
+const DEFAULT_RANGE_DAYS = 90;
+
+function isoDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+function emptyDailySeries(rangeDays: number): DailyActivity[] {
+  const out: DailyActivity[] = [];
+  const today = new Date();
+  today.setUTCHours(0, 0, 0, 0);
+  for (let i = rangeDays - 1; i >= 0; i--) {
+    const d = new Date(today);
+    d.setUTCDate(today.getUTCDate() - i);
+    out.push({ date: isoDate(d), count: 0 });
+  }
+  return out;
+}
+
+function classifyEvent(ev: GitHubEvent): keyof ActivityCounts | null {
+  switch (ev.type) {
+    case 'PushEvent':
+      return 'commits';
+    case 'PullRequestEvent':
+      return 'pullRequests';
+    case 'IssuesEvent':
+      return 'issues';
+    case 'PullRequestReviewEvent':
+    case 'PullRequestReviewCommentEvent':
+      return 'reviews';
+    default:
+      return null;
+  }
+}
+
+function eventWeight(ev: GitHubEvent): number {
+  if (ev.type === 'PushEvent' && ev.payload?.commits) {
+    return ev.payload.commits.length || 1;
+  }
+  return 1;
+}
+
+function computeStreaks(daily: DailyActivity[]): { current: number; longest: number } {
+  let longest = 0;
+  let run = 0;
+  for (const d of daily) {
+    if (d.count > 0) {
+      run += 1;
+      if (run > longest) longest = run;
+    } else {
+      run = 0;
+    }
+  }
+  // Current streak counts back from the most recent day.
+  let current = 0;
+  for (let i = daily.length - 1; i >= 0; i--) {
+    if (daily[i].count > 0) current += 1;
+    else break;
+  }
+  return { current, longest };
+}
+
+export async function fetchGitHubActivity(
+  username: string,
+  rangeDays: number = DEFAULT_RANGE_DAYS,
+): Promise<GitHubActivity> {
+  if (!username) {
+    return {
+      username,
+      counts: { commits: 0, pullRequests: 0, issues: 0, reviews: 0, total: 0 },
+      daily: emptyDailySeries(rangeDays),
+      currentStreak: 0,
+      longestStreak: 0,
+      rangeDays,
+    };
+  }
+
+  // The public events feed paginates at 30 per page, up to 3 pages.
+  const pages = await Promise.all(
+    [1, 2, 3].map(async (page) => {
+      const res = await fetch(
+        `${GITHUB_API}/users/${encodeURIComponent(username)}/events/public?per_page=100&page=${page}`,
+        { headers: { Accept: 'application/vnd.github+json' } },
+      );
+      if (!res.ok) return [] as GitHubEvent[];
+      return (await res.json()) as GitHubEvent[];
+    }),
+  );
+
+  const events = pages.flat();
+  const daily = emptyDailySeries(rangeDays);
+  const dayIndex = new Map(daily.map((d, i) => [d.date, i]));
+  const counts: ActivityCounts = {
+    commits: 0,
+    pullRequests: 0,
+    issues: 0,
+    reviews: 0,
+    total: 0,
+  };
+
+  for (const ev of events) {
+    const day = ev.created_at?.slice(0, 10);
+    if (!day) continue;
+    const idx = dayIndex.get(day);
+    const bucket = classifyEvent(ev);
+    if (bucket == null) continue;
+    const weight = eventWeight(ev);
+    counts[bucket] += weight;
+    counts.total += weight;
+    if (idx != null) daily[idx].count += weight;
+  }
+
+  const { current, longest } = computeStreaks(daily);
+
+  return {
+    username,
+    counts,
+    daily,
+    currentStreak: current,
+    longestStreak: longest,
+    rangeDays,
+  };
+}

--- a/frontend/src/components/profile/ContributorStatsPanel.tsx
+++ b/frontend/src/components/profile/ContributorStatsPanel.tsx
@@ -1,0 +1,67 @@
+import React, { useMemo } from 'react';
+import { motion } from 'framer-motion';
+import type { Bounty, Submission } from '../../types/bounty';
+import { fadeIn } from '../../lib/animations';
+import { useGitHubActivity } from '../../hooks/useGitHubActivity';
+import { GitHubActivityGraph } from './GitHubActivityGraph';
+import { EarningsHistoryChart } from './EarningsHistoryChart';
+import { StatsRow, type ContributorStats } from './StatsRow';
+
+interface Props {
+  username: string | null | undefined;
+  /** Submissions the contributor has made (any status). */
+  submissions: Submission[];
+  /** Bounties the contributor is associated with (creator or submitter). */
+  bounties: Bounty[];
+}
+
+function buildBountyIndex(bounties: Bounty[]): Map<string, Bounty> {
+  const m = new Map<string, Bounty>();
+  for (const b of bounties) m.set(b.id, b);
+  return m;
+}
+
+export function ContributorStatsPanel({ username, submissions, bounties }: Props) {
+  const { data: activity, isLoading: activityLoading } = useGitHubActivity(username, 90);
+
+  const bountiesById = useMemo(() => buildBountyIndex(bounties), [bounties]);
+
+  const paidSubmissions = useMemo(
+    () => submissions.filter((s) => s.status === 'approved'),
+    [submissions],
+  );
+
+  const stats: ContributorStats = useMemo(() => {
+    let totalEarnedUsdc = 0;
+    let totalEarnedFndry = 0;
+    for (const sub of paidSubmissions) {
+      const bounty = bountiesById.get(sub.bounty_id);
+      const earned = sub.earned ?? bounty?.reward_amount ?? 0;
+      if (!earned) continue;
+      if (bounty?.reward_token === 'FNDRY') totalEarnedFndry += earned;
+      else totalEarnedUsdc += earned;
+    }
+    return {
+      totalEarnedUsdc,
+      totalEarnedFndry,
+      bountiesCompleted: paidSubmissions.length,
+      currentStreakDays: activity?.currentStreak ?? 0,
+      longestStreakDays: activity?.longestStreak ?? 0,
+      recentActivityCount: activity?.counts.total ?? 0,
+    };
+  }, [paidSubmissions, bountiesById, activity]);
+
+  return (
+    <motion.section
+      variants={fadeIn}
+      initial="initial"
+      animate="animate"
+      aria-label="Contributor statistics"
+      className="space-y-4"
+    >
+      <StatsRow stats={stats} />
+      <GitHubActivityGraph activity={activity} loading={activityLoading} username={username} />
+      <EarningsHistoryChart paidSubmissions={paidSubmissions} bountiesById={bountiesById} />
+    </motion.section>
+  );
+}

--- a/frontend/src/components/profile/EarningsHistoryChart.tsx
+++ b/frontend/src/components/profile/EarningsHistoryChart.tsx
@@ -1,0 +1,146 @@
+import React, { useMemo, useState } from 'react';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+  Legend,
+} from 'recharts';
+import type { Bounty, Submission } from '../../types/bounty';
+import { formatCompactNumber } from '../../lib/utils';
+
+interface MonthBucket {
+  key: string;
+  month: string;
+  usdc: number;
+  fndry: number;
+}
+
+interface Props {
+  /** Submissions where the contributor was paid out. */
+  paidSubmissions: Submission[];
+  /** Bounty lookup so we can credit each submission with token + amount. */
+  bountiesById: Map<string, Bounty>;
+}
+
+const MONTH_LABELS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+function emptyMonths(count: number): MonthBucket[] {
+  const out: MonthBucket[] = [];
+  const now = new Date();
+  for (let i = count - 1; i >= 0; i--) {
+    const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
+    const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+    out.push({ key, month: MONTH_LABELS[d.getMonth()], usdc: 0, fndry: 0 });
+  }
+  return out;
+}
+
+export function EarningsHistoryChart({ paidSubmissions, bountiesById }: Props) {
+  const [range, setRange] = useState<6 | 12>(12);
+
+  const data = useMemo(() => {
+    const months = emptyMonths(range);
+    const index = new Map(months.map((m, i) => [m.key, i]));
+    for (const sub of paidSubmissions) {
+      const bounty = bountiesById.get(sub.bounty_id);
+      if (!bounty) continue;
+      const earned = sub.earned ?? bounty.reward_amount ?? 0;
+      if (!earned) continue;
+      const d = new Date(sub.created_at);
+      if (Number.isNaN(d.getTime())) continue;
+      const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+      const idx = index.get(key);
+      if (idx == null) continue;
+      if (bounty.reward_token === 'FNDRY') {
+        months[idx].fndry += earned;
+      } else {
+        months[idx].usdc += earned;
+      }
+    }
+    return months;
+  }, [paidSubmissions, bountiesById, range]);
+
+  const totalUsdc = data.reduce((s, m) => s + m.usdc, 0);
+  const totalFndry = data.reduce((s, m) => s + m.fndry, 0);
+  const hasData = totalUsdc + totalFndry > 0;
+
+  return (
+    <div className="rounded-xl border border-border bg-forge-900 p-5">
+      <div className="flex items-baseline justify-between mb-3">
+        <div>
+          <h3 className="font-sans text-base font-semibold text-text-primary">Earnings history</h3>
+          <p className="text-xs text-text-muted mt-0.5">
+            FNDRY payouts and USDC bounties over time
+          </p>
+        </div>
+        <div className="flex items-center gap-1 p-0.5 rounded-md bg-forge-800 text-xs">
+          {([6, 12] as const).map((r) => (
+            <button
+              key={r}
+              onClick={() => setRange(r)}
+              className={`px-2 py-1 rounded transition-colors ${
+                range === r ? 'bg-forge-700 text-text-primary' : 'text-text-muted hover:text-text-secondary'
+              }`}
+            >
+              {r}mo
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {!hasData ? (
+        <div className="h-[200px] flex items-center justify-center text-sm text-text-muted">
+          No payouts yet — complete a bounty to start your earnings history.
+        </div>
+      ) : (
+        <ResponsiveContainer width="100%" height={220}>
+          <BarChart data={data} margin={{ top: 8, right: 8, bottom: 0, left: 0 }}>
+            <CartesianGrid stroke="#1E1E2E" strokeDasharray="3 3" vertical={false} />
+            <XAxis
+              dataKey="month"
+              axisLine={false}
+              tickLine={false}
+              tick={{ fill: '#5C5C78', fontSize: 12, fontFamily: 'JetBrains Mono' }}
+            />
+            <YAxis
+              axisLine={false}
+              tickLine={false}
+              tick={{ fill: '#5C5C78', fontSize: 11, fontFamily: 'JetBrains Mono' }}
+              tickFormatter={(v: number) => formatCompactNumber(v)}
+              width={48}
+            />
+            <Tooltip
+              cursor={{ fill: 'rgba(124,58,237,0.06)' }}
+              contentStyle={{
+                backgroundColor: '#16161F',
+                border: '1px solid #1E1E2E',
+                borderRadius: 8,
+                fontFamily: 'JetBrains Mono',
+                fontSize: 12,
+              }}
+              labelStyle={{ color: '#A0A0B8' }}
+              formatter={(value, name) => {
+                const v = typeof value === 'number' ? value : Number(value) || 0;
+                if (name === 'fndry') return [`${formatCompactNumber(v)} FNDRY`, 'FNDRY'];
+                return [`$${v.toLocaleString()}`, 'USDC'];
+              }}
+            />
+            <Legend
+              verticalAlign="top"
+              height={28}
+              iconType="square"
+              wrapperStyle={{ fontFamily: 'JetBrains Mono', fontSize: 11, color: '#A0A0B8' }}
+              formatter={(v: string) => (v === 'fndry' ? 'FNDRY' : 'USDC')}
+            />
+            <Bar dataKey="usdc" stackId="earn" fill="#00E676" radius={[0, 0, 0, 0]} opacity={0.9} />
+            <Bar dataKey="fndry" stackId="earn" fill="#7C3AED" radius={[4, 4, 0, 0]} opacity={0.9} />
+          </BarChart>
+        </ResponsiveContainer>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/profile/GitHubActivityGraph.tsx
+++ b/frontend/src/components/profile/GitHubActivityGraph.tsx
@@ -1,0 +1,155 @@
+import React, { useMemo } from 'react';
+import { GitCommit, GitPullRequest, AlertCircle, MessageSquare } from 'lucide-react';
+import type { DailyActivity, GitHubActivity } from '../../api/github';
+
+const CELL_PX = 12;
+const CELL_GAP_PX = 3;
+
+const LEVELS = [
+  { min: 0, fill: 'rgba(160,160,184,0.08)' },
+  { min: 1, fill: 'rgba(0,230,118,0.25)' },
+  { min: 3, fill: 'rgba(0,230,118,0.45)' },
+  { min: 6, fill: 'rgba(0,230,118,0.7)' },
+  { min: 12, fill: '#00E676' },
+];
+
+function bucket(count: number): string {
+  let fill = LEVELS[0].fill;
+  for (const l of LEVELS) {
+    if (count >= l.min) fill = l.fill;
+  }
+  return fill;
+}
+
+function chunkIntoWeeks(daily: DailyActivity[]): DailyActivity[][] {
+  if (daily.length === 0) return [];
+  const weeks: DailyActivity[][] = [];
+  // Pad the leading week so columns align to Sunday=0 per GitHub convention.
+  const first = new Date(daily[0].date + 'T00:00:00Z');
+  const leadingPad = first.getUTCDay();
+  let cur: DailyActivity[] = [];
+  for (let i = 0; i < leadingPad; i++) {
+    cur.push({ date: '', count: -1 });
+  }
+  for (const d of daily) {
+    cur.push(d);
+    if (cur.length === 7) {
+      weeks.push(cur);
+      cur = [];
+    }
+  }
+  if (cur.length > 0) {
+    while (cur.length < 7) cur.push({ date: '', count: -1 });
+    weeks.push(cur);
+  }
+  return weeks;
+}
+
+interface Props {
+  activity: GitHubActivity | undefined;
+  loading: boolean;
+  username: string | null | undefined;
+}
+
+const TYPE_BREAKDOWN: Array<{
+  key: 'commits' | 'pullRequests' | 'issues' | 'reviews';
+  label: string;
+  Icon: React.ComponentType<{ className?: string }>;
+  color: string;
+}> = [
+  { key: 'commits', label: 'Commits', Icon: GitCommit, color: 'text-emerald' },
+  { key: 'pullRequests', label: 'Pull requests', Icon: GitPullRequest, color: 'text-status-info' },
+  { key: 'issues', label: 'Issues', Icon: AlertCircle, color: 'text-magenta' },
+  { key: 'reviews', label: 'Reviews', Icon: MessageSquare, color: 'text-purple' },
+];
+
+export function GitHubActivityGraph({ activity, loading, username }: Props) {
+  const weeks = useMemo(() => (activity ? chunkIntoWeeks(activity.daily) : []), [activity]);
+
+  return (
+    <div className="rounded-xl border border-border bg-forge-900 p-5">
+      <div className="flex items-baseline justify-between mb-4">
+        <div>
+          <h3 className="font-sans text-base font-semibold text-text-primary">GitHub activity</h3>
+          <p className="text-xs text-text-muted mt-0.5">
+            {activity
+              ? `${activity.counts.total} events in the last ${activity.rangeDays} days`
+              : username
+                ? 'Loading…'
+                : 'Sign in with GitHub to see your activity'}
+          </p>
+        </div>
+        {activity && (
+          <div className="flex items-center gap-3 text-xs text-text-muted">
+            <span>Less</span>
+            {LEVELS.map((l) => (
+              <span
+                key={l.min}
+                className="inline-block w-3 h-3 rounded-sm"
+                style={{ backgroundColor: l.fill }}
+              />
+            ))}
+            <span>More</span>
+          </div>
+        )}
+      </div>
+
+      {/* Heatmap */}
+      <div className="overflow-x-auto pb-1">
+        {loading && !activity ? (
+          <div className="h-[112px] w-full rounded-md bg-forge-800 animate-pulse" />
+        ) : weeks.length === 0 ? (
+          <div className="h-[112px] flex items-center justify-center text-sm text-text-muted">
+            No public activity in this window.
+          </div>
+        ) : (
+          <svg
+            role="img"
+            aria-label={`GitHub activity heatmap for ${username ?? 'user'}`}
+            width={weeks.length * (CELL_PX + CELL_GAP_PX)}
+            height={7 * (CELL_PX + CELL_GAP_PX)}
+          >
+            {weeks.map((week, wi) =>
+              week.map((day, di) => {
+                if (day.count < 0) return null;
+                return (
+                  <rect
+                    key={`${wi}-${di}`}
+                    x={wi * (CELL_PX + CELL_GAP_PX)}
+                    y={di * (CELL_PX + CELL_GAP_PX)}
+                    width={CELL_PX}
+                    height={CELL_PX}
+                    rx={2}
+                    ry={2}
+                    fill={bucket(day.count)}
+                  >
+                    <title>
+                      {day.date} — {day.count} event{day.count === 1 ? '' : 's'}
+                    </title>
+                  </rect>
+                );
+              }),
+            )}
+          </svg>
+        )}
+      </div>
+
+      {/* Type breakdown */}
+      {activity && (
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mt-5">
+          {TYPE_BREAKDOWN.map(({ key, label, Icon, color }) => (
+            <div key={key} className="flex items-center gap-2.5 rounded-lg bg-forge-800 px-3 py-2">
+              <Icon className={`w-4 h-4 ${color}`} />
+              <div className="min-w-0">
+                <p className="text-xs text-text-muted leading-none">{label}</p>
+                <p className="font-mono text-sm font-semibold text-text-primary mt-1">
+                  {activity.counts[key]}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/profile/ProfileDashboard.tsx
+++ b/frontend/src/components/profile/ProfileDashboard.tsx
@@ -1,12 +1,13 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { motion } from 'framer-motion';
-import { Clock, GitPullRequest, DollarSign, Settings } from 'lucide-react';
-import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from 'recharts';
+import { GitPullRequest } from 'lucide-react';
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
 import { useAuth } from '../../hooks/useAuth';
-import { useBounties } from '../../hooks/useBounties';
+import { useBounties, useMySubmissions } from '../../hooks/useBounties';
 import { timeAgo, formatCurrency } from '../../lib/utils';
 import { fadeIn, staggerContainer, staggerItem } from '../../lib/animations';
 import type { Bounty } from '../../types/bounty';
+import { ContributorStatsPanel } from './ContributorStatsPanel';
 
 const TABS = ['My Bounties', 'My Submissions', 'Earnings', 'Settings'] as const;
 type Tab = typeof TABS[number];
@@ -152,6 +153,7 @@ export function ProfileDashboard() {
   const { user } = useAuth();
   const [activeTab, setActiveTab] = useState<Tab>('My Bounties');
   const { data: bountiesData, isLoading } = useBounties({ limit: 50 });
+  const { data: mySubmissions } = useMySubmissions(!!user);
 
   if (!user) return null;
 
@@ -160,11 +162,13 @@ export function ProfileDashboard() {
     : 'Recently';
 
   const myBounties = bountiesData?.items.filter((b) => b.creator_id === user.id) ?? [];
+  const submissions = mySubmissions ?? [];
+  const allBounties = bountiesData?.items ?? [];
 
   return (
-    <motion.div variants={fadeIn} initial="initial" animate="animate" className="max-w-4xl mx-auto px-4 py-8">
+    <motion.div variants={fadeIn} initial="initial" animate="animate" className="max-w-4xl mx-auto px-4 py-8 space-y-6">
       {/* Header */}
-      <div className="rounded-xl border border-border bg-forge-900 p-6 mb-6">
+      <div className="rounded-xl border border-border bg-forge-900 p-6">
         <div className="flex items-start gap-5">
           {user.avatar_url ? (
             <img src={user.avatar_url} className="w-16 h-16 rounded-full border-2 border-border" alt={user.username} />
@@ -180,9 +184,18 @@ export function ProfileDashboard() {
             </p>
           </div>
         </div>
+      </div>
 
-        {/* Tab switcher */}
-        <div className="flex items-center gap-1 p-1 rounded-lg bg-forge-800 mt-6 w-fit">
+      {/* Contributor stats dashboard: stats row, GitHub activity, earnings */}
+      <ContributorStatsPanel
+        username={user.username}
+        submissions={submissions}
+        bounties={allBounties}
+      />
+
+      {/* Tab switcher */}
+      <div className="rounded-xl border border-border bg-forge-900 p-4">
+        <div className="flex items-center gap-1 p-1 rounded-lg bg-forge-800 w-fit">
           {TABS.map((tab) => (
             <button
               key={tab}
@@ -197,14 +210,13 @@ export function ProfileDashboard() {
             </button>
           ))}
         </div>
-      </div>
 
-      {/* Tab content */}
-      <div>
-        {activeTab === 'My Bounties' && <MyBountiesTab bounties={myBounties} loading={isLoading} />}
-        {activeTab === 'My Submissions' && <SubmissionsTab />}
-        {activeTab === 'Earnings' && <EarningsTab />}
-        {activeTab === 'Settings' && <SettingsTab />}
+        <div className="mt-4">
+          {activeTab === 'My Bounties' && <MyBountiesTab bounties={myBounties} loading={isLoading} />}
+          {activeTab === 'My Submissions' && <SubmissionsTab />}
+          {activeTab === 'Earnings' && <EarningsTab />}
+          {activeTab === 'Settings' && <SettingsTab />}
+        </div>
       </div>
     </motion.div>
   );

--- a/frontend/src/components/profile/StatsRow.tsx
+++ b/frontend/src/components/profile/StatsRow.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { DollarSign, Trophy, Flame, GitCommit } from 'lucide-react';
+import { formatCompactNumber } from '../../lib/utils';
+import { staggerContainer, staggerItem } from '../../lib/animations';
+
+export interface ContributorStats {
+  totalEarnedUsdc: number;
+  totalEarnedFndry: number;
+  bountiesCompleted: number;
+  currentStreakDays: number;
+  longestStreakDays: number;
+  recentActivityCount: number;
+}
+
+interface Props {
+  stats: ContributorStats;
+}
+
+export function StatsRow({ stats }: Props) {
+  const cards = [
+    {
+      key: 'earned',
+      label: 'Total earned',
+      Icon: DollarSign,
+      tint: 'text-emerald bg-emerald-bg border-emerald-border',
+      primary: stats.totalEarnedUsdc > 0 ? `$${formatCompactNumber(stats.totalEarnedUsdc)}` : '—',
+      secondary:
+        stats.totalEarnedFndry > 0 ? `+ ${formatCompactNumber(stats.totalEarnedFndry)} FNDRY` : 'USDC',
+    },
+    {
+      key: 'completed',
+      label: 'Bounties completed',
+      Icon: Trophy,
+      tint: 'text-status-info bg-status-info/10 border-status-info/20',
+      primary: stats.bountiesCompleted.toString(),
+      secondary: stats.bountiesCompleted === 1 ? 'submission approved' : 'submissions approved',
+    },
+    {
+      key: 'streak',
+      label: 'Contribution streak',
+      Icon: Flame,
+      tint: 'text-magenta bg-magenta-bg border-magenta-border',
+      primary: `${stats.currentStreakDays}d`,
+      secondary: stats.longestStreakDays > 0 ? `best: ${stats.longestStreakDays}d` : '—',
+    },
+    {
+      key: 'activity',
+      label: 'Recent activity',
+      Icon: GitCommit,
+      tint: 'text-purple bg-purple-bg border-purple-border',
+      primary: stats.recentActivityCount.toString(),
+      secondary: 'events · last 90d',
+    },
+  ];
+
+  return (
+    <motion.div
+      variants={staggerContainer}
+      initial="initial"
+      animate="animate"
+      className="grid grid-cols-2 lg:grid-cols-4 gap-3"
+    >
+      {cards.map(({ key, label, Icon, tint, primary, secondary }) => (
+        <motion.div
+          key={key}
+          variants={staggerItem}
+          className="rounded-xl border border-border bg-forge-900 p-4 flex items-start gap-3"
+        >
+          <div className={`w-9 h-9 rounded-lg border flex items-center justify-center flex-shrink-0 ${tint}`}>
+            <Icon className="w-4 h-4" />
+          </div>
+          <div className="min-w-0">
+            <p className="text-xs text-text-muted leading-none">{label}</p>
+            <p className="font-mono text-xl font-bold text-text-primary mt-2 truncate">{primary}</p>
+            <p className="text-[11px] text-text-muted mt-1 truncate">{secondary}</p>
+          </div>
+        </motion.div>
+      ))}
+    </motion.div>
+  );
+}

--- a/frontend/src/hooks/useBounties.ts
+++ b/frontend/src/hooks/useBounties.ts
@@ -1,5 +1,5 @@
 import { useQuery, useInfiniteQuery } from '@tanstack/react-query';
-import { listBounties, getBounty } from '../api/bounties';
+import { listBounties, getBounty, listMySubmissions } from '../api/bounties';
 import type { BountiesListParams } from '../api/bounties';
 
 export function useBounties(params?: BountiesListParams) {
@@ -30,6 +30,15 @@ export function useBounty(id: string | undefined) {
     queryKey: ['bounty', id],
     queryFn: () => getBounty(id!),
     enabled: !!id,
+    staleTime: 30_000,
+  });
+}
+
+export function useMySubmissions(enabled: boolean = true) {
+  return useQuery({
+    queryKey: ['my-submissions'],
+    queryFn: listMySubmissions,
+    enabled,
     staleTime: 30_000,
   });
 }

--- a/frontend/src/hooks/useGitHubActivity.ts
+++ b/frontend/src/hooks/useGitHubActivity.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchGitHubActivity } from '../api/github';
+
+export function useGitHubActivity(username: string | null | undefined, rangeDays: number = 90) {
+  return useQuery({
+    queryKey: ['github-activity', username, rangeDays],
+    queryFn: () => fetchGitHubActivity(username ?? '', rangeDays),
+    enabled: !!username,
+    staleTime: 5 * 60_000,
+  });
+}

--- a/frontend/src/lib/animations.ts
+++ b/frontend/src/lib/animations.ts
@@ -1,0 +1,40 @@
+import type { Variants } from 'framer-motion';
+
+export const fadeIn: Variants = {
+  initial: { opacity: 0, y: 8 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.25, ease: 'easeOut' } },
+  exit: { opacity: 0, y: -8, transition: { duration: 0.15, ease: 'easeIn' } },
+};
+
+export const pageTransition: Variants = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.3, ease: 'easeOut' } },
+  exit: { opacity: 0, y: -12, transition: { duration: 0.15, ease: 'easeIn' } },
+};
+
+export const staggerContainer: Variants = {
+  initial: {},
+  animate: { transition: { staggerChildren: 0.05 } },
+};
+
+export const staggerItem: Variants = {
+  initial: { opacity: 0, y: 8 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.22, ease: 'easeOut' } },
+};
+
+export const cardHover: Variants = {
+  rest: { y: 0, boxShadow: '0 0 0 0 rgba(0,230,118,0)' },
+  hover: { y: -2, boxShadow: '0 6px 24px -8px rgba(0,230,118,0.18)', transition: { duration: 0.18, ease: 'easeOut' } },
+};
+
+export const buttonHover: Variants = {
+  rest: { scale: 1 },
+  hover: { scale: 1.03, transition: { duration: 0.15, ease: 'easeOut' } },
+  tap: { scale: 0.97, transition: { duration: 0.08 } },
+};
+
+export const slideInRight: Variants = {
+  initial: { opacity: 0, x: 16 },
+  animate: { opacity: 1, x: 0, transition: { duration: 0.25, ease: 'easeOut' } },
+  exit: { opacity: 0, x: -16, transition: { duration: 0.15, ease: 'easeIn' } },
+};

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,86 @@
+/**
+ * Shared formatting + display helpers used across the frontend.
+ * Kept dependency-free so they can be imported anywhere.
+ */
+
+export function formatCurrency(amount: number, token: string = 'USDC'): string {
+  const normalized = token?.toUpperCase?.() ?? 'USDC';
+  if (normalized === 'FNDRY') {
+    return `${formatCompactNumber(amount)} FNDRY`;
+  }
+  if (normalized === 'SOL') {
+    return `${amount.toLocaleString(undefined, { maximumFractionDigits: 4 })} SOL`;
+  }
+  return `$${amount.toLocaleString(undefined, { maximumFractionDigits: 2 })}`;
+}
+
+export function formatCompactNumber(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(n % 1_000_000 === 0 ? 0 : 1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(n % 1_000 === 0 ? 0 : 1)}K`;
+  return n.toLocaleString();
+}
+
+function diffSeconds(target: Date, base: Date = new Date()): number {
+  return Math.round((target.getTime() - base.getTime()) / 1000);
+}
+
+export function timeAgo(timestamp: string | number | Date | null | undefined): string {
+  if (!timestamp) return '';
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return '';
+  const seconds = -diffSeconds(date);
+  if (seconds < 60) return 'just now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo ago`;
+  const years = Math.floor(days / 365);
+  return `${years}y ago`;
+}
+
+export function timeLeft(deadline: string | number | Date | null | undefined): string {
+  if (!deadline) return '—';
+  const date = new Date(deadline);
+  if (Number.isNaN(date.getTime())) return '—';
+  const seconds = diffSeconds(date);
+  if (seconds <= 0) return 'ended';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m left`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h left`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d left`;
+  const months = Math.floor(days / 30);
+  return `${months}mo left`;
+}
+
+export function cn(...classes: Array<string | false | null | undefined>): string {
+  return classes.filter(Boolean).join(' ');
+}
+
+/** GitHub-aligned language colors (subset). Falls back to muted grey when absent. */
+export const LANG_COLORS: Record<string, string> = {
+  Rust: '#DEA584',
+  TypeScript: '#3178C6',
+  JavaScript: '#F1E05A',
+  Python: '#3572A5',
+  Go: '#00ADD8',
+  Solidity: '#AA6746',
+  Move: '#4F5D95',
+  React: '#61DAFB',
+  Solana: '#9945FF',
+  Anchor: '#512BD4',
+  CSS: '#563D7C',
+  HTML: '#E34F26',
+  Shell: '#89E051',
+  Docker: '#384D54',
+  Frontend: '#40C4FF',
+  Backend: '#00E676',
+  Smart_Contracts: '#7C3AED',
+  Design: '#E040FB',
+  Docs: '#A0A0B8',
+};


### PR DESCRIPTION
/claim #836

> ⚠️ **This PR is AI-assisted.** It was implemented end-to-end by Claude (Anthropic) at the request of the bounty hunter. Please review the diff carefully before merging.

## Summary
Builds the **Contributor Profile Stats Dashboard** described in #836. The profile page now leads with a stats dashboard — visible before the existing tabbed area — that pulls together GitHub activity, FNDRY/USDC earnings history, and headline contributor metrics.

### What landed
- **GitHub activity heatmap** (`GitHubActivityGraph`) — last 90 days of public events from `api.github.com/users/{username}/events/public`, rendered as a GitHub-style daily heatmap (SVG, no extra deps) with a per-event-type breakdown (commits, PRs, issues, reviews).
- **Earnings history chart** (`EarningsHistoryChart`) — stacked monthly bar chart of USDC + FNDRY payouts (recharts), with a 6mo / 12mo range toggle, built from the contributor's approved submissions joined against their bounty rewards.
- **Key stats row** (`StatsRow`) — total earned (USDC + FNDRY), bounties completed, current / longest contribution streak (derived from the GitHub event stream), and rolling event count.
- **`/api/users/me/submissions` client + `useMySubmissions` hook** — graceful 404/501 fallback so the panel renders an empty-but-useful state until the backend ships that endpoint.

### Drive-by fix
The repo-wide `.gitignore` had a `lib/` rule (intended for Python venvs) that was silently catching `frontend/src/lib/`. The `lib/utils` and `lib/animations` modules were referenced across ~20 frontend files but had never been committed — `tsc` and `vite build` both failed on `main` before this PR. The ignore is narrowed to venv paths and the two missing modules are now tracked.

## Files
- `frontend/src/api/github.ts` + `hooks/useGitHubActivity.ts` — GitHub events fetcher with weight-by-commit-count and streak math
- `frontend/src/components/profile/{ContributorStatsPanel,GitHubActivityGraph,EarningsHistoryChart,StatsRow}.tsx`
- `frontend/src/api/bounties.ts` + `hooks/useBounties.ts` — new `listMySubmissions` / `useMySubmissions` with 404 fallback
- `frontend/src/components/profile/ProfileDashboard.tsx` — wires the new panel into the existing dashboard
- `frontend/src/lib/{utils,animations}.ts` — restored shared helpers (formatCurrency / timeAgo / animation variants)
- `frontend/src/__tests__/{github-activity,utils}.test.ts` — 12 new passing unit tests covering event aggregation, streak computation, and number/date formatting
- `.gitignore` — narrow the Python `lib/` ignore so it doesn't swallow the frontend lib folder

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vite build` — succeeds (previously failed on `main` because of the missing `lib/` modules)
- [x] `npx vitest run src/__tests__/github-activity.test.ts src/__tests__/utils.test.ts` — 12/12 pass
- [x] Dev server (`npx vite`) boots and serves the profile page without runtime errors
- [ ] Manual smoke test against a real GitHub account (recommend reviewer try their own username — the heatmap is hydrated client-side from the public events API, no token required)

## Acceptance criteria mapping
- ✅ GitHub activity graph (commits, PRs, issues) via GitHub API → `GitHubActivityGraph` + `api/github.ts`
- ✅ Earning history chart showing FNDRY payouts over time → `EarningsHistoryChart` (stacked USDC + FNDRY)
- ✅ Key stats: total earned, bounties completed, contribution streak → `StatsRow`

## Notes for reviewers
- The GitHub public events feed only returns ~90 days of data and is unauthenticated, so it has a 60 req/hr per-IP rate limit. The query is cached in React Query for 5 minutes per username, so the typical session stays well under that.
- Earnings rely on `/api/users/me/submissions` returning approved submissions. The frontend handles a missing endpoint gracefully (empty state); the panel will light up automatically once the backend exposes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)