### PR TITLE
feat: wire activity feed hook with refresh and fallback

### DIFF
--- a/frontend/src/api/activity.ts
+++ b/frontend/src/api/activity.ts
@@ -1,0 +1,20 @@
+import { apiClient } from '../services/apiClient';
+
+export interface ActivityEvent {
+  id: string;
+  type: 'completed' | 'submitted' | 'posted' | 'review';
+  username: string;
+  avatar_url?: string | null;
+  detail: string;
+  timestamp: string;
+}
+
+interface ActivityResponse {
+  items: ActivityEvent[];
+}
+
+export async function listActivity(limit = 4): Promise<ActivityResponse> {
+  return apiClient<ActivityResponse>('/api/activity', {
+    params: { limit },
+  });
+}

--- a/frontend/src/components/home/ActivityFeed.tsx
+++ b/frontend/src/components/home/ActivityFeed.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { slideInRight } from '../../lib/animations';
 import { timeAgo } from '../../lib/utils';
+import { useActivity } from '../../hooks/useActivity';
 
 interface ActivityEvent {
   id: string;
@@ -76,7 +77,9 @@ function EventItem({ event }: { event: ActivityEvent }) {
 }
 
 export function ActivityFeed({ events }: { events?: ActivityEvent[] }) {
-  const displayEvents = events?.length ? events.slice(0, 4) : MOCK_EVENTS;
+  const { data, isError } = useActivity(4);
+  const remoteEvents = data?.items ?? [];
+  const displayEvents = events?.length ? events.slice(0, 4) : remoteEvents.length ? remoteEvents : MOCK_EVENTS;
   const [visibleEvents, setVisibleEvents] = useState<ActivityEvent[]>(displayEvents.slice(0, 4));
 
   useEffect(() => {
@@ -91,6 +94,9 @@ export function ActivityFeed({ events }: { events?: ActivityEvent[] }) {
           <span className="font-mono text-xs text-text-muted uppercase tracking-wider">Recent Activity</span>
         </div>
         <div className="space-y-1">
+          {isError && (
+            <p className="px-3 pb-1 text-xs text-text-muted">Using fallback activity feed while API is unavailable.</p>
+          )}
           <AnimatePresence mode="popLayout">
             {visibleEvents.map((event) => (
               <motion.div

--- a/frontend/src/hooks/useActivity.ts
+++ b/frontend/src/hooks/useActivity.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { listActivity } from '../api/activity';
+
+export function useActivity(limit = 4) {
+  return useQuery({
+    queryKey: ['activity', limit],
+    queryFn: () => listActivity(limit),
+    refetchInterval: 30_000,
+    staleTime: 15_000,
+  });
+}


### PR DESCRIPTION
## Summary
- add `frontend/src/api/activity.ts` for `/api/activity` requests
- add `useActivity` React Query hook with 30s auto refresh
- wire `ActivityFeed` to remote activity data with graceful fallback to mock feed
- show subtle fallback notice when API is unavailable

## Why
Issue #822 asks to wire activity feed to real API data with periodic refresh and resilience.

## Acceptance mapping
- [x] Real API integration for activity feed
- [x] Auto-refresh cadence (30s)
- [x] Empty/error-safe fallback behavior

Closes #822

## Wallet
Wallet: 74jSPYaxEJcGEuW4jr6bqQdg2iuLChyLEuEmC8QhcQVW
