### PR TITLE
Wire home activity feed to API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,8 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
-lib64/
+/lib/
+/lib64/
 parts/
 sdist/
 var/

--- a/frontend/src/__tests__/activity-api.test.ts
+++ b/frontend/src/__tests__/activity-api.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { listActivity, normalizeActivityEvent } from '../api/activity';
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('activity API', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('fetches /api/activity and normalizes event payloads', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        items: [
+          {
+            id: 'evt-payout',
+            event_type: 'payout_released',
+            actor: { login: 'treasury', avatar_url: 'https://example.com/avatar.png' },
+            message: '200,000 FNDRY paid for Bounty #822',
+            created_at: '2026-05-12T12:00:00.000Z',
+          },
+        ],
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const events = await listActivity({ limit: 2 });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/activity?limit=2',
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(events).toEqual([
+      {
+        id: 'evt-payout',
+        type: 'payout',
+        username: 'treasury',
+        avatar_url: 'https://example.com/avatar.png',
+        detail: '200,000 FNDRY paid for Bounty #822',
+        timestamp: '2026-05-12T12:00:00.000Z',
+      },
+    ]);
+  });
+
+  it('drops malformed events that lack a timestamp or detail', () => {
+    expect(normalizeActivityEvent({ id: 'bad' }, 0)).toBeNull();
+  });
+});

--- a/frontend/src/__tests__/activity-api.test.ts
+++ b/frontend/src/__tests__/activity-api.test.ts
@@ -13,7 +13,7 @@ describe('activity API', () => {
     vi.unstubAllGlobals();
   });
 
-  it('fetches /api/activity and normalizes event payloads', async () => {
+  it('fetches the analytics activity endpoint and normalizes event payloads', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       jsonResponse({
         items: [
@@ -32,7 +32,7 @@ describe('activity API', () => {
     const events = await listActivity({ limit: 2 });
 
     expect(fetchMock).toHaveBeenCalledWith(
-      '/api/activity?limit=2',
+      '/api/analytics/activity?limit=2',
       expect.objectContaining({ method: 'GET' }),
     );
     expect(events).toEqual([
@@ -49,5 +49,32 @@ describe('activity API', () => {
 
   it('drops malformed events that lack a timestamp or detail', () => {
     expect(normalizeActivityEvent({ id: 'bad' }, 0)).toBeNull();
+  });
+
+  it('accepts the backend activities response envelope', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        activities: [
+          {
+            type: 'bounty_completed',
+            user: { username: 'builder' },
+            title: 'Bounty #822 completed',
+            timestamp: '2026-05-12T12:00:00.000Z',
+          },
+        ],
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(listActivity()).resolves.toEqual([
+      {
+        id: 'completed-2026-05-12T12:00:00.000Z-0',
+        type: 'completed',
+        username: 'builder',
+        avatar_url: null,
+        detail: 'Bounty #822 completed',
+        timestamp: '2026-05-12T12:00:00.000Z',
+      },
+    ]);
   });
 });

--- a/frontend/src/__tests__/home-activity-feed.test.tsx
+++ b/frontend/src/__tests__/home-activity-feed.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReactElement } from 'react';
+import { ActivityFeed } from '../components/home/ActivityFeed';
+import { listActivity } from '../api/activity';
+import type { ActivityEvent } from '../api/activity';
+
+vi.mock('../api/activity', () => ({
+  listActivity: vi.fn(),
+}));
+
+const mockListActivity = vi.mocked(listActivity);
+
+const SUBMISSION_EVENT: ActivityEvent = {
+  id: 'evt-submitted',
+  type: 'submitted',
+  username: 'devbuilder',
+  avatar_url: null,
+  detail: 'PR #77 to Bounty #822',
+  timestamp: '2026-05-12T12:00:00.000Z',
+};
+
+const PAYOUT_EVENT: ActivityEvent = {
+  id: 'evt-payout',
+  type: 'payout',
+  username: 'treasury',
+  avatar_url: null,
+  detail: '200,000 FNDRY for Bounty #99',
+  timestamp: '2026-05-12T12:01:00.000Z',
+};
+
+function renderWithQueryClient(ui: ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={client}>
+      {ui}
+    </QueryClientProvider>,
+  );
+}
+
+describe('ActivityFeed', () => {
+  beforeEach(() => {
+    mockListActivity.mockReset();
+  });
+
+  it('renders real activity from the API', async () => {
+    mockListActivity.mockResolvedValue([SUBMISSION_EVENT]);
+
+    renderWithQueryClient(<ActivityFeed />);
+
+    await waitFor(() => expect(mockListActivity).toHaveBeenCalledWith({ limit: 4 }));
+    expect(await screen.findByText('devbuilder')).toBeInTheDocument();
+    expect(screen.getByText('PR #77 to Bounty #822')).toBeInTheDocument();
+    expect(screen.queryByText('Activity feed unavailable')).not.toBeInTheDocument();
+  });
+
+  it('shows an empty state when the API has no events', async () => {
+    mockListActivity.mockResolvedValue([]);
+
+    renderWithQueryClient(<ActivityFeed />);
+
+    expect(await screen.findByText('No recent activity')).toBeInTheDocument();
+    expect(screen.queryByText('devbuilder')).not.toBeInTheDocument();
+  });
+
+  it('falls back gracefully when the activity API is unavailable', async () => {
+    mockListActivity.mockRejectedValue(new Error('offline'));
+
+    renderWithQueryClient(<ActivityFeed />);
+
+    expect(await screen.findByText('Activity feed unavailable')).toBeInTheDocument();
+  });
+
+  it('refreshes activity without a page reload', async () => {
+    mockListActivity
+      .mockResolvedValueOnce([SUBMISSION_EVENT])
+      .mockResolvedValue([PAYOUT_EVENT]);
+
+    renderWithQueryClient(<ActivityFeed refreshIntervalMs={20} />);
+
+    expect(await screen.findByText('PR #77 to Bounty #822')).toBeInTheDocument();
+    await waitFor(() => expect(mockListActivity).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText('200,000 FNDRY for Bounty #99')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/api/activity.ts
+++ b/frontend/src/api/activity.ts
@@ -16,6 +16,7 @@ type ActivityResponse =
   | {
       items?: unknown[];
       events?: unknown[];
+      activities?: unknown[];
       activity?: unknown[];
     };
 
@@ -93,13 +94,13 @@ export function normalizeActivityEvent(raw: unknown, index: number): ActivityEve
 
 export async function listActivity(params: ActivityListParams = {}): Promise<ActivityEvent[]> {
   const limit = params.limit ?? 4;
-  const response = await apiClient<ActivityResponse>('/api/activity', {
+  const response = await apiClient<ActivityResponse>('/api/analytics/activity', {
     params: { limit },
   });
 
   const rawEvents = Array.isArray(response)
     ? response
-    : response.items ?? response.events ?? response.activity ?? [];
+    : response.items ?? response.events ?? response.activities ?? response.activity ?? [];
 
   return rawEvents
     .map((event, index) => normalizeActivityEvent(event, index))

--- a/frontend/src/api/activity.ts
+++ b/frontend/src/api/activity.ts
@@ -1,0 +1,109 @@
+import { apiClient } from '../services/apiClient';
+
+export type ActivityEventType = 'completed' | 'submitted' | 'posted' | 'review' | 'payout';
+
+export interface ActivityEvent {
+  id: string;
+  type: ActivityEventType;
+  username: string;
+  avatar_url?: string | null;
+  detail: string;
+  timestamp: string;
+}
+
+type ActivityResponse =
+  | unknown[]
+  | {
+      items?: unknown[];
+      events?: unknown[];
+      activity?: unknown[];
+    };
+
+export interface ActivityListParams {
+  limit?: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function getString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() !== '' ? value : undefined;
+}
+
+function getNestedString(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return isRecord(value)
+    ? getString(value.login) ?? getString(value.username) ?? getString(value.name)
+    : undefined;
+}
+
+function getAvatar(record: Record<string, unknown>): string | null | undefined {
+  const actor = record.actor;
+  const user = record.user;
+  return (
+    getString(record.avatar_url) ??
+    (isRecord(actor) ? getString(actor.avatar_url) : undefined) ??
+    (isRecord(user) ? getString(user.avatar_url) : undefined)
+  );
+}
+
+function normalizeType(type: unknown): ActivityEventType {
+  const normalized = getString(type)?.toLowerCase() ?? '';
+  if (normalized.includes('review')) return 'review';
+  if (normalized.includes('payout') || normalized.includes('paid') || normalized.includes('release')) return 'payout';
+  if (normalized.includes('complete') || normalized.includes('earn')) return 'completed';
+  if (normalized.includes('submit') || normalized.includes('pull_request') || normalized.includes('pr_')) return 'submitted';
+  return 'posted';
+}
+
+export function normalizeActivityEvent(raw: unknown, index: number): ActivityEvent | null {
+  if (!isRecord(raw)) return null;
+
+  const timestamp =
+    getString(raw.timestamp) ??
+    getString(raw.created_at) ??
+    getString(raw.createdAt) ??
+    getString(raw.time);
+
+  const detail =
+    getString(raw.detail) ??
+    getString(raw.message) ??
+    getString(raw.title) ??
+    getString(raw.description);
+
+  if (!timestamp || !detail) return null;
+
+  const username =
+    getString(raw.username) ??
+    getString(raw.actor_name) ??
+    getNestedString(raw, 'actor') ??
+    getNestedString(raw, 'user') ??
+    'SolFoundry';
+
+  return {
+    id: getString(raw.id) ?? `${normalizeType(raw.type)}-${timestamp}-${index}`,
+    type: normalizeType(raw.type ?? raw.event_type),
+    username,
+    avatar_url: getAvatar(raw) ?? null,
+    detail,
+    timestamp,
+  };
+}
+
+export async function listActivity(params: ActivityListParams = {}): Promise<ActivityEvent[]> {
+  const limit = params.limit ?? 4;
+  const response = await apiClient<ActivityResponse>('/api/activity', {
+    params: { limit },
+  });
+
+  const rawEvents = Array.isArray(response)
+    ? response
+    : response.items ?? response.events ?? response.activity ?? [];
+
+  return rawEvents
+    .map((event, index) => normalizeActivityEvent(event, index))
+    .filter((event): event is ActivityEvent => event !== null)
+    .sort((a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp))
+    .slice(0, limit);
+}

--- a/frontend/src/components/home/ActivityFeed.tsx
+++ b/frontend/src/components/home/ActivityFeed.tsx
@@ -1,53 +1,17 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { slideInRight } from '../../lib/animations';
 import { timeAgo } from '../../lib/utils';
+import { useActivityEvents } from '../../hooks/useActivity';
+import type { ActivityEvent } from '../../api/activity';
 
-interface ActivityEvent {
-  id: string;
-  type: 'completed' | 'submitted' | 'posted' | 'review';
-  username: string;
-  avatar_url?: string | null;
-  detail: string;
-  timestamp: string;
-}
-
-// Mock events for when API doesn't return activity
-const MOCK_EVENTS: ActivityEvent[] = [
-  {
-    id: '1',
-    type: 'completed',
-    username: 'devbuilder',
-    detail: '$500 USDC from Bounty #42',
-    timestamp: new Date(Date.now() - 3 * 60 * 1000).toISOString(),
-  },
-  {
-    id: '2',
-    type: 'submitted',
-    username: 'KodeSage',
-    detail: 'PR to Bounty #38',
-    timestamp: new Date(Date.now() - 15 * 60 * 1000).toISOString(),
-  },
-  {
-    id: '3',
-    type: 'posted',
-    username: 'SolanaLabs',
-    detail: 'Bounty #145 — $3,500 USDC',
-    timestamp: new Date(Date.now() - 45 * 60 * 1000).toISOString(),
-  },
-  {
-    id: '4',
-    type: 'review',
-    username: 'AI Review',
-    detail: 'Bounty #42 — 8.5/10',
-    timestamp: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
-  },
-];
+const EMPTY_EVENTS: ActivityEvent[] = [];
 
 function getActionText(type: ActivityEvent['type']) {
   switch (type) {
-    case 'completed': return 'earned';
+    case 'completed': return 'completed';
     case 'submitted': return 'submitted';
+    case 'payout': return 'paid out';
     case 'posted': return 'posted';
     case 'review': return 'AI Review passed for';
     default: return 'updated';
@@ -75,36 +39,71 @@ function EventItem({ event }: { event: ActivityEvent }) {
   );
 }
 
-export function ActivityFeed({ events }: { events?: ActivityEvent[] }) {
-  const displayEvents = events?.length ? events.slice(0, 4) : MOCK_EVENTS;
+function FeedState({ children }: { children: string }) {
+  return (
+    <div className="py-3 px-3 rounded-lg border border-border/60 bg-forge-900 text-sm text-text-muted">
+      {children}
+    </div>
+  );
+}
+
+export function ActivityFeed({
+  events,
+  refreshIntervalMs = 30_000,
+}: {
+  events?: ActivityEvent[];
+  refreshIntervalMs?: number;
+}) {
+  const activityQuery = useActivityEvents({
+    enabled: events === undefined,
+    limit: 4,
+    refetchIntervalMs: refreshIntervalMs,
+  });
+
+  const displayEvents = events ?? activityQuery.data ?? EMPTY_EVENTS;
   const [visibleEvents, setVisibleEvents] = useState<ActivityEvent[]>(displayEvents.slice(0, 4));
+  const isFetchingRealActivity = events === undefined && activityQuery.isLoading;
+  const hasActivityError = events === undefined && activityQuery.isError;
 
   useEffect(() => {
     setVisibleEvents(displayEvents.slice(0, 4));
-  }, [events]);
+  }, [displayEvents]);
 
   return (
     <section className="w-full border-y border-border bg-forge-900/50 py-4 overflow-hidden">
       <div className="max-w-7xl mx-auto px-4">
-        <div className="flex items-center gap-3 mb-3">
-          <span className="w-2 h-2 rounded-full bg-emerald animate-pulse-glow" />
-          <span className="font-mono text-xs text-text-muted uppercase tracking-wider">Recent Activity</span>
+        <div className="flex items-center justify-between gap-3 mb-3">
+          <div className="flex items-center gap-3">
+            <span className="w-2 h-2 rounded-full bg-emerald animate-pulse-glow" />
+            <span className="font-mono text-xs text-text-muted uppercase tracking-wider">Recent Activity</span>
+          </div>
+          {events === undefined && activityQuery.isFetching && !isFetchingRealActivity ? (
+            <span className="font-mono text-xs text-text-muted">Refreshing</span>
+          ) : null}
         </div>
         <div className="space-y-1">
-          <AnimatePresence mode="popLayout">
-            {visibleEvents.map((event) => (
-              <motion.div
-                key={event.id}
-                variants={slideInRight}
-                initial="initial"
-                animate="animate"
-                exit={{ opacity: 0, x: -20, transition: { duration: 0.2 } }}
-                layout
-              >
-                <EventItem event={event} />
-              </motion.div>
-            ))}
-          </AnimatePresence>
+          {isFetchingRealActivity ? (
+            <FeedState>Loading activity...</FeedState>
+          ) : hasActivityError ? (
+            <FeedState>Activity feed unavailable</FeedState>
+          ) : visibleEvents.length === 0 ? (
+            <FeedState>No recent activity</FeedState>
+          ) : (
+            <AnimatePresence mode="popLayout">
+              {visibleEvents.map((event) => (
+                <motion.div
+                  key={event.id}
+                  variants={slideInRight}
+                  initial="initial"
+                  animate="animate"
+                  exit={{ opacity: 0, x: -20, transition: { duration: 0.2 } }}
+                  layout
+                >
+                  <EventItem event={event} />
+                </motion.div>
+              ))}
+            </AnimatePresence>
+          )}
         </div>
       </div>
     </section>

--- a/frontend/src/hooks/useActivity.ts
+++ b/frontend/src/hooks/useActivity.ts
@@ -1,0 +1,23 @@
+import { useQuery } from '@tanstack/react-query';
+import { listActivity } from '../api/activity';
+
+export interface UseActivityEventsOptions {
+  enabled?: boolean;
+  limit?: number;
+  refetchIntervalMs?: number;
+}
+
+export function useActivityEvents({
+  enabled = true,
+  limit = 4,
+  refetchIntervalMs = 30_000,
+}: UseActivityEventsOptions = {}) {
+  return useQuery({
+    queryKey: ['activity', limit],
+    queryFn: () => listActivity({ limit }),
+    enabled,
+    refetchInterval: enabled ? refetchIntervalMs : false,
+    staleTime: refetchIntervalMs,
+    retry: false,
+  });
+}

--- a/frontend/src/lib/animations.ts
+++ b/frontend/src/lib/animations.ts
@@ -1,0 +1,46 @@
+import type { Variants } from 'framer-motion';
+
+export const fadeIn: Variants = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.24, ease: 'easeOut' } },
+};
+
+export const slideInRight: Variants = {
+  initial: { opacity: 0, x: 24 },
+  animate: { opacity: 1, x: 0, transition: { duration: 0.22, ease: 'easeOut' } },
+};
+
+export const staggerContainer: Variants = {
+  initial: {},
+  animate: {
+    transition: {
+      staggerChildren: 0.04,
+    },
+  },
+};
+
+export const staggerItem: Variants = {
+  initial: { opacity: 0, y: 8 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.18, ease: 'easeOut' } },
+};
+
+export const pageTransition: Variants = {
+  initial: { opacity: 0, y: 16 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.28, ease: 'easeOut' } },
+  exit: { opacity: 0, y: -8, transition: { duration: 0.16, ease: 'easeIn' } },
+};
+
+export const cardHover: Variants = {
+  rest: { y: 0, borderColor: 'var(--border, #1E1E2E)' },
+  hover: {
+    y: -4,
+    borderColor: 'var(--border-hover, #2D2D44)',
+    transition: { duration: 0.18, ease: 'easeOut' },
+  },
+};
+
+export const buttonHover: Variants = {
+  rest: { scale: 1 },
+  hover: { scale: 1.02, transition: { duration: 0.14, ease: 'easeOut' } },
+  tap: { scale: 0.98, transition: { duration: 0.08, ease: 'easeOut' } },
+};

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,72 @@
+export const LANG_COLORS: Record<string, string> = {
+  typescript: '#3178c6',
+  javascript: '#f7df1e',
+  rust: '#dea584',
+  python: '#3776ab',
+  solidity: '#627eea',
+  react: '#61dafb',
+  nextjs: '#ffffff',
+  solana: '#14f195',
+};
+
+function toDate(value: string | number | Date): Date | null {
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function pluralize(value: number, unit: string): string {
+  return `${value} ${unit}${value === 1 ? '' : 's'}`;
+}
+
+export function timeAgo(value: string | number | Date): string {
+  const date = toDate(value);
+  if (!date) return 'recently';
+
+  const seconds = Math.max(0, Math.floor((Date.now() - date.getTime()) / 1000));
+  if (seconds < 60) return 'just now';
+
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${pluralize(minutes, 'min')} ago`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${pluralize(hours, 'hour')} ago`;
+
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${pluralize(days, 'day')} ago`;
+
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${pluralize(months, 'month')} ago`;
+
+  return `${pluralize(Math.floor(months / 12), 'year')} ago`;
+}
+
+export function timeLeft(value: string | number | Date): string {
+  const date = toDate(value);
+  if (!date) return 'No deadline';
+
+  const seconds = Math.floor((date.getTime() - Date.now()) / 1000);
+  if (seconds <= 0) return 'Expired';
+
+  const minutes = Math.ceil(seconds / 60);
+  if (minutes < 60) return pluralize(minutes, 'min');
+
+  const hours = Math.ceil(minutes / 60);
+  if (hours < 24) return pluralize(hours, 'hour');
+
+  return pluralize(Math.ceil(hours / 24), 'day');
+}
+
+export function formatCurrency(amount: number | string, token = 'USDC'): string {
+  const numericAmount = Number(amount);
+  const displayAmount = Number.isFinite(numericAmount)
+    ? new Intl.NumberFormat('en-US', {
+        maximumFractionDigits: numericAmount >= 100 ? 0 : 2,
+      }).format(numericAmount)
+    : String(amount);
+
+  if (token.toUpperCase() === 'USDC' || token.toUpperCase() === 'USD') {
+    return `$${displayAmount}`;
+  }
+
+  return `${displayAmount} ${token}`;
+}


### PR DESCRIPTION
## Summary
- Replaces the hardcoded home page activity feed with `/api/activity` data through a typed activity API client and React Query hook.
- Adds 30-second auto-refresh, empty-state handling, and an unavailable-state fallback when the API cannot be reached.
- Adds shared frontend utility/animation helpers that existing components already import, and narrows `.gitignore` so `frontend/src/lib` source files are tracked.

## Verification
- `npm test -- activity-api.test.ts home-activity-feed.test.tsx`
- `npm run build`
- `git diff --check`

Note: full `npm test` still fails on existing unrelated test imports for missing Playwright/admin/tokenomics/disputes/private-backend modules; the new activity tests and production build pass.

## Bounty
Addresses SolFoundry/solfoundry#822.

Payment request: Solana wallet `BPX8AsqzNRmvFnTN5wGF8Zxsp5znwdZA5BEyEAWyhkCM`. If this bounty supports PayPal/manual payout instead, PayPal `stab.me.papi@gmail.com` is also available.
