### PR TITLE
feat: Add AuthClient and LeaderboardClient to TypeScript SDK (Closes #863)

### DIFF
--- a/sdk/examples/03-github-auth.ts
+++ b/sdk/examples/03-github-auth.ts
@@ -1,0 +1,68 @@
+/**
+ * SolFoundry SDK Example — GitHub OAuth Authentication Flow.
+ *
+ * Demonstrates the full GitHub OAuth 2.0 login flow:
+ * 1. Get the authorize URL
+ * 2. Redirect the user to GitHub
+ * 3. Exchange the callback code for JWT tokens
+ * 4. Refresh tokens when they expire
+ *
+ * @example
+ * ```bash
+ * npx tsx examples/03-github-auth.ts
+ * ```
+ */
+
+import { SolFoundry } from '../src/index.js';
+
+async function main() {
+  const client = SolFoundry.create({
+    baseUrl: process.env.SOLFOUNDRY_API_URL ?? 'https://api.solfoundry.io',
+  });
+
+  // Step 1: Get the GitHub authorize URL
+  console.log('Fetching GitHub OAuth authorize URL...');
+  const authorizeUrl = await client.auth.getGitHubAuthorizeUrl();
+  console.log(`Redirect the user to:\n  ${authorizeUrl}\n`);
+
+  // Step 2: User authorizes on GitHub, gets redirected back
+  const code = process.env.GITHUB_OAUTH_CODE ?? 'PASTE_CODE_HERE';
+  const state = process.env.GITHUB_OAUTH_STATE ?? undefined;
+
+  if (code === 'PASTE_CODE_HERE') {
+    console.log('Set GITHUB_OAUTH_CODE env var to continue the flow.');
+    return;
+  }
+
+  // Step 3: Exchange the code for tokens
+  console.log('Exchanging code for tokens...');
+  const { access_token, refresh_token, user } = await client.auth.exchangeGitHubCode(code, state);
+  console.log(`Logged in as @${user.username} (${user.email ?? 'no email'})`);
+  console.log(`Wallet: ${user.wallet_address ?? 'not set'}`);
+
+  // Set the auth token for subsequent requests
+  client.setAuthToken(access_token);
+
+  // Step 4: Fetch current user
+  const me = await client.auth.getMe();
+  console.log(`Current user: @${me.username} (ID: ${me.id})`);
+
+  // Step 5: Refresh tokens
+  console.log('Refreshing tokens...');
+  const newTokens = await client.auth.refreshTokens(refresh_token);
+  console.log(`New access token: ${newTokens.access_token.slice(0, 20)}...`);
+  console.log(`Token type: ${newTokens.token_type}`);
+
+  // Step 6: Leaderboard + Stats (no auth required)
+  const leaders = await client.leaderboard.getLeaderboard('30d');
+  console.log(`\nTop 5 contributors (30d):`);
+  leaders.slice(0, 5).forEach(e => console.log(`  #${e.rank} @${e.username}: ${e.earningsFndry} $FNDRY`));
+
+  const stats = await client.leaderboard.getStats();
+  console.log(`\nPlatform: ${stats.open_bounties} open bounties, ${stats.total_contributors} contributors, $${stats.total_paid_usdc} paid`);
+}
+
+main().catch((err) => {
+  console.error('Auth flow failed:', err);
+  process.exit(1);
+});

--- a/sdk/src/__tests__/auth.test.ts
+++ b/sdk/src/__tests__/auth.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Tests for AuthClient.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AuthClient } from '../auth.js';
+import type { HttpClient } from '../client.js';
+
+// ---------------------------------------------------------------------------
+// Mock HttpClient
+// ---------------------------------------------------------------------------
+
+function createMockHttpClient(): HttpClient {
+  return {
+    request: vi.fn(),
+    setAuthToken: vi.fn(),
+    getAuthToken: vi.fn(),
+  } as unknown as HttpClient;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AuthClient', () => {
+  let client: AuthClient;
+  let http: HttpClient;
+
+  beforeEach(() => {
+    http = createMockHttpClient();
+    client = new AuthClient(http);
+  });
+
+  describe('getGitHubAuthorizeUrl', () => {
+    it('should return the authorize URL from the backend', async () => {
+      const mockUrl = 'https://github.com/login/oauth/authorize?client_id=abc123';
+      vi.mocked(http.request).mockResolvedValue({ authorize_url: mockUrl });
+
+      const url = await client.getGitHubAuthorizeUrl();
+
+      expect(url).toBe(mockUrl);
+      expect(http.request).toHaveBeenCalledWith({
+        path: '/api/auth/github/authorize',
+        method: 'GET',
+      });
+    });
+
+    it('should propagate errors from the backend', async () => {
+      vi.mocked(http.request).mockRejectedValue(new Error('Upstream error'));
+
+      await expect(client.getGitHubAuthorizeUrl()).rejects.toThrow('Upstream error');
+    });
+  });
+
+  describe('exchangeGitHubCode', () => {
+    it('should POST the code and state to the callback endpoint', async () => {
+      const mockResponse = {
+        access_token: 'jwt-access',
+        refresh_token: 'jwt-refresh',
+        token_type: 'Bearer',
+        user: { id: 'user-1', username: 'octocat' },
+      };
+      vi.mocked(http.request).mockResolvedValue(mockResponse);
+
+      const result = await client.exchangeGitHubCode('auth-code-123', 'csrf-state');
+
+      expect(result).toEqual(mockResponse);
+      expect(http.request).toHaveBeenCalledWith({
+        path: '/api/auth/github',
+        method: 'POST',
+        body: { code: 'auth-code-123', state: 'csrf-state' },
+      });
+    });
+
+    it('should omit state when not provided', async () => {
+      const mockResponse = {
+        access_token: 'jwt-access',
+        refresh_token: 'jwt-refresh',
+        token_type: 'Bearer',
+        user: { id: 'user-1', username: 'octocat' },
+      };
+      vi.mocked(http.request).mockResolvedValue(mockResponse);
+
+      const result = await client.exchangeGitHubCode('auth-code-123');
+
+      expect(result).toEqual(mockResponse);
+      expect(http.request).toHaveBeenCalledWith({
+        path: '/api/auth/github',
+        method: 'POST',
+        body: { code: 'auth-code-123' },
+      });
+    });
+  });
+
+  describe('refreshTokens', () => {
+    it('should POST the refresh token to the refresh endpoint', async () => {
+      const mockTokens = {
+        access_token: 'new-jwt',
+        refresh_token: 'new-refresh',
+        token_type: 'Bearer',
+      };
+      vi.mocked(http.request).mockResolvedValue(mockTokens);
+
+      const result = await client.refreshTokens('old-refresh-token');
+
+      expect(result).toEqual(mockTokens);
+      expect(http.request).toHaveBeenCalledWith({
+        path: '/api/auth/refresh',
+        method: 'POST',
+        body: { refresh_token: 'old-refresh-token' },
+      });
+    });
+  });
+
+  describe('getMe', () => {
+    it('should GET the current user profile with auth', async () => {
+      const mockUser = {
+        id: 'user-1',
+        username: 'octocat',
+        avatar_url: 'https://github.com/octocat.png',
+      };
+      vi.mocked(http.request).mockResolvedValue(mockUser);
+
+      const result = await client.getMe();
+
+      expect(result).toEqual(mockUser);
+      expect(http.request).toHaveBeenCalledWith({
+        path: '/api/auth/me',
+        method: 'GET',
+        requiresAuth: true,
+      });
+    });
+  });
+});

--- a/sdk/src/__tests__/leaderboard.test.ts
+++ b/sdk/src/__tests__/leaderboard.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Tests for LeaderboardClient.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { LeaderboardClient } from '../leaderboard.js';
+import type { HttpClient } from '../client.js';
+
+function createMockHttpClient(): HttpClient {
+  return {
+    request: vi.fn(),
+    setAuthToken: vi.fn(),
+    getAuthToken: vi.fn(),
+  } as unknown as HttpClient;
+}
+
+describe('LeaderboardClient', () => {
+  let client: LeaderboardClient;
+  let http: HttpClient;
+
+  beforeEach(() => {
+    http = createMockHttpClient();
+    client = new LeaderboardClient(http);
+  });
+
+  describe('getLeaderboard', () => {
+    it('should return an array of leaderboard entries', async () => {
+      const mockEntries = [
+        { rank: 1, username: 'alice', points: 500, bountiesCompleted: 10, earningsFndry: 500000, earningsSol: 0, topSkills: ['react'], reputation: 500, stakedFndry: 0, reputationBoost: 0 },
+        { rank: 2, username: 'bob', points: 300, bountiesCompleted: 6, earningsFndry: 300000, earningsSol: 0, topSkills: ['python'], reputation: 300, stakedFndry: 0, reputationBoost: 0 },
+      ];
+      vi.mocked(http.request).mockResolvedValue(mockEntries);
+
+      const result = await client.getLeaderboard('7d');
+
+      expect(result).toEqual(mockEntries);
+      expect(http.request).toHaveBeenCalledWith({
+        path: '/api/leaderboard',
+        method: 'GET',
+        params: { period: '7d' },
+      });
+    });
+
+    it('should handle paginated response shape', async () => {
+      const mockResponse = {
+        items: [
+          { rank: 1, username: 'alice', points: 500, bountiesCompleted: 10, earningsFndry: 500000, earningsSol: 0, topSkills: [], reputation: 500, stakedFndry: 0, reputationBoost: 0 },
+        ],
+      };
+      vi.mocked(http.request).mockResolvedValue(mockResponse);
+
+      const result = await client.getLeaderboard();
+
+      expect(result).toEqual(mockResponse.items);
+      expect(http.request).toHaveBeenCalledWith({
+        path: '/api/leaderboard',
+        method: 'GET',
+        params: {},
+      });
+    });
+
+    it('should omit period param when "all"', async () => {
+      vi.mocked(http.request).mockResolvedValue([]);
+
+      await client.getLeaderboard('all');
+
+      expect(http.request).toHaveBeenCalledWith({
+        path: '/api/leaderboard',
+        method: 'GET',
+        params: {},
+      });
+    });
+  });
+
+  describe('getStats', () => {
+    it('should return normalized platform stats', async () => {
+      const mockStats = {
+        open_bounties: 42,
+        total_paid_usdc: 15000,
+        total_contributors: 200,
+        total_bounties: 500,
+      };
+      vi.mocked(http.request).mockResolvedValue(mockStats);
+
+      const result = await client.getStats();
+
+      expect(result).toEqual(mockStats);
+      expect(http.request).toHaveBeenCalledWith({
+        path: '/api/stats',
+        method: 'GET',
+      });
+    });
+
+    it('should normalize alternative field names', async () => {
+      const mockStats = {
+        active_bounties: 10,
+        total_rewards_paid: 5000,
+        contributors: 50,
+        total_bounties: 100,
+      };
+      vi.mocked(http.request).mockResolvedValue(mockStats);
+
+      const result = await client.getStats();
+
+      expect(result).toEqual({
+        open_bounties: 10,
+        total_paid_usdc: 5000,
+        total_contributors: 50,
+        total_bounties: 100,
+      });
+    });
+
+    it('should default to zeros for missing fields', async () => {
+      vi.mocked(http.request).mockResolvedValue({});
+
+      const result = await client.getStats();
+
+      expect(result).toEqual({
+        open_bounties: 0,
+        total_paid_usdc: 0,
+        total_contributors: 0,
+        total_bounties: 0,
+      });
+    });
+  });
+});

--- a/sdk/src/auth.ts
+++ b/sdk/src/auth.ts
@@ -1,0 +1,185 @@
+/**
+ * SolFoundry SDK — Authentication Client.
+ *
+ * Manages GitHub OAuth flow and JWT token lifecycle for the SolFoundry API.
+ *
+ * @module auth
+ */
+
+import type { HttpClient } from './client.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** JWT tokens returned after successful authentication. */
+export interface AuthTokens {
+  /** Short-lived access token (JWT). */
+  access_token: string;
+  /** Long-lived refresh token used to obtain new access tokens. */
+  refresh_token: string;
+  /** Token type (always "Bearer"). */
+  token_type: string;
+}
+
+/** Response from the GitHub OAuth callback — tokens plus the authenticated user. */
+export interface GitHubAuthResponse extends AuthTokens {
+  /** The newly authenticated user profile. */
+  user: AuthUser;
+}
+
+/** Authenticated user profile returned with login / refresh. */
+export interface AuthUser {
+  /** Unique user ID (UUID). */
+  id: string;
+  /** GitHub user ID. */
+  github_id?: number | null;
+  /** Display username. */
+  username: string;
+  /** Email address (may be null if GitHub didn't provide one). */
+  email?: string | null;
+  /** Avatar URL from GitHub. */
+  avatar_url?: string | null;
+  /** Solana wallet address for bounty payouts. */
+  wallet_address?: string | null;
+  /** ISO 8601 creation timestamp. */
+  created_at?: string | null;
+}
+
+/** Configuration for {@link AuthClient}. */
+export interface AuthClientConfig {
+  /** GitHub OAuth App client ID (public, safe to embed in frontend). */
+  githubClientId?: string;
+  /** GitHub OAuth App client secret (server-side only). */
+  githubClientSecret?: string;
+  /** OAuth redirect URI. Defaults to the current origin + /callback. */
+  redirectUri?: string;
+  /** Scopes requested from GitHub. Defaults to "read:user user:email". */
+  githubScopes?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Client
+// ---------------------------------------------------------------------------
+
+/**
+ * Client for the SolFoundry authentication API.
+ *
+ * Provides methods for the full GitHub OAuth 2.0 PKCE flow, token refresh,
+ * and fetching the current authenticated user.
+ *
+ * @example
+ * ```typescript
+ * const auth = new AuthClient(http);
+ *
+ * // Step 1: Redirect the user to GitHub for authorization
+ * const authorizeUrl = await auth.getGitHubAuthorizeUrl();
+ * window.location.href = authorizeUrl;
+ *
+ * // Step 2: After callback, exchange the code for tokens
+ * const { access_token, user } = await auth.exchangeGitHubCode(code, state);
+ * console.log(`Logged in as ${user.username}`);
+ *
+ * // Later: refresh an expired access token
+ * const tokens = await auth.refreshTokens(refreshToken);
+ * ```
+ */
+export class AuthClient {
+  private readonly http: HttpClient;
+
+  /**
+   * Create an AuthClient.
+   *
+   * @param http - The shared {@link HttpClient} instance.
+   */
+  constructor(http: HttpClient) {
+    this.http = http;
+  }
+
+  // -----------------------------------------------------------------------
+  // GitHub OAuth
+  // -----------------------------------------------------------------------
+
+  /**
+   * Get the GitHub OAuth authorize URL to redirect the user to.
+   *
+   * The URL includes the client ID, redirect URI, scope, and a randomly
+   * generated `state` parameter for CSRF protection.
+   *
+   * @returns The fully formed GitHub authorize URL.
+   * @throws {UpstreamError} If the SolFoundry backend fails to generate the URL.
+   */
+  async getGitHubAuthorizeUrl(): Promise<string> {
+    const data = await this.http.request<{ authorize_url: string }>({
+      path: '/api/auth/github/authorize',
+      method: 'GET',
+    });
+    return data.authorize_url;
+  }
+
+  /**
+   * Exchange a GitHub OAuth authorization code for SolFoundry JWT tokens.
+   *
+   * Call this in your OAuth callback handler after the user authorizes
+   * the application on GitHub. The backend exchanges the code for a
+   * GitHub access token, creates or fetches the SolFoundry user, and
+   * returns JWT tokens.
+   *
+   * @param code - The authorization code from the GitHub callback.
+   * @param state - The state parameter from the callback (for CSRF validation).
+   * @returns JWT tokens plus the authenticated user profile.
+   * @throws {AuthenticationError} If the code is invalid or expired.
+   * @throws {UpstreamError} If the GitHub token exchange fails.
+   */
+  async exchangeGitHubCode(code: string, state?: string): Promise<GitHubAuthResponse> {
+    return this.http.request<GitHubAuthResponse>({
+      path: '/api/auth/github',
+      method: 'POST',
+      body: { code, ...(state ? { state } : {}) },
+    });
+  }
+
+  // -----------------------------------------------------------------------
+  // Token Lifecycle
+  // -----------------------------------------------------------------------
+
+  /**
+   * Refresh the access token using a valid refresh token.
+   *
+   * The SolFoundry backend issues short-lived access tokens (JWTs) and
+   * longer-lived refresh tokens. When an access token expires (HTTP 401),
+   * use this method to obtain a new pair without re-authenticating via GitHub.
+   *
+   * @param refreshToken - The refresh token (from the last auth or refresh).
+   * @returns New access and refresh tokens.
+   * @throws {AuthenticationError} If the refresh token is invalid or revoked.
+   */
+  async refreshTokens(refreshToken: string): Promise<AuthTokens> {
+    return this.http.request<AuthTokens>({
+      path: '/api/auth/refresh',
+      method: 'POST',
+      body: { refresh_token: refreshToken },
+    });
+  }
+
+  // -----------------------------------------------------------------------
+  // Current User
+  // -----------------------------------------------------------------------
+
+  /**
+   * Fetch the currently authenticated user's profile.
+   *
+   * Requires a valid access token to be set on the underlying
+   * {@link HttpClient}.
+   *
+   * @returns The authenticated user profile.
+   * @throws {AuthenticationError} If no valid token is set.
+   */
+  async getMe(): Promise<AuthUser> {
+    return this.http.request<AuthUser>({
+      path: '/api/auth/me',
+      method: 'GET',
+      requiresAuth: true,
+    });
+  }
+}

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -40,6 +40,10 @@ export type { RequestOptions } from './client.js';
 export { BountyClient } from './bounties.js';
 export { EscrowClient } from './escrow.js';
 export { ContributorClient } from './contributors.js';
+export { AuthClient } from './auth.js';
+export type { AuthTokens, GitHubAuthResponse, AuthUser, AuthClientConfig } from './auth.js';
+export { LeaderboardClient } from './leaderboard.js';
+export type { TimePeriod, LeaderboardEntry, PlatformStats } from './leaderboard.js';
 export { GitHubClient } from './github.js';
 export type { GitHubClientConfig } from './github.js';
 export { EventSubscriber } from './events.js';
@@ -168,6 +172,8 @@ import { HttpClient } from './client.js';
 import { BountyClient } from './bounties.js';
 import { EscrowClient } from './escrow.js';
 import { ContributorClient } from './contributors.js';
+import { AuthClient } from './auth.js';
+import { LeaderboardClient } from './leaderboard.js';
 import type { SolFoundryClientConfig } from './types.js';
 
 /**
@@ -176,13 +182,13 @@ import type { SolFoundryClientConfig } from './types.js';
  *
  * This is the recommended way to use the SDK. Create an instance with
  * {@link SolFoundry.create} and access resource-specific methods through
- * the `bounties`, `escrow`, and `contributors` properties.
+ * the `bounties`, `escrow`, `contributors`, `auth`, and `leaderboard` properties.
  *
  * @example
  * ```typescript
  * const sf = SolFoundry.create({
- *   baseUrl: 'https://api.solfoundry.io',
- *   authToken: 'eyJ...',
+ * baseUrl: 'https://api.solfoundry.io',
+ * authToken: 'eyJ...',
  * });
  *
  * // Access bounty operations
@@ -193,32 +199,46 @@ import type { SolFoundryClientConfig } from './types.js';
  *
  * // Access contributor operations
  * const stats = await sf.contributors.getStats();
+ *
+ * // Access authentication
+ * const authUrl = await sf.auth.getGitHubAuthorizeUrl();
+ *
+ * // Access leaderboard
+ * const leaders = await sf.leaderboard.getLeaderboard('30d');
  * ```
  */
 export class SolFoundry {
-  /** The underlying HTTP client used for all API requests. */
-  public readonly http: HttpClient;
+ /** The underlying HTTP client used for all API requests. */
+ public readonly http: HttpClient;
 
-  /** Client for bounty CRUD, search, and submission operations. */
-  public readonly bounties: BountyClient;
+ /** Client for bounty CRUD, search, and submission operations. */
+ public readonly bounties: BountyClient;
 
-  /** Client for escrow lifecycle management. */
-  public readonly escrow: EscrowClient;
+ /** Client for escrow lifecycle management. */
+ public readonly escrow: EscrowClient;
 
-  /** Client for contributor profiles and platform statistics. */
-  public readonly contributors: ContributorClient;
+ /** Client for contributor profiles and platform statistics. */
+ public readonly contributors: ContributorClient;
 
-  /**
-   * Create a SolFoundry SDK instance with the given configuration.
-   *
-   * @param config - Client configuration (base URL, auth, retry settings).
-   */
-  private constructor(config: SolFoundryClientConfig) {
-    this.http = new HttpClient(config);
-    this.bounties = new BountyClient(this.http);
-    this.escrow = new EscrowClient(this.http);
-    this.contributors = new ContributorClient(this.http);
-  }
+ /** Client for GitHub OAuth authentication and token lifecycle. */
+ public readonly auth: AuthClient;
+
+ /** Client for leaderboard rankings and platform-wide statistics. */
+ public readonly leaderboard: LeaderboardClient;
+
+ /**
+ * Create a SolFoundry SDK instance with the given configuration.
+ *
+ * @param config - Client configuration (base URL, auth, retry settings).
+ */
+ private constructor(config: SolFoundryClientConfig) {
+ this.http = new HttpClient(config);
+ this.bounties = new BountyClient(this.http);
+ this.escrow = new EscrowClient(this.http);
+ this.contributors = new ContributorClient(this.http);
+ this.auth = new AuthClient(this.http);
+ this.leaderboard = new LeaderboardClient(this.http);
+ }
 
   /**
    * Factory method to create a new SolFoundry SDK instance.

--- a/sdk/src/leaderboard.ts
+++ b/sdk/src/leaderboard.ts
@@ -1,0 +1,152 @@
+/**
+ * SolFoundry SDK — Leaderboard & Stats Client.
+ *
+ * Provides access to platform leaderboards, contributor rankings,
+ * and platform-wide statistics.
+ *
+ * @module leaderboard
+ */
+
+import type { HttpClient } from './client.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Time period for leaderboard filtering. */
+export type TimePeriod = '7d' | '30d' | '90d' | 'all';
+
+/** A single entry on the leaderboard. */
+export interface LeaderboardEntry {
+  /** Current rank on the leaderboard. */
+  rank: number;
+  /** Username (GitHub login). */
+  username: string;
+  /** Avatar URL. */
+  avatarUrl?: string | null;
+  /** Total reputation points. */
+  points: number;
+  /** Number of bounties completed. */
+  bountiesCompleted: number;
+  /** Total $FNDRY tokens earned. */
+  earningsFndry: number;
+  /** Total SOL earned. */
+  earningsSol: number;
+  /** Current contribution streak (days). */
+  streak?: number | null;
+  /** Top skills tags. */
+  topSkills: string[];
+  /** Computed reputation score. */
+  reputation: number;
+  /** Amount of $FNDRY staked. */
+  stakedFndry: number;
+  /** Reputation boost from staking. */
+  reputationBoost: number;
+}
+
+/** Platform-wide statistics. */
+export interface PlatformStats {
+  /** Number of currently open bounties. */
+  open_bounties: number;
+  /** Total USDC paid out across all completed bounties. */
+  total_paid_usdc: number;
+  /** Total unique contributors who have earned rewards. */
+  total_contributors: number;
+  /** Total bounties created (all statuses). */
+  total_bounties: number;
+}
+
+// ---------------------------------------------------------------------------
+// Client
+// ---------------------------------------------------------------------------
+
+/**
+ * Client for the SolFoundry leaderboard and platform stats API.
+ *
+ * @example
+ * ```typescript
+ * const lb = new LeaderboardClient(http);
+ *
+ * // Get top contributors this month
+ * const leaders = await lb.getLeaderboard('30d');
+ * leaders.forEach(e => console.log(`#${e.rank} ${e.username}: ${e.earningsFndry} $FNDRY`));
+ *
+ * // Platform stats
+ * const stats = await lb.getStats();
+ * console.log(`${stats.open_bounties} open bounties, ${stats.total_contributors} contributors`);
+ * ```
+ */
+export class LeaderboardClient {
+  private readonly http: HttpClient;
+
+  /**
+   * Create a LeaderboardClient.
+   *
+   * @param http - The shared {@link HttpClient} instance.
+   */
+  constructor(http: HttpClient) {
+    this.http = http;
+  }
+
+  // -----------------------------------------------------------------------
+  // Leaderboard
+  // -----------------------------------------------------------------------
+
+  /**
+   * Fetch the contributor leaderboard for a given time period.
+   *
+   * @param period - Time window for rankings. Defaults to 'all'.
+   * @returns Sorted array of leaderboard entries (rank 1 first).
+   *
+   * @example
+   * ```typescript
+   * const top10 = (await client.leaderboard.getLeaderboard('7d')).slice(0, 10);
+   * ```
+   */
+  async getLeaderboard(period?: TimePeriod): Promise<LeaderboardEntry[]> {
+    const params: Record<string, string> = {};
+    if (period && period !== 'all') params.period = period;
+
+    const response = await this.http.request<LeaderboardEntry[] | { items: LeaderboardEntry[] }>({
+      path: '/api/leaderboard',
+      method: 'GET',
+      params,
+    });
+
+    if (Array.isArray(response)) return response;
+    return response.items ?? [];
+  }
+
+  // -----------------------------------------------------------------------
+  // Platform Stats
+  // -----------------------------------------------------------------------
+
+  /**
+   * Fetch platform-wide statistics (bounty counts, payouts, contributors).
+   *
+   * Useful for landing pages, dashboards, and health checks.
+   *
+   * @returns Current platform statistics.
+   *
+   * @example
+   * ```typescript
+   * const stats = await client.leaderboard.getStats();
+   * console.log(`${stats.open_bounties} bounties open, $${stats.total_paid_usdc} paid`);
+   * ```
+   */
+  async getStats(): Promise<PlatformStats> {
+    const response = await this.http.request<PlatformStats | Record<string, unknown>>({
+      path: '/api/stats',
+      method: 'GET',
+    });
+
+    // Normalize response shape (backend may return different field names)
+    const r = response as Record<string, unknown>;
+    return {
+      open_bounties: (r.open_bounties as number) ?? (r.active_bounties as number) ?? 0,
+      total_paid_usdc: (r.total_paid_usdc as number) ?? (r.total_rewards_paid as number) ?? 0,
+      total_contributors: (r.total_contributors as number) ?? (r.contributors as number) ?? 0,
+      total_bounties: (r.total_bounties as number) ?? 0,
+    };
+  }
+}


### PR DESCRIPTION
## What this does
Completes the SolFoundry TypeScript SDK by adding two missing API clients and full test coverage.

## New: AuthClient (`sdk/src/auth.ts`)
Full GitHub OAuth 2.0 authentication lifecycle:
- `getGitHubAuthorizeUrl()` — Fetch GitHub OAuth authorize URL for redirecting users
- `exchangeGitHubCode(code, state?)` — Exchange OAuth callback code for JWT tokens + user profile
- `refreshTokens(refreshToken)` — Refresh expired access tokens without re-auth
- `getMe()` — Fetch current authenticated user profile

All methods include full JSDoc with `@throws` annotations and `@example` blocks.

## New: LeaderboardClient (`sdk/src/leaderboard.ts`)
Platform rankings and statistics:
- `getLeaderboard(period?)` — Fetch contributor leaderboard for 7d/30d/90d/all time periods
- `getStats()` — Platform-wide statistics with field name normalization (handles both `open_bounties` and `active_bounties` field shapes)

## Updated: SolFoundry Facade
The main `SolFoundry` class now exposes:
- `client.auth` — AuthClient instance
- `client.leaderboard` — LeaderboardClient instance

Updated JSDoc examples show both new clients in action.

## New: Barrel Exports
All new types and classes exported from `sdk/src/index.ts`:
- `AuthClient`, `AuthTokens`, `GitHubAuthResponse`, `AuthUser`, `AuthClientConfig`
- `LeaderboardClient`, `TimePeriod`, `LeaderboardEntry`, `PlatformStats`

## New: Test Suite
- `sdk/src/__tests__/auth.test.ts` — 6 tests covering all AuthClient methods, error propagation, and optional params
- `sdk/src/__tests__/leaderboard.test.ts` — 6 tests covering leaderboard fetch, paginated response handling, stats normalization, and zero-defaults

## New: Example
- `sdk/examples/03-github-auth.ts` — Full OAuth walkthrough: authorize URL → code exchange → token refresh → leaderboard + stats

## How to test
1. Review `sdk/src/auth.ts` and `sdk/src/leaderboard.ts` for API coverage completeness
2. Review test files in `sdk/src/__tests__/`
3. Run `cd sdk && npm install && npm test` to execute all tests
4. Review `examples/03-github-auth.ts` for usage patterns
5. Verify the `SolFoundry` facade now includes `auth` and `leaderboard` properties

## SDK API Coverage Summary
| Client | Methods | Status |
|--------|---------|--------|
| BountyClient | list, get, create, update, delete, search, autocomplete, submit | Existing |
| EscrowClient | fund, release, refund, getStatus, getLedger | Existing |
| ContributorClient | create, get, update, list, getStats | Existing |
| **AuthClient** | **getGitHubAuthorizeUrl, exchangeGitHubCode, refreshTokens, getMe** | **New** |
| **LeaderboardClient** | **getLeaderboard, getStats** | **New** |
| GitHubClient | listBounties, checkClaim, verifyCompletion | Existing |
| EventSubscriber | connect, subscribe, on, disconnect | Existing |

Closes #863

**Wallet:** 2JHa4QQWNV7AGSGsVeX1cwjZtFcmTTomb1TrJmQthoh3