### PR TITLE
Fix GitHub OAuth sign-in redirect

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,8 @@ REDIS_URL=redis://redis:6379/0
 # GitHub
 GITHUB_TOKEN=
 GITHUB_WEBHOOK_SECRET=
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
 
 # Solana - defaults to devnet for safe local development
 SOLANA_RPC_URL=https://api.devnet.solana.com
@@ -30,6 +32,7 @@ SOLANA_RPC_URL=https://api.devnet.solana.com
 # Frontend
 FRONTEND_PORT=3000
 VITE_API_URL=http://localhost:8000
+VITE_GITHUB_CLIENT_ID=
 
 # Deploy health-check URLs (set as GitHub repository variables, not secrets)
 STAGING_HEALTH_URL=https://staging-api.solfoundry.org/health

--- a/frontend/src/__tests__/auth.test.ts
+++ b/frontend/src/__tests__/auth.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildGitHubAuthorizeUrl, exchangeGitHubCode, getGitHubAuthorizeUrl } from '../api/auth';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function mockResponse(body: unknown, status = 200, statusText = 'OK'): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText,
+    json: () => Promise.resolve(body),
+    headers: new Headers({ 'content-type': 'application/json' }),
+  } as Response;
+}
+
+describe('GitHub OAuth URL handling', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    sessionStorage.clear();
+    vi.stubEnv('VITE_GITHUB_CLIENT_ID', 'test-client-id');
+  });
+
+  it('builds a direct GitHub authorize URL with callback and state', () => {
+    const url = new URL(buildGitHubAuthorizeUrl());
+
+    expect(url.origin + url.pathname).toBe('https://github.com/login/oauth/authorize');
+    expect(url.searchParams.get('client_id')).toBe('test-client-id');
+    expect(url.searchParams.get('redirect_uri')).toBe(`${window.location.origin}/auth/github/callback`);
+    expect(url.searchParams.get('scope')).toBe('read:user user:email');
+    expect(url.searchParams.get('state')).toBeTruthy();
+    expect(sessionStorage.getItem('sf_github_oauth_state')).toBe(url.searchParams.get('state'));
+  });
+
+  it('prefers backend-provided authorize URL when available', async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse({ authorize_url: 'https://example.test/oauth' }));
+
+    await expect(getGitHubAuthorizeUrl()).resolves.toBe('https://example.test/oauth');
+  });
+
+  it('falls back to direct GitHub authorize URL when backend authorize endpoint is unavailable', async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse({ detail: 'Not found' }, 404, 'Not Found'));
+
+    const url = new URL(await getGitHubAuthorizeUrl());
+
+    expect(url.origin + url.pathname).toBe('https://github.com/login/oauth/authorize');
+    expect(url.searchParams.get('client_id')).toBe('test-client-id');
+  });
+
+  it('rejects callback exchanges when OAuth state does not match', async () => {
+    sessionStorage.setItem('sf_github_oauth_state', 'expected-state');
+
+    await expect(exchangeGitHubCode('code-123', 'wrong-state')).rejects.toThrow('Invalid GitHub OAuth state');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -11,12 +11,61 @@ export interface GitHubCallbackResponse extends AuthTokens {
   user: User;
 }
 
+const GITHUB_AUTHORIZE_URL = 'https://github.com/login/oauth/authorize';
+const GITHUB_OAUTH_STATE_KEY = 'sf_github_oauth_state';
+const GITHUB_OAUTH_SCOPE = 'read:user user:email';
+
+function getGitHubClientId(): string | null {
+  const clientId = import.meta.env?.VITE_GITHUB_CLIENT_ID;
+  return typeof clientId === 'string' && clientId.trim() !== '' ? clientId.trim() : null;
+}
+
+function createOAuthState(): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+export function buildGitHubAuthorizeUrl(): string {
+  const clientId = getGitHubClientId();
+  if (!clientId) {
+    throw new Error('VITE_GITHUB_CLIENT_ID is required for GitHub OAuth fallback');
+  }
+
+  const state = createOAuthState();
+  sessionStorage.setItem(GITHUB_OAUTH_STATE_KEY, state);
+
+  const url = new URL(GITHUB_AUTHORIZE_URL);
+  url.searchParams.set('client_id', clientId);
+  url.searchParams.set('redirect_uri', `${window.location.origin}/auth/github/callback`);
+  url.searchParams.set('scope', GITHUB_OAUTH_SCOPE);
+  url.searchParams.set('state', state);
+  return url.toString();
+}
+
 export async function getGitHubAuthorizeUrl(): Promise<string> {
-  const data = await apiClient<{ authorize_url: string }>('/api/auth/github/authorize');
-  return data.authorize_url;
+  try {
+    const data = await apiClient<{ authorize_url: string }>('/api/auth/github/authorize');
+    if (data.authorize_url) return data.authorize_url;
+  } catch {
+    return buildGitHubAuthorizeUrl();
+  }
+
+  return buildGitHubAuthorizeUrl();
+}
+
+export async function redirectToGitHubSignIn(): Promise<void> {
+  window.location.href = await getGitHubAuthorizeUrl();
 }
 
 export async function exchangeGitHubCode(code: string, state?: string): Promise<GitHubCallbackResponse> {
+  const expectedState = sessionStorage.getItem(GITHUB_OAUTH_STATE_KEY);
+  if (expectedState && state !== expectedState) {
+    throw new Error('Invalid GitHub OAuth state');
+  }
+  sessionStorage.removeItem(GITHUB_OAUTH_STATE_KEY);
+
   return apiClient<GitHubCallbackResponse>('/api/auth/github', {
     method: 'POST',
     body: { code, ...(state ? { state } : {}) },

--- a/frontend/src/components/auth/AuthGuard.tsx
+++ b/frontend/src/components/auth/AuthGuard.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { GitBranch } from 'lucide-react';
 import { useAuth } from '../../hooks/useAuth';
-import { getGitHubAuthorizeUrl } from '../../api/auth';
+import { redirectToGitHubSignIn } from '../../api/auth';
 
 interface AuthGuardProps {
   children: React.ReactNode;
@@ -22,13 +22,7 @@ export function AuthGuard({ children }: AuthGuardProps) {
 
   if (!isAuthenticated) {
     const handleSignIn = async () => {
-      try {
-        const url = await getGitHubAuthorizeUrl();
-        window.location.href = url;
-      } catch {
-        // fallback: redirect to backend OAuth endpoint directly
-        window.location.href = '/api/auth/github/authorize';
-      }
+      await redirectToGitHubSignIn();
     };
 
     return (

--- a/frontend/src/components/bounty/BountyDetail.tsx
+++ b/frontend/src/components/bounty/BountyDetail.tsx
@@ -7,6 +7,7 @@ import { timeLeft, timeAgo, formatCurrency, LANG_COLORS } from '../../lib/utils'
 import { useAuth } from '../../hooks/useAuth';
 import { SubmissionForm } from './SubmissionForm';
 import { fadeIn } from '../../lib/animations';
+import { redirectToGitHubSignIn } from '../../api/auth';
 
 interface BountyDetailProps {
   bounty: Bounty;
@@ -101,12 +102,15 @@ export function BountyDetail({ bounty }: BountyDetailProps) {
               ) : (
                 <div className="text-center py-6">
                   <p className="text-text-muted text-sm mb-4">Sign in with GitHub to submit a solution.</p>
-                  <a
-                    href="/api/auth/github/authorize"
+                  <button
+                    type="button"
+                    onClick={() => {
+                      void redirectToGitHubSignIn();
+                    }}
                     className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-forge-800 border border-border hover:border-border-hover text-text-primary text-sm font-medium transition-all duration-200"
                   >
                     Sign in with GitHub
-                  </a>
+                  </button>
                 </div>
               )}
             </div>

--- a/frontend/src/components/home/HeroSection.tsx
+++ b/frontend/src/components/home/HeroSection.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { motion, useInView, animate, useMotionValue } from 'framer-motion';
 import { useStats } from '../../hooks/useStats';
-import { getGitHubAuthorizeUrl } from '../../api/auth';
+import { redirectToGitHubSignIn } from '../../api/auth';
 import { useAuth } from '../../hooks/useAuth';
 import { buttonHover, fadeIn } from '../../lib/animations';
 
@@ -78,12 +78,7 @@ export function HeroSection() {
   }, []);
 
   const handleSignIn = async () => {
-    try {
-      const url = await getGitHubAuthorizeUrl();
-      window.location.href = url;
-    } catch {
-      window.location.href = '/api/auth/github/authorize';
-    }
+    await redirectToGitHubSignIn();
   };
 
   return (

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -4,7 +4,7 @@ import { Menu, X, ChevronDown, LogOut, User } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useAuth } from '../../hooks/useAuth';
 import { useStats } from '../../hooks/useStats';
-import { getGitHubAuthorizeUrl } from '../../api/auth';
+import { redirectToGitHubSignIn } from '../../api/auth';
 
 const GitHubIcon = () => (
   <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
@@ -34,13 +34,7 @@ export function Navbar() {
   }, []);
 
   const handleGitHubSignIn = async () => {
-    try {
-      const url = await getGitHubAuthorizeUrl();
-      window.location.href = url;
-    } catch {
-      // Fallback: direct to backend authorize endpoint
-      window.location.href = '/api/auth/github/authorize';
-    }
+    await redirectToGitHubSignIn();
   };
 
   const isActive = (to: string) => {

--- a/frontend/src/lib/animations.ts
+++ b/frontend/src/lib/animations.ts
@@ -1,0 +1,47 @@
+import type { Variants } from 'framer-motion';
+
+export const fadeIn: Variants = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.28, ease: 'easeOut' } },
+};
+
+export const pageTransition: Variants = {
+  initial: { opacity: 0, y: 16 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.32, ease: 'easeOut' } },
+  exit: { opacity: 0, y: -8, transition: { duration: 0.18, ease: 'easeIn' } },
+};
+
+export const staggerContainer: Variants = {
+  initial: {},
+  animate: {
+    transition: {
+      staggerChildren: 0.07,
+      delayChildren: 0.04,
+    },
+  },
+};
+
+export const staggerItem: Variants = {
+  initial: { opacity: 0, y: 14 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.24, ease: 'easeOut' } },
+};
+
+export const cardHover: Variants = {
+  rest: { y: 0, scale: 1 },
+  hover: {
+    y: -3,
+    scale: 1.01,
+    transition: { duration: 0.18, ease: 'easeOut' },
+  },
+};
+
+export const buttonHover: Variants = {
+  rest: { scale: 1 },
+  hover: { scale: 1.03, transition: { duration: 0.15, ease: 'easeOut' } },
+  tap: { scale: 0.98, transition: { duration: 0.08, ease: 'easeOut' } },
+};
+
+export const slideInRight: Variants = {
+  initial: { opacity: 0, x: 24 },
+  animate: { opacity: 1, x: 0, transition: { duration: 0.24, ease: 'easeOut' } },
+};

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,63 @@
+export const LANG_COLORS: Record<string, string> = {
+  TypeScript: '#3178c6',
+  JavaScript: '#f1e05a',
+  Python: '#3572A5',
+  Rust: '#dea584',
+  Go: '#00ADD8',
+  Solidity: '#AA6746',
+  React: '#61dafb',
+  Next: '#ffffff',
+  Frontend: '#00E676',
+  Backend: '#E040FB',
+  Docs: '#8b949e',
+};
+
+export function formatCurrency(amount: number, token = 'USDC'): string {
+  const value = Number.isFinite(amount) ? amount : 0;
+  const normalizedToken = token.toUpperCase();
+
+  if (normalizedToken === 'USDC' || normalizedToken === 'USD') {
+    return `$${value.toLocaleString(undefined, { maximumFractionDigits: 2 })}`;
+  }
+
+  return `${value.toLocaleString(undefined, { maximumFractionDigits: 2 })} ${token}`;
+}
+
+export function timeAgo(value: string | Date): string {
+  const date = new Date(value);
+  const diffMs = Date.now() - date.getTime();
+  if (!Number.isFinite(diffMs)) return '';
+
+  const seconds = Math.max(0, Math.floor(diffMs / 1000));
+  if (seconds < 60) return 'just now';
+
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo ago`;
+
+  return `${Math.floor(months / 12)}y ago`;
+}
+
+export function timeLeft(value: string | Date): string {
+  const date = new Date(value);
+  const diffMs = date.getTime() - Date.now();
+  if (!Number.isFinite(diffMs)) return '';
+  if (diffMs <= 0) return 'Expired';
+
+  const minutes = Math.ceil(diffMs / 60_000);
+  if (minutes < 60) return `${minutes}m left`;
+
+  const hours = Math.ceil(minutes / 60);
+  if (hours < 24) return `${hours}h left`;
+
+  const days = Math.ceil(hours / 24);
+  return `${days}d left`;
+}


### PR DESCRIPTION
## Summary
- Fixes #821
- Centralizes GitHub sign-in redirects through one OAuth helper
- Falls back to the official GitHub authorize URL when `/api/auth/github/authorize` is unavailable, instead of redirecting users to a 404-prone relative API route
- Adds client-side OAuth state generation/storage and callback state validation before exchanging the code
- Replaces remaining hard-coded `/api/auth/github/authorize` sign-in entry points
- Adds missing shared frontend utility modules required for the production build

## Verification
- `npm test -- auth.test.ts --run`
- `npm run build`
- `git diff --check`

## Notes
- `npm test -- --run` still fails on existing baseline issues unrelated to this PR: missing Playwright dependency for `frontend/tests/e2e/*` and many existing tests importing components/modules that are not present in the repo. The focused OAuth tests and production build pass.

## Bounty
Submitting for the T1 bounty in #821. Payout details can be coordinated after review/merge.