### PR TITLE
feat: add bounty search, toasts, and activity feed

### DIFF
--- a/frontend/src/api/activity.ts
+++ b/frontend/src/api/activity.ts
@@ -1,0 +1,43 @@
+import { apiClient } from '../services/apiClient';
+
+export type ActivityEventType = 'completed' | 'submitted' | 'posted' | 'review';
+
+export interface ActivityEvent {
+  id: string;
+  type: ActivityEventType;
+  username: string;
+  avatar_url?: string | null;
+  detail: string;
+  timestamp: string;
+}
+
+type RawActivityEvent = Partial<ActivityEvent> & {
+  created_at?: string;
+  message?: string;
+  actor?: string;
+  user?: string;
+};
+
+function normalizeActivityEvent(event: RawActivityEvent, index: number): ActivityEvent {
+  return {
+    id: event.id ?? `${event.type ?? 'activity'}-${event.timestamp ?? event.created_at ?? index}`,
+    type: event.type ?? 'posted',
+    username: event.username ?? event.actor ?? event.user ?? 'SolFoundry',
+    avatar_url: event.avatar_url ?? null,
+    detail: event.detail ?? event.message ?? 'updated a bounty',
+    timestamp: event.timestamp ?? event.created_at ?? new Date().toISOString(),
+  };
+}
+
+export async function listActivity(): Promise<ActivityEvent[]> {
+  const response = await apiClient<ActivityEvent[] | { items?: RawActivityEvent[]; events?: RawActivityEvent[] }>(
+    '/api/activity',
+    { retries: 1 },
+  );
+
+  const events = Array.isArray(response)
+    ? response
+    : response.items ?? response.events ?? [];
+
+  return events.map(normalizeActivityEvent);
+}

--- a/frontend/src/api/bounties.ts
+++ b/frontend/src/api/bounties.ts
@@ -15,6 +15,7 @@ export interface BountiesListParams {
   skill?: string;
   tier?: string;
   reward_token?: string;
+  search?: string;
 }
 
 export interface BountiesListResponse {
@@ -26,11 +27,19 @@ export interface BountiesListResponse {
 
 // Map backend field names to frontend types (funding_token -> reward_token)
 function mapBounty(b: Bounty): Bounty {
-  const raw = b as Bounty & { funding_token?: string };
+  const raw = b as Bounty & {
+    funding_token?: string;
+    required_skills?: string[];
+    tier?: Bounty['tier'] | 1 | 2 | 3;
+  };
   if (!raw.reward_token && raw.funding_token) {
     raw.reward_token = raw.funding_token as Bounty['reward_token'];
   }
   if (!raw.reward_token) raw.reward_token = 'FNDRY';
+  if (!raw.skills && raw.required_skills) raw.skills = raw.required_skills;
+  if (typeof raw.tier === 'number') raw.tier = `T${raw.tier}` as Bounty['tier'];
+  if (!raw.skills) raw.skills = [];
+  if (raw.submission_count == null) raw.submission_count = 0;
   return raw;
 }
 

--- a/frontend/src/components/bounty/BountyGrid.tsx
+++ b/frontend/src/components/bounty/BountyGrid.tsx
@@ -1,7 +1,7 @@
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { ChevronDown, Loader2, Plus } from 'lucide-react';
+import { ChevronDown, Loader2, Plus, Search, X } from 'lucide-react';
 import { BountyCard } from './BountyCard';
 import { useInfiniteBounties } from '../../hooks/useBounties';
 import { staggerContainer, staggerItem } from '../../lib/animations';
@@ -11,11 +11,22 @@ const FILTER_SKILLS = ['All', 'TypeScript', 'Rust', 'Solidity', 'Python', 'Go', 
 export function BountyGrid() {
   const [activeSkill, setActiveSkill] = useState<string>('All');
   const [statusFilter, setStatusFilter] = useState<string>('open');
+  const [searchInput, setSearchInput] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
 
-  const params = {
+  useEffect(() => {
+    const id = window.setTimeout(() => {
+      setDebouncedSearch(searchInput.trim());
+    }, 250);
+
+    return () => window.clearTimeout(id);
+  }, [searchInput]);
+
+  const params = useMemo(() => ({
     status: statusFilter,
     skill: activeSkill !== 'All' ? activeSkill : undefined,
-  };
+    search: debouncedSearch || undefined,
+  }), [activeSkill, debouncedSearch, statusFilter]);
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, isError } =
     useInfiniteBounties(params);
@@ -53,21 +64,45 @@ export function BountyGrid() {
           </div>
         </div>
 
-        {/* Filter pills */}
-        <div className="flex items-center gap-2 flex-wrap mb-8">
-          {FILTER_SKILLS.map((skill) => (
-            <button
-              key={skill}
-              onClick={() => setActiveSkill(skill)}
-              className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors duration-150 ${
-                activeSkill === skill
-                  ? 'bg-forge-700 text-text-primary'
-                  : 'text-text-muted hover:text-text-secondary bg-forge-800'
-              }`}
-            >
-              {skill}
-            </button>
-          ))}
+        <div className="mb-8 space-y-4">
+          <div className="relative max-w-xl">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted pointer-events-none" />
+            <input
+              type="search"
+              value={searchInput}
+              onChange={(e) => setSearchInput(e.target.value)}
+              placeholder="Search bounties by title, description, or tags"
+              aria-label="Search bounties"
+              className="w-full bg-forge-800 border border-border rounded-lg pl-10 pr-10 py-2.5 text-sm text-text-primary placeholder:text-text-muted focus:border-emerald focus:ring-1 focus:ring-emerald/30 outline-none transition-all duration-150"
+            />
+            {searchInput && (
+              <button
+                type="button"
+                onClick={() => setSearchInput('')}
+                aria-label="Clear search"
+                className="absolute right-2 top-1/2 -translate-y-1/2 p-1 rounded-md text-text-muted hover:text-text-primary hover:bg-forge-700 transition-colors"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            )}
+          </div>
+
+          {/* Filter pills */}
+          <div className="flex items-center gap-2 flex-wrap">
+            {FILTER_SKILLS.map((skill) => (
+              <button
+                key={skill}
+                onClick={() => setActiveSkill(skill)}
+                className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors duration-150 ${
+                  activeSkill === skill
+                    ? 'bg-forge-700 text-text-primary'
+                    : 'text-text-muted hover:text-text-secondary bg-forge-800'
+                }`}
+              >
+                {skill}
+              </button>
+            ))}
+          </div>
         </div>
 
         {/* Loading state */}
@@ -97,7 +132,11 @@ export function BountyGrid() {
           <div className="text-center py-16">
             <p className="text-text-muted text-lg mb-2">No bounties found</p>
             <p className="text-text-muted text-sm">
-              {activeSkill !== 'All' ? `Try a different language filter.` : 'Check back soon for new bounties.'}
+              {debouncedSearch
+                ? 'Try a different search term or clear the search.'
+                : activeSkill !== 'All'
+                  ? 'Try a different language filter.'
+                  : 'Check back soon for new bounties.'}
             </p>
           </div>
         )}

--- a/frontend/src/components/bounty/SubmissionForm.tsx
+++ b/frontend/src/components/bounty/SubmissionForm.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Loader2, Check, Copy } from 'lucide-react';
 import type { Bounty } from '../../types/bounty';
 import { createSubmission, getReviewFee, verifyReviewFee } from '../../api/bounties';
+import { useToast } from '../../contexts/ToastContext';
 
 interface SubmissionFormProps {
   bounty: Bounty;
@@ -9,6 +10,7 @@ interface SubmissionFormProps {
 }
 
 export function SubmissionForm({ bounty, onSuccess }: SubmissionFormProps) {
+  const { showToast } = useToast();
   const hasRepo = bounty.has_repo ?? !!bounty.github_repo_url;
   const [url, setUrl] = useState('');
   const [description, setDescription] = useState('');
@@ -38,11 +40,16 @@ export function SubmissionForm({ bounty, onSuccess }: SubmissionFormProps) {
       const result = await verifyReviewFee({ bounty_id: bounty.id, tx_signature: txSig });
       if (result.verified) {
         setFeeVerified(true);
+        showToast({ variant: 'success', title: 'Review fee verified' });
       } else {
-        setError(result.error ?? 'Fee verification failed. Check your transaction signature.');
+        const message = result.error ?? 'Fee verification failed. Check your transaction signature.';
+        setError(message);
+        showToast({ variant: 'error', title: 'Fee verification failed', message });
       }
     } catch {
-      setError('Fee verification failed. Try again.');
+      const message = 'Fee verification failed. Try again.';
+      setError(message);
+      showToast({ variant: 'error', title: 'Fee verification failed', message });
     } finally {
       setVerifying(false);
     }
@@ -61,9 +68,12 @@ export function SubmissionForm({ bounty, onSuccess }: SubmissionFormProps) {
         tx_signature: txSig,
       });
       setSuccess(true);
+      showToast({ variant: 'success', title: 'Submission received', message: 'AI review will begin shortly.' });
       onSuccess?.();
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : 'Submission failed. Try again.');
+      const message = e instanceof Error ? e.message : 'Submission failed. Try again.';
+      setError(message);
+      showToast({ variant: 'error', title: 'Submission failed', message });
     } finally {
       setSubmitting(false);
     }

--- a/frontend/src/components/home/ActivityFeed.tsx
+++ b/frontend/src/components/home/ActivityFeed.tsx
@@ -2,15 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { slideInRight } from '../../lib/animations';
 import { timeAgo } from '../../lib/utils';
-
-interface ActivityEvent {
-  id: string;
-  type: 'completed' | 'submitted' | 'posted' | 'review';
-  username: string;
-  avatar_url?: string | null;
-  detail: string;
-  timestamp: string;
-}
+import type { ActivityEvent } from '../../api/activity';
 
 // Mock events for when API doesn't return activity
 const MOCK_EVENTS: ActivityEvent[] = [
@@ -75,13 +67,23 @@ function EventItem({ event }: { event: ActivityEvent }) {
   );
 }
 
-export function ActivityFeed({ events }: { events?: ActivityEvent[] }) {
-  const displayEvents = events?.length ? events.slice(0, 4) : MOCK_EVENTS;
+export function ActivityFeed({
+  events,
+  isLoading = false,
+  isError = false,
+}: {
+  events?: ActivityEvent[];
+  isLoading?: boolean;
+  isError?: boolean;
+}) {
+  const displayEvents = events?.length ? events.slice(0, 4) : [];
   const [visibleEvents, setVisibleEvents] = useState<ActivityEvent[]>(displayEvents.slice(0, 4));
 
   useEffect(() => {
     setVisibleEvents(displayEvents.slice(0, 4));
   }, [events]);
+
+  const hasEvents = visibleEvents.length > 0;
 
   return (
     <section className="w-full border-y border-border bg-forge-900/50 py-4 overflow-hidden">
@@ -90,9 +92,24 @@ export function ActivityFeed({ events }: { events?: ActivityEvent[] }) {
           <span className="w-2 h-2 rounded-full bg-emerald animate-pulse-glow" />
           <span className="font-mono text-xs text-text-muted uppercase tracking-wider">Recent Activity</span>
         </div>
+        {isLoading && (
+          <div className="space-y-2 px-3 py-2">
+            {Array.from({ length: 3 }).map((_, index) => (
+              <div key={index} className="h-6 rounded-md bg-forge-800 animate-pulse" />
+            ))}
+          </div>
+        )}
+        {isError && (
+          <p className="text-sm text-text-muted px-3 py-2">
+            Activity is unavailable right now. Showing demo activity.
+          </p>
+        )}
+        {!isLoading && !isError && !hasEvents && (
+          <p className="text-sm text-text-muted px-3 py-2">No recent activity</p>
+        )}
         <div className="space-y-1">
           <AnimatePresence mode="popLayout">
-            {visibleEvents.map((event) => (
+            {(!isLoading ? (isError ? MOCK_EVENTS : visibleEvents) : []).map((event) => (
               <motion.div
                 key={event.id}
                 variants={slideInRight}

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -4,6 +4,7 @@
  */
 import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
 import { setAuthToken, setOnAuthExpired } from '../services/apiClient';
+import { useToast } from './ToastContext';
 
 export interface AuthUser {
   id: string;
@@ -37,6 +38,7 @@ const REFRESH_KEY = 'sf_refresh_token';
 const USER_KEY = 'sf_user';
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const { showToast } = useToast();
   const [state, setState] = useState<AuthState>({
     user: null,
     accessToken: null,
@@ -83,11 +85,20 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setState({ user: null, accessToken: null, refreshToken: null, isAuthenticated: false, isLoading: false });
   }, []);
 
+  const handleAuthExpired = useCallback(() => {
+    logout();
+    showToast({
+      variant: 'warning',
+      title: 'Session expired',
+      message: 'Please sign in again to continue.',
+    });
+  }, [logout, showToast]);
+
   // Wire apiClient's auth-expired callback to logout
   useEffect(() => {
-    setOnAuthExpired(logout);
+    setOnAuthExpired(handleAuthExpired);
     return () => setOnAuthExpired(null);
-  }, [logout]);
+  }, [handleAuthExpired]);
 
   const updateUser = useCallback((updates: Partial<AuthUser>) => {
     setState(prev => {

--- a/frontend/src/contexts/ToastContext.tsx
+++ b/frontend/src/contexts/ToastContext.tsx
@@ -1,0 +1,113 @@
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { AlertCircle, CheckCircle2, Info, TriangleAlert, X } from 'lucide-react';
+
+type ToastVariant = 'success' | 'error' | 'warning' | 'info';
+
+interface Toast {
+  id: string;
+  title: string;
+  message?: string;
+  variant: ToastVariant;
+}
+
+interface ToastInput {
+  title: string;
+  message?: string;
+  variant?: ToastVariant;
+}
+
+interface ToastContextValue {
+  showToast: (toast: ToastInput) => string;
+  dismissToast: (id: string) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+const variantStyles: Record<ToastVariant, string> = {
+  success: 'border-emerald/40 bg-forge-900 text-emerald',
+  error: 'border-status-error/40 bg-forge-900 text-status-error',
+  warning: 'border-status-warning/40 bg-forge-900 text-status-warning',
+  info: 'border-status-info/40 bg-forge-900 text-status-info',
+};
+
+const icons = {
+  success: CheckCircle2,
+  error: AlertCircle,
+  warning: TriangleAlert,
+  info: Info,
+};
+
+function ToastItem({ toast, onDismiss }: { toast: Toast; onDismiss: (id: string) => void }) {
+  const Icon = icons[toast.variant];
+
+  return (
+    <motion.div
+      layout
+      initial={{ opacity: 0, x: 48, scale: 0.98 }}
+      animate={{ opacity: 1, x: 0, scale: 1 }}
+      exit={{ opacity: 0, x: 48, scale: 0.98 }}
+      transition={{ duration: 0.18 }}
+      role="alert"
+      className={`pointer-events-auto w-full max-w-sm rounded-lg border shadow-xl shadow-black/20 ${variantStyles[toast.variant]}`}
+    >
+      <div className="flex gap-3 p-4">
+        <Icon className="w-5 h-5 flex-shrink-0 mt-0.5" />
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-semibold text-text-primary">{toast.title}</p>
+          {toast.message && <p className="mt-1 text-sm text-text-muted">{toast.message}</p>}
+        </div>
+        <button
+          type="button"
+          onClick={() => onDismiss(toast.id)}
+          aria-label="Dismiss notification"
+          className="p-1 rounded-md text-text-muted hover:text-text-primary hover:bg-forge-800 transition-colors"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+    </motion.div>
+  );
+}
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const dismissToast = useCallback((id: string) => {
+    setToasts((current) => current.filter((toast) => toast.id !== id));
+  }, []);
+
+  const showToast = useCallback((input: ToastInput) => {
+    const id = crypto.randomUUID();
+    const toast: Toast = {
+      id,
+      title: input.title,
+      message: input.message,
+      variant: input.variant ?? 'info',
+    };
+    setToasts((current) => [toast, ...current].slice(0, 5));
+    window.setTimeout(() => dismissToast(id), 5_000);
+    return id;
+  }, [dismissToast]);
+
+  const value = useMemo(() => ({ showToast, dismissToast }), [dismissToast, showToast]);
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <div className="fixed right-4 top-4 z-50 flex w-[calc(100vw-2rem)] max-w-sm flex-col gap-3 pointer-events-none">
+        <AnimatePresence initial={false}>
+          {toasts.map((toast) => (
+            <ToastItem key={toast.id} toast={toast} onDismiss={dismissToast} />
+          ))}
+        </AnimatePresence>
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const context = useContext(ToastContext);
+  if (!context) throw new Error('useToast must be used inside ToastProvider');
+  return context;
+}

--- a/frontend/src/hooks/useActivity.ts
+++ b/frontend/src/hooks/useActivity.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { listActivity } from '../api/activity';
+
+export function useActivity() {
+  return useQuery({
+    queryKey: ['activity'],
+    queryFn: listActivity,
+    refetchInterval: 30_000,
+    staleTime: 15_000,
+  });
+}

--- a/frontend/src/lib/animations.ts
+++ b/frontend/src/lib/animations.ts
@@ -1,0 +1,36 @@
+export const fadeIn = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.25 } },
+};
+
+export const pageTransition = {
+  initial: { opacity: 0 },
+  animate: { opacity: 1, transition: { duration: 0.2 } },
+  exit: { opacity: 0, transition: { duration: 0.15 } },
+};
+
+export const staggerContainer = {
+  initial: {},
+  animate: { transition: { staggerChildren: 0.05 } },
+};
+
+export const staggerItem = {
+  initial: { opacity: 0, y: 10 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.2 } },
+};
+
+export const cardHover = {
+  rest: { y: 0 },
+  hover: { y: -3, transition: { duration: 0.15 } },
+};
+
+export const buttonHover = {
+  rest: { scale: 1 },
+  hover: { scale: 1.02, transition: { duration: 0.15 } },
+  tap: { scale: 0.98 },
+};
+
+export const slideInRight = {
+  initial: { opacity: 0, x: 20 },
+  animate: { opacity: 1, x: 0, transition: { duration: 0.2 } },
+};

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,50 @@
+import type { RewardToken } from '../types/bounty';
+
+export const LANG_COLORS: Record<string, string> = {
+  TypeScript: '#3178C6',
+  JavaScript: '#F7DF1E',
+  Rust: '#DEA584',
+  Solidity: '#AA6746',
+  Python: '#3776AB',
+  Go: '#00ADD8',
+  React: '#61DAFB',
+  TS: '#3178C6',
+};
+
+export function formatCurrency(amount: number, token: RewardToken = 'FNDRY'): string {
+  const value = Number.isFinite(amount) ? amount : 0;
+  const compact =
+    Math.abs(value) >= 1_000_000
+      ? `${(value / 1_000_000).toFixed(value % 1_000_000 === 0 ? 0 : 1)}M`
+      : Math.abs(value) >= 1_000
+        ? `${(value / 1_000).toFixed(value % 1_000 === 0 ? 0 : 1)}k`
+        : value.toLocaleString();
+  return `${compact} ${token}`;
+}
+
+export function timeLeft(deadline: string): string {
+  const diff = new Date(deadline).getTime() - Date.now();
+  if (!Number.isFinite(diff) || diff <= 0) return 'Expired';
+
+  const minutes = Math.floor(diff / 60_000);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+
+  if (days > 0) return `${days}d ${hours % 24}h`;
+  if (hours > 0) return `${hours}h ${minutes % 60}m`;
+  return `${minutes}m`;
+}
+
+export function timeAgo(timestamp: string): string {
+  const diff = Date.now() - new Date(timestamp).getTime();
+  if (!Number.isFinite(diff) || diff < 0) return 'just now';
+
+  const minutes = Math.floor(diff / 60_000);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+
+  if (days > 0) return `${days}d ago`;
+  if (hours > 0) return `${hours}h ago`;
+  if (minutes > 0) return `${minutes}m ago`;
+  return 'just now';
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { AuthProvider } from './contexts/AuthContext';
+import { ToastProvider } from './contexts/ToastContext';
 import { queryClient } from './services/queryClient';
 import App from './App';
 import './index.css';
@@ -14,9 +15,11 @@ createRoot(root).render(
   <StrictMode>
     <BrowserRouter>
       <QueryClientProvider client={queryClient}>
-        <AuthProvider>
-          <App />
-        </AuthProvider>
+        <ToastProvider>
+          <AuthProvider>
+            <App />
+          </AuthProvider>
+        </ToastProvider>
       </QueryClientProvider>
     </BrowserRouter>
   </StrictMode>

--- a/frontend/src/pages/GitHubCallbackPage.tsx
+++ b/frontend/src/pages/GitHubCallbackPage.tsx
@@ -5,11 +5,13 @@ import { useAuth } from '../hooks/useAuth';
 import { exchangeGitHubCode } from '../api/auth';
 import { setAuthToken } from '../services/apiClient';
 import { fadeIn } from '../lib/animations';
+import { useToast } from '../contexts/ToastContext';
 
 export function GitHubCallbackPage() {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const { login } = useAuth();
+  const { showToast } = useToast();
   const didRun = useRef(false);
 
   useEffect(() => {
@@ -21,6 +23,7 @@ export function GitHubCallbackPage() {
     const error = searchParams.get('error');
 
     if (error || !code) {
+      showToast({ variant: 'error', title: 'GitHub sign-in failed', message: error ?? 'Missing authorization code.' });
       navigate('/', { replace: true });
       return;
     }
@@ -35,12 +38,18 @@ export function GitHubCallbackPage() {
         if (response.refresh_token) {
           localStorage.setItem('sf_refresh_token', response.refresh_token);
         }
+        showToast({ variant: 'success', title: 'Signed in with GitHub' });
         navigate('/', { replace: true });
       })
-      .catch(() => {
+      .catch((caught: unknown) => {
+        showToast({
+          variant: 'error',
+          title: 'GitHub sign-in failed',
+          message: caught instanceof Error ? caught.message : 'Please try again.',
+        });
         navigate('/', { replace: true });
       });
-  }, []);
+  }, [login, navigate, searchParams, showToast]);
 
   return (
     <div className="min-h-screen bg-forge-950 flex items-center justify-center">

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -5,12 +5,15 @@ import { ActivityFeed } from '../components/home/ActivityFeed';
 import { HowItWorksCondensed } from '../components/home/HowItWorksCondensed';
 import { FeaturedBounties } from '../components/home/FeaturedBounties';
 import { WhySolFoundry } from '../components/home/WhySolFoundry';
+import { useActivity } from '../hooks/useActivity';
 
 export function HomePage() {
+  const { data: activity, isLoading, isError } = useActivity();
+
   return (
     <PageLayout noFooter={false}>
       <HeroSection />
-      <ActivityFeed />
+      <ActivityFeed events={activity} isLoading={isLoading} isError={isError} />
       <HowItWorksCondensed />
       <FeaturedBounties />
       <WhySolFoundry />


### PR DESCRIPTION
## Summary
- Add debounced search to the bounties grid, alongside existing status and skill filters
- Add a global accessible toast notification system and wire it into auth/submission flows
- Wire the homepage activity feed to /api/activity with 30s refresh, loading, empty, and fallback states
- Add missing frontend lib utilities/animations used by existing components so the frontend builds cleanly

Closes #823
Closes #825
Closes #822

## Verification
- npm run build

Note: npm test currently fails on existing test-suite issues unrelated to this change: missing Playwright dependency and tests importing components/hooks that are not present in the repository.