### PR TITLE
fix: harden github oauth sign-in flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,8 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
-lib64/
+/lib/
+/lib64/
 parts/
 sdist/
 var/

--- a/frontend/src/__tests__/auth-github-oauth.test.tsx
+++ b/frontend/src/__tests__/auth-github-oauth.test.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import {
+  getGitHubAuthorizeUrl,
+  validateGitHubOAuthState,
+} from '../api/auth';
+import { setAuthToken } from '../services/apiClient';
+import { AuthProvider } from '../contexts/AuthContext';
+import { GitHubCallbackPage } from '../pages/GitHubCallbackPage';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function mockResponse(body: unknown, status = 200, statusText = 'OK'): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText,
+    json: () => Promise.resolve(body),
+    headers: new Headers({ 'content-type': 'application/json' }),
+    redirected: false,
+    type: 'basic' as ResponseType,
+    url: '',
+    clone: () => mockResponse(body, status, statusText),
+    body: null,
+    bodyUsed: false,
+    arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+    blob: () => Promise.resolve(new Blob()),
+    formData: () => Promise.resolve(new FormData()),
+    text: () => Promise.resolve(JSON.stringify(body)),
+    bytes: () => Promise.resolve(new Uint8Array()),
+  } as Response;
+}
+
+function renderCallback(initialEntry: string) {
+  return render(
+    <AuthProvider>
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <Routes>
+          <Route path="/" element={<div>Home</div>} />
+          <Route path="/auth/github/callback" element={<GitHubCallbackPage />} />
+        </Routes>
+      </MemoryRouter>
+    </AuthProvider>,
+  );
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  localStorage.clear();
+  setAuthToken(null);
+  vi.unstubAllEnvs();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('GitHub OAuth helpers', () => {
+  it('uses the backend authorize URL and remembers its state', async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({
+        authorize_url: 'https://github.com/login/oauth/authorize?client_id=abc&state=server-state',
+      }),
+    );
+
+    const authorizeUrl = await getGitHubAuthorizeUrl();
+
+    expect(authorizeUrl).toContain('github.com/login/oauth/authorize');
+    expect(localStorage.getItem('sf_github_oauth_state')).toBe('server-state');
+  });
+
+  it('falls back to a direct GitHub authorize URL when the backend route is unavailable', async () => {
+    vi.stubEnv('VITE_GITHUB_CLIENT_ID', 'client-123');
+    mockFetch.mockResolvedValueOnce(mockResponse({ detail: 'Not Found' }, 404, 'Not Found'));
+
+    const authorizeUrl = await getGitHubAuthorizeUrl();
+    const parsed = new URL(authorizeUrl);
+
+    expect(parsed.origin + parsed.pathname).toBe('https://github.com/login/oauth/authorize');
+    expect(parsed.searchParams.get('client_id')).toBe('client-123');
+    expect(parsed.searchParams.get('redirect_uri')).toBe(`${window.location.origin}/auth/github/callback`);
+    expect(parsed.searchParams.get('scope')).toBe('read:user user:email');
+    expect(parsed.searchParams.get('state')).toBe(localStorage.getItem('sf_github_oauth_state'));
+  });
+
+  it('validates and consumes the stored OAuth state', () => {
+    localStorage.setItem('sf_github_oauth_state', 'expected-state');
+
+    expect(validateGitHubOAuthState('expected-state')).toBe(true);
+    expect(localStorage.getItem('sf_github_oauth_state')).toBeNull();
+  });
+
+  it('rejects mismatched OAuth state and consumes it', () => {
+    localStorage.setItem('sf_github_oauth_state', 'expected-state');
+
+    expect(validateGitHubOAuthState('different-state')).toBe(false);
+    expect(localStorage.getItem('sf_github_oauth_state')).toBeNull();
+  });
+});
+
+describe('GitHubCallbackPage', () => {
+  it('exchanges a valid callback code and stores JWT/user session data', async () => {
+    localStorage.setItem('sf_github_oauth_state', 'valid-state');
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({
+        access_token: 'access-token',
+        refresh_token: 'refresh-token',
+        token_type: 'bearer',
+        user: {
+          id: 'user-1',
+          username: 'octocat',
+          avatar_url: 'https://avatars.githubusercontent.com/u/1?v=4',
+          github_id: '1',
+        },
+      }),
+    );
+
+    renderCallback('/auth/github/callback?code=abc123&state=valid-state');
+
+    await screen.findByText('Home');
+    expect(localStorage.getItem('sf_access_token')).toBe('access-token');
+    expect(localStorage.getItem('sf_refresh_token')).toBe('refresh-token');
+    expect(localStorage.getItem('sf_user')).toContain('octocat');
+    expect(mockFetch).toHaveBeenCalledOnce();
+  });
+
+  it('shows a graceful error and skips token exchange when state is invalid', async () => {
+    localStorage.setItem('sf_github_oauth_state', 'valid-state');
+
+    renderCallback('/auth/github/callback?code=abc123&state=wrong-state');
+
+    expect(await screen.findByText('GitHub sign-in failed')).toBeInTheDocument();
+    expect(screen.getByText('GitHub sign-in session expired. Please try again.')).toBeInTheDocument();
+    await waitFor(() => expect(mockFetch).not.toHaveBeenCalled());
+  });
+});

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,6 +1,11 @@
 import { apiClient } from '../services/apiClient';
 import type { User } from '../types/user';
 
+const GITHUB_AUTHORIZE_URL = 'https://github.com/login/oauth/authorize';
+const GITHUB_CALLBACK_PATH = '/auth/github/callback';
+const GITHUB_SCOPE = 'read:user user:email';
+const GITHUB_OAUTH_STATE_KEY = 'sf_github_oauth_state';
+
 export interface AuthTokens {
   access_token: string;
   refresh_token: string;
@@ -11,9 +16,82 @@ export interface GitHubCallbackResponse extends AuthTokens {
   user: User;
 }
 
+function createOAuthState(): string {
+  const bytes = new Uint8Array(16);
+  if (globalThis.crypto?.getRandomValues) {
+    globalThis.crypto.getRandomValues(bytes);
+  } else {
+    for (let i = 0; i < bytes.length; i += 1) {
+      bytes[i] = Math.floor(Math.random() * 256);
+    }
+  }
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+function getAppOrigin(): string {
+  return typeof window !== 'undefined' && window.location?.origin
+    ? window.location.origin
+    : '';
+}
+
+function rememberOAuthStateFromUrl(authorizeUrl: string): void {
+  try {
+    const parsed = new URL(authorizeUrl, getAppOrigin());
+    const state = parsed.searchParams.get('state');
+    if (state) {
+      localStorage.setItem(GITHUB_OAUTH_STATE_KEY, state);
+    }
+  } catch {
+    /* Ignore malformed URLs from the API and let the redirect fail naturally. */
+  }
+}
+
+function buildDirectGitHubAuthorizeUrl(): string {
+  const clientId = import.meta.env.VITE_GITHUB_CLIENT_ID as string | undefined;
+  if (!clientId) {
+    throw new Error('GitHub OAuth client ID is not configured');
+  }
+
+  const state = createOAuthState();
+  localStorage.setItem(GITHUB_OAUTH_STATE_KEY, state);
+
+  const authorizeUrl = new URL(GITHUB_AUTHORIZE_URL);
+  authorizeUrl.searchParams.set('client_id', clientId);
+  authorizeUrl.searchParams.set('redirect_uri', `${getAppOrigin()}${GITHUB_CALLBACK_PATH}`);
+  authorizeUrl.searchParams.set('scope', GITHUB_SCOPE);
+  authorizeUrl.searchParams.set('state', state);
+
+  return authorizeUrl.toString();
+}
+
+export function validateGitHubOAuthState(receivedState: string | null): boolean {
+  const expectedState = localStorage.getItem(GITHUB_OAUTH_STATE_KEY);
+  if (!expectedState) return true;
+
+  localStorage.removeItem(GITHUB_OAUTH_STATE_KEY);
+  return receivedState === expectedState;
+}
+
+export function clearGitHubOAuthState(): void {
+  localStorage.removeItem(GITHUB_OAUTH_STATE_KEY);
+}
+
 export async function getGitHubAuthorizeUrl(): Promise<string> {
-  const data = await apiClient<{ authorize_url: string }>('/api/auth/github/authorize');
-  return data.authorize_url;
+  try {
+    const data = await apiClient<{ authorize_url: string }>('/api/auth/github/authorize');
+    if (data.authorize_url) {
+      rememberOAuthStateFromUrl(data.authorize_url);
+      return data.authorize_url;
+    }
+  } catch {
+    return buildDirectGitHubAuthorizeUrl();
+  }
+
+  return buildDirectGitHubAuthorizeUrl();
+}
+
+export async function redirectToGitHubSignIn(): Promise<void> {
+  window.location.assign(await getGitHubAuthorizeUrl());
 }
 
 export async function exchangeGitHubCode(code: string, state?: string): Promise<GitHubCallbackResponse> {

--- a/frontend/src/components/auth/AuthGuard.tsx
+++ b/frontend/src/components/auth/AuthGuard.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { GitBranch } from 'lucide-react';
 import { useAuth } from '../../hooks/useAuth';
-import { getGitHubAuthorizeUrl } from '../../api/auth';
+import { redirectToGitHubSignIn } from '../../api/auth';
 
 interface AuthGuardProps {
   children: React.ReactNode;
@@ -22,13 +22,7 @@ export function AuthGuard({ children }: AuthGuardProps) {
 
   if (!isAuthenticated) {
     const handleSignIn = async () => {
-      try {
-        const url = await getGitHubAuthorizeUrl();
-        window.location.href = url;
-      } catch {
-        // fallback: redirect to backend OAuth endpoint directly
-        window.location.href = '/api/auth/github/authorize';
-      }
+      await redirectToGitHubSignIn();
     };
 
     return (

--- a/frontend/src/components/bounty/BountyDetail.tsx
+++ b/frontend/src/components/bounty/BountyDetail.tsx
@@ -7,6 +7,7 @@ import { timeLeft, timeAgo, formatCurrency, LANG_COLORS } from '../../lib/utils'
 import { useAuth } from '../../hooks/useAuth';
 import { SubmissionForm } from './SubmissionForm';
 import { fadeIn } from '../../lib/animations';
+import { redirectToGitHubSignIn } from '../../api/auth';
 
 interface BountyDetailProps {
   bounty: Bounty;
@@ -22,6 +23,10 @@ export function BountyDetail({ bounty }: BountyDetailProps) {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     });
+  };
+
+  const handleGitHubSignIn = async () => {
+    await redirectToGitHubSignIn();
   };
 
   return (
@@ -101,12 +106,13 @@ export function BountyDetail({ bounty }: BountyDetailProps) {
               ) : (
                 <div className="text-center py-6">
                   <p className="text-text-muted text-sm mb-4">Sign in with GitHub to submit a solution.</p>
-                  <a
-                    href="/api/auth/github/authorize"
+                  <button
+                    type="button"
+                    onClick={handleGitHubSignIn}
                     className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-forge-800 border border-border hover:border-border-hover text-text-primary text-sm font-medium transition-all duration-200"
                   >
                     Sign in with GitHub
-                  </a>
+                  </button>
                 </div>
               )}
             </div>

--- a/frontend/src/components/home/HeroSection.tsx
+++ b/frontend/src/components/home/HeroSection.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { motion, useInView, animate, useMotionValue } from 'framer-motion';
 import { useStats } from '../../hooks/useStats';
-import { getGitHubAuthorizeUrl } from '../../api/auth';
+import { redirectToGitHubSignIn } from '../../api/auth';
 import { useAuth } from '../../hooks/useAuth';
 import { buttonHover, fadeIn } from '../../lib/animations';
 
@@ -78,12 +78,7 @@ export function HeroSection() {
   }, []);
 
   const handleSignIn = async () => {
-    try {
-      const url = await getGitHubAuthorizeUrl();
-      window.location.href = url;
-    } catch {
-      window.location.href = '/api/auth/github/authorize';
-    }
+    await redirectToGitHubSignIn();
   };
 
   return (

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -4,7 +4,7 @@ import { Menu, X, ChevronDown, LogOut, User } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useAuth } from '../../hooks/useAuth';
 import { useStats } from '../../hooks/useStats';
-import { getGitHubAuthorizeUrl } from '../../api/auth';
+import { redirectToGitHubSignIn } from '../../api/auth';
 
 const GitHubIcon = () => (
   <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
@@ -34,13 +34,7 @@ export function Navbar() {
   }, []);
 
   const handleGitHubSignIn = async () => {
-    try {
-      const url = await getGitHubAuthorizeUrl();
-      window.location.href = url;
-    } catch {
-      // Fallback: direct to backend authorize endpoint
-      window.location.href = '/api/auth/github/authorize';
-    }
+    await redirectToGitHubSignIn();
   };
 
   const isActive = (to: string) => {

--- a/frontend/src/lib/animations.ts
+++ b/frontend/src/lib/animations.ts
@@ -1,0 +1,47 @@
+import type { Variants } from 'framer-motion';
+
+export const fadeIn: Variants = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.35, ease: 'easeOut' } },
+};
+
+export const pageTransition: Variants = {
+  initial: { opacity: 0 },
+  animate: { opacity: 1, transition: { duration: 0.3, ease: 'easeOut' } },
+  exit: { opacity: 0, transition: { duration: 0.2, ease: 'easeIn' } },
+};
+
+export const staggerContainer: Variants = {
+  initial: {},
+  animate: {
+    transition: {
+      staggerChildren: 0.06,
+    },
+  },
+};
+
+export const staggerItem: Variants = {
+  initial: { opacity: 0, y: 10 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.3, ease: 'easeOut' } },
+};
+
+export const slideInRight: Variants = {
+  initial: { opacity: 0, x: 24 },
+  animate: { opacity: 1, x: 0, transition: { duration: 0.3, ease: 'easeOut' } },
+  exit: { opacity: 0, x: 24, transition: { duration: 0.2, ease: 'easeIn' } },
+};
+
+export const cardHover: Variants = {
+  rest: { y: 0, borderColor: '#1E1E2E' },
+  hover: {
+    y: -4,
+    borderColor: '#2E2E42',
+    transition: { duration: 0.2, ease: 'easeOut' },
+  },
+};
+
+export const buttonHover: Variants = {
+  rest: { scale: 1 },
+  hover: { scale: 1.02, transition: { duration: 0.15, ease: 'easeOut' } },
+  tap: { scale: 0.98 },
+};

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,75 @@
+export const LANG_COLORS: Record<string, string> = {
+  TypeScript: '#3178C6',
+  JavaScript: '#F7DF1E',
+  Python: '#3776AB',
+  Rust: '#DEA584',
+  Go: '#00ADD8',
+  Solidity: '#363636',
+  Java: '#B07219',
+  C: '#555555',
+  'C++': '#F34B7D',
+  Ruby: '#CC342D',
+  Swift: '#FA7343',
+  Kotlin: '#A97BFF',
+  Shell: '#89E051',
+};
+
+export function formatCurrency(amount?: number | string | null, token = 'USDC') {
+  const numericAmount = Number(amount ?? 0);
+  const formattedAmount = Number.isFinite(numericAmount)
+    ? numericAmount.toLocaleString(undefined, { maximumFractionDigits: 2 })
+    : '0';
+
+  if (token.toUpperCase() === 'USDC' || token === '$') {
+    return `$${formattedAmount}`;
+  }
+
+  return `${formattedAmount} ${token}`;
+}
+
+export function timeAgo(value?: string | Date | null) {
+  if (!value) return 'recently';
+
+  const date = value instanceof Date ? value : new Date(value);
+  const timestamp = date.getTime();
+  if (Number.isNaN(timestamp)) return 'recently';
+
+  const seconds = Math.max(0, Math.floor((Date.now() - timestamp) / 1000));
+  const units: Array<[Intl.RelativeTimeFormatUnit, number]> = [
+    ['year', 60 * 60 * 24 * 365],
+    ['month', 60 * 60 * 24 * 30],
+    ['week', 60 * 60 * 24 * 7],
+    ['day', 60 * 60 * 24],
+    ['hour', 60 * 60],
+    ['minute', 60],
+  ];
+
+  for (const [unit, size] of units) {
+    const count = Math.floor(seconds / size);
+    if (count >= 1) {
+      return new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' }).format(-count, unit);
+    }
+  }
+
+  return 'just now';
+}
+
+export function timeLeft(value?: string | Date | null) {
+  if (!value) return 'No deadline';
+
+  const date = value instanceof Date ? value : new Date(value);
+  const timestamp = date.getTime();
+  if (Number.isNaN(timestamp)) return 'No deadline';
+
+  const seconds = Math.floor((timestamp - Date.now()) / 1000);
+  if (seconds <= 0) return 'Expired';
+
+  const days = Math.floor(seconds / (60 * 60 * 24));
+  if (days >= 1) return `${days}d left`;
+
+  const hours = Math.floor(seconds / (60 * 60));
+  if (hours >= 1) return `${hours}h left`;
+
+  const minutes = Math.max(1, Math.floor(seconds / 60));
+  return `${minutes}m left`;
+}

--- a/frontend/src/pages/GitHubCallbackPage.tsx
+++ b/frontend/src/pages/GitHubCallbackPage.tsx
@@ -1,16 +1,40 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { useAuth } from '../hooks/useAuth';
-import { exchangeGitHubCode } from '../api/auth';
-import { setAuthToken } from '../services/apiClient';
+import {
+  clearGitHubOAuthState,
+  exchangeGitHubCode,
+  redirectToGitHubSignIn,
+  validateGitHubOAuthState,
+} from '../api/auth';
+import { ApiError, setAuthToken } from '../services/apiClient';
 import { fadeIn } from '../lib/animations';
+
+function getSignInErrorMessage(error: unknown): string {
+  if (error instanceof ApiError) {
+    if (error.status === 400 || error.status === 401) {
+      return 'That GitHub sign-in link expired. Please try again.';
+    }
+    if (error.status === 403 || error.status === 429) {
+      return 'GitHub sign-in is temporarily rate limited. Please try again in a moment.';
+    }
+  }
+  return 'Could not complete GitHub sign-in. Please try again.';
+}
 
 export function GitHubCallbackPage() {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const { login } = useAuth();
   const didRun = useRef(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const retrySignIn = () => {
+    redirectToGitHubSignIn().catch(() => {
+      setErrorMessage('GitHub sign-in is not configured. Please try again later.');
+    });
+  };
 
   useEffect(() => {
     if (didRun.current) return;
@@ -20,8 +44,20 @@ export function GitHubCallbackPage() {
     const state = searchParams.get('state');
     const error = searchParams.get('error');
 
-    if (error || !code) {
-      navigate('/', { replace: true });
+    if (error) {
+      clearGitHubOAuthState();
+      setErrorMessage('GitHub sign-in was cancelled or denied.');
+      return;
+    }
+
+    if (!code) {
+      clearGitHubOAuthState();
+      setErrorMessage('Missing GitHub authorization code. Please try again.');
+      return;
+    }
+
+    if (!validateGitHubOAuthState(state)) {
+      setErrorMessage('GitHub sign-in session expired. Please try again.');
       return;
     }
 
@@ -37,8 +73,8 @@ export function GitHubCallbackPage() {
         }
         navigate('/', { replace: true });
       })
-      .catch(() => {
-        navigate('/', { replace: true });
+      .catch((caught: unknown) => {
+        setErrorMessage(getSignInErrorMessage(caught));
       });
   }, []);
 
@@ -50,8 +86,23 @@ export function GitHubCallbackPage() {
         animate="animate"
         className="text-center"
       >
-        <div className="w-12 h-12 rounded-full border-2 border-emerald border-t-transparent animate-spin mx-auto mb-4" />
-        <p className="text-text-muted font-mono text-sm">Signing in with GitHub...</p>
+        {errorMessage ? (
+          <div className="max-w-sm rounded-xl border border-border bg-forge-900 p-6">
+            <p className="text-text-primary font-semibold mb-2">GitHub sign-in failed</p>
+            <p className="text-text-muted text-sm mb-5">{errorMessage}</p>
+            <button
+              onClick={retrySignIn}
+              className="px-4 py-2 rounded-lg bg-emerald text-forge-950 font-semibold text-sm hover:bg-emerald/90 transition-colors"
+            >
+              Try again
+            </button>
+          </div>
+        ) : (
+          <>
+            <div className="w-12 h-12 rounded-full border-2 border-emerald border-t-transparent animate-spin mx-auto mb-4" />
+            <p className="text-text-muted font-mono text-sm">Signing in with GitHub...</p>
+          </>
+        )}
       </motion.div>
     </div>
   );


### PR DESCRIPTION
## Description
Fixes the GitHub OAuth sign-in flow for bounty #821 by removing the 404-prone raw fallback redirects and centralizing sign-in through the auth helper.

Changes include:
- backend authorize URL support with stored OAuth state
- direct GitHub authorize fallback using `VITE_GITHUB_CLIENT_ID` when the backend authorize endpoint is unavailable
- OAuth state validation before callback code exchange
- graceful callback errors for cancelled login, missing code, expired/invalid state, expired codes, and rate limits
- shared redirect helper used by navbar, hero CTA, auth guard, and bounty detail sign-in
- JWT and user session storage covered by callback tests
- restores existing shared frontend `src/lib` modules and narrows the broad `.gitignore` `lib/` rule so imported frontend source is tracked

Closes #821

## Solana Wallet for Payout
**Wallet:** C2z3FWAacvSYVrrkfpk6nQyNhF4t3z7t9iXRW1xfZPy1

## Type of Change
- [x] Bug fix
- [x] Test addition/update

## Checklist
- [x] Code is clean and follows the issue spec exactly
- [x] One PR per bounty (no multiple bounties in one PR)
- [x] Tests included for new functionality
- [x] No `console.log` or debugging code left behind
- [x] No hardcoded secrets or API keys
- [x] GitHub authorize redirect is covered
- [x] OAuth callback state validation is covered
- [x] JWT/user session storage is covered

## Testing
- [x] `npm test -- auth-github-oauth.test.tsx`
- [x] `npm run build`
- [x] `git diff --check`

## Notes
I also ran the full `npm test` suite. It currently fails before running most suites because upstream tests import modules that are not present in this repository snapshot, such as `../hooks/useAdminData`, `../components/tokenomics/TokenomicsPage`, `../components/bounties/BountyBoard`, and `@playwright/test`. The new OAuth-focused test file passes, and the production build passes.