### PR TITLE
fix: polish mobile responsive layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,8 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
-lib64/
+/lib/
+/lib64/
 parts/
 sdist/
 var/

--- a/frontend/src/__tests__/mobile-responsive-polish.test.tsx
+++ b/frontend/src/__tests__/mobile-responsive-polish.test.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { BountyCard } from '../components/bounty/BountyCard';
+import { BountyGrid } from '../components/bounty/BountyGrid';
+import { ActivityFeed } from '../components/home/ActivityFeed';
+import { HeroSection } from '../components/home/HeroSection';
+import type { Bounty } from '../types/bounty';
+
+class MockIntersectionObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
+
+vi.mock('../hooks/useBounties', () => ({
+  useInfiniteBounties: () => ({
+    data: { pages: [{ items: [], total: 0, limit: 12, offset: 0 }] },
+    fetchNextPage: vi.fn(),
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    isLoading: false,
+    isError: false,
+  }),
+}));
+
+vi.mock('../hooks/useStats', () => ({
+  useStats: () => ({
+    data: { open_bounties: 12, total_paid_usdc: 3400, total_contributors: 8 },
+  }),
+}));
+
+vi.mock('../hooks/useAuth', () => ({
+  useAuth: () => ({
+    isAuthenticated: false,
+  }),
+}));
+
+const bounty: Bounty = {
+  id: 'mobile-bounty',
+  title: 'Very long mobile responsive bounty title that should wrap cleanly in a narrow card',
+  description: 'Make sure bounty cards do not overflow on small screens.',
+  status: 'open',
+  tier: 'T1',
+  reward_amount: 150000,
+  reward_token: 'FNDRY',
+  github_issue_url: 'https://github.com/SolFoundry/solfoundry/issues/824',
+  org_name: 'SolFoundry',
+  repo_name: 'solfoundry',
+  issue_number: 824,
+  skills: ['TypeScript', 'React', 'Tailwind', 'CSS'],
+  deadline: new Date(Date.now() + 48 * 60 * 60 * 1000).toISOString(),
+  submission_count: 7,
+  created_at: new Date().toISOString(),
+};
+
+function renderRoute(ui: React.ReactElement) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+describe('mobile responsive polish', () => {
+  it('lets bounty card content wrap before desktop positioning kicks in', () => {
+    renderRoute(<BountyCard bounty={bounty} />);
+
+    const card = screen.getByText(/very long mobile responsive bounty title/i).closest('div');
+    expect(card).toHaveClass('min-w-0', 'p-4', 'sm:p-5');
+
+    const reward = screen.getByText('150,000 FNDRY');
+    expect(reward.parentElement).toHaveClass('flex-col', 'sm:flex-row');
+
+    const status = screen.getByText('Open');
+    expect(status).toHaveClass('mt-3', 'sm:absolute', 'sm:mt-0');
+  });
+
+  it('stacks bounty page actions on mobile and restores inline controls on larger screens', () => {
+    renderRoute(<BountyGrid />);
+
+    const postButton = screen.getByRole('link', { name: /post a bounty/i });
+    expect(postButton.parentElement).toHaveClass('w-full', 'flex-col', 'sm:flex-row');
+    expect(postButton).toHaveClass('justify-center', 'py-2', 'sm:py-1.5');
+
+    const statusFilter = screen.getByRole('combobox');
+    expect(statusFilter).toHaveClass('w-full', 'py-2', 'sm:py-1.5');
+  });
+
+  it('uses a compact terminal command and wrapped stat row in the mobile hero', () => {
+    renderRoute(<HeroSection />);
+
+    expect(screen.getByText('forge bounty --tier 2')).toHaveClass('sm:hidden');
+    expect(screen.getByText('forge bounty --reward 100 --lang typescript --tier 2')).toHaveClass('hidden', 'sm:inline-block');
+    expect(screen.getByText(/open bounties/i).parentElement).toHaveClass('flex-wrap');
+  });
+
+  it('allows activity feed detail text to wrap on narrow screens', () => {
+    render(
+      <ActivityFeed
+        events={[
+          {
+            id: 'activity-mobile',
+            type: 'posted',
+            username: 'SolanaLabs',
+            detail: 'Bounty #145 - $3,500 USDC',
+            timestamp: new Date().toISOString(),
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('SolanaLabs').closest('p')).toHaveClass('min-w-0', 'break-words');
+    expect(screen.getByText('Bounty #145 - $3,500 USDC')).toHaveClass('break-words');
+  });
+});

--- a/frontend/src/components/bounty/BountyCard.tsx
+++ b/frontend/src/components/bounty/BountyCard.tsx
@@ -61,10 +61,10 @@ export function BountyCard({ bounty }: BountyCardProps) {
       initial="rest"
       whileHover="hover"
       onClick={() => navigate(`/bounties/${bounty.id}`)}
-      className="relative rounded-xl border border-border bg-forge-900 p-5 cursor-pointer transition-colors duration-200 overflow-hidden group"
+      className="relative min-w-0 rounded-xl border border-border bg-forge-900 p-4 sm:p-5 cursor-pointer transition-colors duration-200 overflow-hidden group"
     >
       {/* Row 1: Repo + Tier */}
-      <div className="flex items-center justify-between text-sm">
+      <div className="flex items-start justify-between gap-3 text-sm">
         <div className="flex items-center gap-2 min-w-0">
           {bounty.org_avatar_url && (
             <img src={bounty.org_avatar_url} className="w-5 h-5 rounded-full flex-shrink-0" alt="" />
@@ -74,17 +74,19 @@ export function BountyCard({ bounty }: BountyCardProps) {
             {issueNumber && <span className="ml-1">#{issueNumber}</span>}
           </span>
         </div>
-        <TierBadge tier={bounty.tier ?? 'T1'} />
+        <div className="flex-shrink-0">
+          <TierBadge tier={bounty.tier ?? 'T1'} />
+        </div>
       </div>
 
       {/* Row 2: Title */}
-      <h3 className="mt-3 font-sans text-base font-semibold text-text-primary leading-snug line-clamp-2">
+      <h3 className="mt-3 font-sans text-base font-semibold text-text-primary leading-snug line-clamp-3 sm:line-clamp-2 break-words">
         {bounty.title}
       </h3>
 
       {/* Row 3: Language dots */}
       {skills.length > 0 && (
-        <div className="flex items-center gap-3 mt-3">
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 mt-3">
           {skills.map((lang) => (
             <span key={lang} className="inline-flex items-center gap-1.5 text-xs text-text-muted">
               <span
@@ -101,11 +103,11 @@ export function BountyCard({ bounty }: BountyCardProps) {
       <div className="mt-4 border-t border-border/50" />
 
       {/* Row 4: Reward + Meta */}
-      <div className="flex items-center justify-between mt-3">
-        <span className="font-mono text-lg font-semibold text-emerald">
+      <div className="flex flex-col gap-2 mt-3 sm:flex-row sm:items-center sm:justify-between">
+        <span className="font-mono text-base sm:text-lg font-semibold text-emerald break-words">
           {formatCurrency(bounty.reward_amount, bounty.reward_token)}
         </span>
-        <div className="flex items-center gap-3 text-xs text-text-muted">
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-text-muted">
           <span className="inline-flex items-center gap-1">
             <GitPullRequest className="w-3.5 h-3.5" />
             {bounty.submission_count} PRs
@@ -120,7 +122,7 @@ export function BountyCard({ bounty }: BountyCardProps) {
       </div>
 
       {/* Status badge */}
-      <span className={`absolute bottom-4 right-5 text-xs font-medium inline-flex items-center gap-1 ${statusColor}`}>
+      <span className={`mt-3 text-xs font-medium inline-flex items-center gap-1 ${statusColor} sm:absolute sm:bottom-4 sm:right-5 sm:mt-0`}>
         <span className={`w-1.5 h-1.5 rounded-full ${dotColor}`} />
         {statusLabel}
       </span>

--- a/frontend/src/components/bounty/BountyGrid.tsx
+++ b/frontend/src/components/bounty/BountyGrid.tsx
@@ -28,20 +28,20 @@ export function BountyGrid() {
         {/* Header row */}
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-8">
           <h2 className="font-sans text-2xl font-semibold text-text-primary">Open Bounties</h2>
-          <div className="flex items-center gap-2">
+          <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center">
             <Link
               to="/bounties/create"
-              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-emerald text-forge-950 font-semibold text-sm hover:bg-emerald/90 transition-colors duration-150"
+              className="inline-flex items-center justify-center gap-1.5 px-3 py-2 sm:py-1.5 rounded-lg bg-emerald text-forge-950 font-semibold text-sm hover:bg-emerald/90 transition-colors duration-150"
             >
               <Plus className="w-4 h-4" />
               Post a Bounty
             </Link>
             {/* Status filter */}
-            <div className="relative">
+            <div className="relative w-full sm:w-auto">
               <select
                 value={statusFilter}
                 onChange={(e) => setStatusFilter(e.target.value)}
-                className="appearance-none bg-forge-800 border border-border rounded-lg px-3 py-1.5 pr-8 text-sm text-text-secondary font-medium focus:border-emerald outline-none transition-colors duration-150 cursor-pointer"
+                className="w-full appearance-none bg-forge-800 border border-border rounded-lg px-3 py-2 sm:py-1.5 pr-8 text-sm text-text-secondary font-medium focus:border-emerald outline-none transition-colors duration-150 cursor-pointer"
               >
                 <option value="open">Open</option>
                 <option value="funded">Funded</option>

--- a/frontend/src/components/home/ActivityFeed.tsx
+++ b/frontend/src/components/home/ActivityFeed.tsx
@@ -57,7 +57,7 @@ function getActionText(type: ActivityEvent['type']) {
 function EventItem({ event }: { event: ActivityEvent }) {
   const isMagenta = event.type === 'review';
   return (
-    <div className="flex items-center gap-3 py-2 px-3 rounded-lg hover:bg-forge-850 transition-colors duration-150">
+    <div className="flex items-start gap-3 py-2 px-3 rounded-lg hover:bg-forge-850 transition-colors duration-150">
       {event.avatar_url ? (
         <img src={event.avatar_url} className="w-6 h-6 rounded-full flex-shrink-0" alt="" />
       ) : (
@@ -65,12 +65,12 @@ function EventItem({ event }: { event: ActivityEvent }) {
           <span className="font-mono text-xs text-text-muted">{event.username[0]?.toUpperCase()}</span>
         </div>
       )}
-      <p className="text-sm text-text-secondary flex-1 truncate">
+      <p className="min-w-0 text-sm text-text-secondary flex-1 break-words">
         <span className="font-medium text-text-primary">{event.username}</span>
         {' '}{getActionText(event.type)}{' '}
-        <span className={`font-mono ${isMagenta ? 'text-magenta' : 'text-emerald'}`}>{event.detail}</span>
+        <span className={`font-mono break-words ${isMagenta ? 'text-magenta' : 'text-emerald'}`}>{event.detail}</span>
       </p>
-      <span className="font-mono text-xs text-text-muted flex-shrink-0">{timeAgo(event.timestamp)}</span>
+      <span className="mt-0.5 font-mono text-xs text-text-muted flex-shrink-0 whitespace-nowrap">{timeAgo(event.timestamp)}</span>
     </div>
   );
 }

--- a/frontend/src/components/home/HeroSection.tsx
+++ b/frontend/src/components/home/HeroSection.tsx
@@ -87,7 +87,7 @@ export function HeroSection() {
   };
 
   return (
-    <section className="relative min-h-[90vh] flex flex-col items-center justify-center px-4 pt-24 pb-16 overflow-hidden">
+    <section className="relative min-h-[90vh] flex flex-col items-center justify-center px-4 pt-20 sm:pt-24 pb-14 sm:pb-16 overflow-hidden">
       {/* Background layers */}
       <div className="absolute inset-0 bg-grid-forge bg-grid-forge pointer-events-none" style={{ backgroundSize: '40px 40px' }} />
       <div className="absolute inset-0 bg-gradient-hero pointer-events-none" />
@@ -101,21 +101,24 @@ export function HeroSection() {
         className="w-full max-w-xl rounded-xl border border-border bg-forge-900/90 backdrop-blur-sm overflow-hidden shadow-2xl shadow-black/50"
       >
         {/* Title bar */}
-        <div className="flex items-center gap-2 px-4 py-2.5 bg-forge-800 border-b border-border">
+        <div className="flex items-center gap-2 px-3 sm:px-4 py-2.5 bg-forge-800 border-b border-border">
           <div className="flex gap-1.5">
             <span className="w-3 h-3 rounded-full bg-status-error/80" />
             <span className="w-3 h-3 rounded-full bg-status-warning/80" />
             <span className="w-3 h-3 rounded-full bg-status-success/80" />
           </div>
-          <span className="font-mono text-xs text-text-muted ml-2">solfoundry — terminal</span>
+          <span className="font-mono text-xs text-text-muted ml-2 truncate">solfoundry terminal</span>
         </div>
 
         {/* Terminal body */}
-        <div className="p-5 font-mono text-sm leading-relaxed">
-          <div className="overflow-hidden">
+        <div className="p-4 sm:p-5 font-mono text-xs sm:text-sm leading-relaxed">
+          <div className="overflow-hidden whitespace-nowrap">
             <span className="text-emerald">$ </span>
-            <span className="text-text-secondary overflow-hidden whitespace-nowrap inline-block animate-typewriter">
+            <span className="hidden sm:inline-block text-text-secondary overflow-hidden whitespace-nowrap max-w-[calc(100%-1rem)] align-bottom animate-typewriter">
               forge bounty --reward 100 --lang typescript --tier 2
+            </span>
+            <span className="sm:hidden inline-block text-text-secondary overflow-hidden whitespace-nowrap max-w-[calc(100%-1rem)] align-bottom animate-typewriter">
+              forge bounty --tier 2
             </span>
             {typewriterDone && (
               <span className="inline-block w-2 h-5 bg-emerald animate-blink ml-0.5 align-middle" />
@@ -154,7 +157,7 @@ export function HeroSection() {
         initial={{ opacity: 0, y: 16 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ delay: 0.3, duration: 0.5 }}
-        className="font-display text-4xl md:text-5xl font-bold text-text-primary tracking-wider text-center mt-10"
+        className="font-display text-3xl sm:text-4xl md:text-5xl font-bold text-text-primary tracking-wide text-center mt-8 sm:mt-10 leading-tight"
       >
         THE AI-POWERED BOUNTY{' '}
         <span className="text-emerald">FORGE</span>
@@ -164,7 +167,7 @@ export function HeroSection() {
         initial={{ opacity: 0, y: 12 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ delay: 0.45, duration: 0.5 }}
-        className="font-sans text-lg text-text-secondary text-center mt-4 max-w-lg"
+        className="font-sans text-base sm:text-lg text-text-secondary text-center mt-4 max-w-lg"
       >
         Fund bounties. Ship code. Earn rewards.
       </motion.p>
@@ -174,12 +177,12 @@ export function HeroSection() {
         initial={{ opacity: 0, y: 12 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ delay: 0.6, duration: 0.5 }}
-        className="flex flex-wrap items-center justify-center gap-4 mt-8"
+        className="flex w-full flex-wrap items-center justify-center gap-3 sm:gap-4 mt-8"
       >
         <motion.div variants={buttonHover} initial="rest" whileHover="hover" whileTap="tap">
           <Link
             to="/bounties"
-            className="px-6 py-3 rounded-lg bg-emerald text-text-inverse font-semibold text-sm hover:bg-emerald-light transition-colors duration-200 shadow-lg shadow-emerald/20 inline-block"
+            className="w-full max-w-xs sm:w-auto px-6 py-3 rounded-lg bg-emerald text-text-inverse font-semibold text-sm hover:bg-emerald-light transition-colors duration-200 shadow-lg shadow-emerald/20 inline-block text-center"
           >
             Browse Bounties
           </Link>
@@ -188,7 +191,7 @@ export function HeroSection() {
         <motion.div variants={buttonHover} initial="rest" whileHover="hover" whileTap="tap">
           <Link
             to="/bounties/create"
-            className="px-6 py-3 rounded-lg border border-emerald text-emerald font-semibold text-sm hover:bg-emerald-bg transition-colors duration-200 inline-block"
+            className="w-full max-w-xs sm:w-auto px-6 py-3 rounded-lg border border-emerald text-emerald font-semibold text-sm hover:bg-emerald-bg transition-colors duration-200 inline-block text-center"
           >
             Post a Bounty
           </Link>
@@ -198,7 +201,7 @@ export function HeroSection() {
           <motion.div variants={buttonHover} initial="rest" whileHover="hover" whileTap="tap">
             <button
               onClick={handleSignIn}
-              className="px-6 py-3 rounded-lg border border-border text-text-secondary font-medium text-sm hover:border-border-hover hover:text-text-primary transition-all duration-200 inline-flex items-center gap-2"
+              className="w-full max-w-xs sm:w-auto px-6 py-3 rounded-lg border border-border text-text-secondary font-medium text-sm hover:border-border-hover hover:text-text-primary transition-all duration-200 inline-flex items-center justify-center gap-2"
             >
               <GitHubIcon /> GitHub
             </button>
@@ -211,7 +214,7 @@ export function HeroSection() {
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         transition={{ delay: 0.8, duration: 0.5 }}
-        className="flex items-center justify-center gap-6 mt-8 font-mono text-sm text-text-muted"
+        className="flex flex-wrap items-center justify-center gap-x-4 gap-y-2 sm:gap-x-6 mt-8 font-mono text-xs sm:text-sm text-text-muted"
       >
         <span>
           <span className="text-text-primary font-semibold">

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -27,14 +27,14 @@ export function Footer() {
   };
 
   return (
-    <footer className="relative mt-24 border-t border-border bg-forge-950">
+    <footer className="relative mt-16 sm:mt-24 border-t border-border bg-forge-950 overflow-hidden">
       {/* Magenta accent line */}
       <div className="absolute top-0 left-0 right-0 h-px bg-gradient-footer opacity-50" />
 
-      <div className="max-w-7xl mx-auto px-4 py-12">
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-10">
+      <div className="max-w-7xl mx-auto px-4 py-10 sm:py-12">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8 lg:gap-10">
           {/* Col 1: Brand */}
-          <div>
+          <div className="min-w-0">
             <div className="flex items-center gap-2 mb-3">
               <img src="/logo-icon.png" alt="SolFoundry" className="w-6 h-6" />
               <span className="font-display text-lg font-semibold text-text-primary">SolFoundry</span>
@@ -45,7 +45,7 @@ export function Footer() {
           </div>
 
           {/* Col 2: Platform */}
-          <div>
+          <div className="min-w-0">
             <h4 className="font-sans text-sm font-semibold text-text-primary mb-4">Platform</h4>
             <ul className="space-y-2">
               {[
@@ -64,7 +64,7 @@ export function Footer() {
           </div>
 
           {/* Col 3: Social */}
-          <div>
+          <div className="min-w-0">
             <h4 className="font-sans text-sm font-semibold text-text-primary mb-4">Social</h4>
             <div className="flex flex-col gap-3">
               <a
@@ -89,10 +89,10 @@ export function Footer() {
           </div>
 
           {/* Col 4: Token */}
-          <div>
+          <div className="min-w-0">
             <h4 className="font-sans text-sm font-semibold text-text-primary mb-4">$FNDRY Token</h4>
             <p className="text-sm text-text-muted mb-3">Contract Address:</p>
-            <div className="font-mono text-xs text-text-muted bg-forge-800 rounded px-3 py-2 inline-flex items-center gap-2 w-full">
+            <div className="font-mono text-xs text-text-muted bg-forge-800 rounded px-3 py-2 inline-flex items-center gap-2 w-full min-w-0">
               <span className="truncate">{FNDRY_CA.slice(0, 8)}...{FNDRY_CA.slice(-4)}</span>
               <button
                 onClick={copyCA}

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -33,6 +33,11 @@ export function Navbar() {
     return () => window.removeEventListener('scroll', onScroll);
   }, []);
 
+  useEffect(() => {
+    setMenuOpen(false);
+    setDropdownOpen(false);
+  }, [location.pathname]);
+
   const handleGitHubSignIn = async () => {
     try {
       const url = await getGitHubAuthorizeUrl();
@@ -168,6 +173,10 @@ export function Navbar() {
           {/* Mobile hamburger */}
           <button
             onClick={() => setMenuOpen(!menuOpen)}
+            type="button"
+            aria-label={menuOpen ? 'Close navigation menu' : 'Open navigation menu'}
+            aria-expanded={menuOpen}
+            aria-controls="mobile-navigation"
             className="md:hidden p-2 rounded-lg hover:bg-forge-800 transition-colors text-text-secondary"
           >
             {menuOpen ? <X className="w-5 h-5" /> : <Menu className="w-5 h-5" />}
@@ -179,6 +188,7 @@ export function Navbar() {
       <AnimatePresence>
         {menuOpen && (
           <motion.div
+            id="mobile-navigation"
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: 'auto' }}
             exit={{ opacity: 0, height: 0 }}
@@ -190,7 +200,11 @@ export function Navbar() {
                   key={link.to}
                   to={link.to}
                   onClick={() => setMenuOpen(false)}
-                  className="px-4 py-2.5 rounded-lg text-sm font-medium text-text-secondary hover:text-text-primary hover:bg-forge-850 transition-colors duration-150"
+                  className={`px-4 py-3 rounded-lg text-sm font-medium transition-colors duration-150 ${
+                    isActive(link.to)
+                      ? 'bg-forge-850 text-text-primary'
+                      : 'text-text-secondary hover:text-text-primary hover:bg-forge-850'
+                  }`}
                 >
                   {link.label}
                 </Link>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -115,6 +115,7 @@
 html {
   scroll-behavior: smooth;
   font-size: 16px;
+  overflow-x: clip;
 }
 
 body {
@@ -123,6 +124,32 @@ body {
   -moz-osx-font-smoothing: grayscale;
   background-color: #050505;
   color: #F0F0F5;
+  min-width: 0;
+  overflow-x: clip;
+}
+
+#root {
+  min-width: 0;
+  overflow-x: clip;
+}
+
+@supports not (overflow: clip) {
+  html,
+  body,
+  #root {
+    overflow-x: hidden;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+img,
+svg,
+video,
+canvas {
+  max-width: 100%;
 }
 
 /* Custom scrollbar */

--- a/frontend/src/lib/animations.ts
+++ b/frontend/src/lib/animations.ts
@@ -1,0 +1,47 @@
+import type { Variants } from 'framer-motion';
+
+export const fadeIn: Variants = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.35, ease: 'easeOut' } },
+};
+
+export const pageTransition: Variants = {
+  initial: { opacity: 0 },
+  animate: { opacity: 1, transition: { duration: 0.3, ease: 'easeOut' } },
+  exit: { opacity: 0, transition: { duration: 0.2, ease: 'easeIn' } },
+};
+
+export const staggerContainer: Variants = {
+  initial: {},
+  animate: {
+    transition: {
+      staggerChildren: 0.06,
+    },
+  },
+};
+
+export const staggerItem: Variants = {
+  initial: { opacity: 0, y: 10 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.3, ease: 'easeOut' } },
+};
+
+export const slideInRight: Variants = {
+  initial: { opacity: 0, x: 24 },
+  animate: { opacity: 1, x: 0, transition: { duration: 0.3, ease: 'easeOut' } },
+  exit: { opacity: 0, x: 24, transition: { duration: 0.2, ease: 'easeIn' } },
+};
+
+export const cardHover: Variants = {
+  rest: { y: 0, borderColor: '#1E1E2E' },
+  hover: {
+    y: -4,
+    borderColor: '#2E2E42',
+    transition: { duration: 0.2, ease: 'easeOut' },
+  },
+};
+
+export const buttonHover: Variants = {
+  rest: { scale: 1 },
+  hover: { scale: 1.02, transition: { duration: 0.15, ease: 'easeOut' } },
+  tap: { scale: 0.98 },
+};

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,75 @@
+export const LANG_COLORS: Record<string, string> = {
+  TypeScript: '#3178C6',
+  JavaScript: '#F7DF1E',
+  Python: '#3776AB',
+  Rust: '#DEA584',
+  Go: '#00ADD8',
+  Solidity: '#363636',
+  Java: '#B07219',
+  C: '#555555',
+  'C++': '#F34B7D',
+  Ruby: '#CC342D',
+  Swift: '#FA7343',
+  Kotlin: '#A97BFF',
+  Shell: '#89E051',
+};
+
+export function formatCurrency(amount?: number | string | null, token = 'USDC') {
+  const numericAmount = Number(amount ?? 0);
+  const formattedAmount = Number.isFinite(numericAmount)
+    ? numericAmount.toLocaleString(undefined, { maximumFractionDigits: 2 })
+    : '0';
+
+  if (token.toUpperCase() === 'USDC' || token === '$') {
+    return `$${formattedAmount}`;
+  }
+
+  return `${formattedAmount} ${token}`;
+}
+
+export function timeAgo(value?: string | Date | null) {
+  if (!value) return 'recently';
+
+  const date = value instanceof Date ? value : new Date(value);
+  const timestamp = date.getTime();
+  if (Number.isNaN(timestamp)) return 'recently';
+
+  const seconds = Math.max(0, Math.floor((Date.now() - timestamp) / 1000));
+  const units: Array<[Intl.RelativeTimeFormatUnit, number]> = [
+    ['year', 60 * 60 * 24 * 365],
+    ['month', 60 * 60 * 24 * 30],
+    ['week', 60 * 60 * 24 * 7],
+    ['day', 60 * 60 * 24],
+    ['hour', 60 * 60],
+    ['minute', 60],
+  ];
+
+  for (const [unit, size] of units) {
+    const count = Math.floor(seconds / size);
+    if (count >= 1) {
+      return new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' }).format(-count, unit);
+    }
+  }
+
+  return 'just now';
+}
+
+export function timeLeft(value?: string | Date | null) {
+  if (!value) return 'No deadline';
+
+  const date = value instanceof Date ? value : new Date(value);
+  const timestamp = date.getTime();
+  if (Number.isNaN(timestamp)) return 'No deadline';
+
+  const seconds = Math.floor((timestamp - Date.now()) / 1000);
+  if (seconds <= 0) return 'Expired';
+
+  const days = Math.floor(seconds / (60 * 60 * 24));
+  if (days >= 1) return `${days}d left`;
+
+  const hours = Math.floor(seconds / (60 * 60));
+  if (hours >= 1) return `${hours}h left`;
+
+  const minutes = Math.max(1, Math.floor(seconds / 60));
+  return `${minutes}m left`;
+}


### PR DESCRIPTION
## Description
Fixes the mobile responsive polish bounty for #824 by tightening the 375px and 768px layouts across the bounty cards, navigation, hero terminal, activity feed, and footer.

Changes include:
- bounty cards now wrap repo/title/skill/reward/meta content safely on narrow screens
- mobile card status badges are placed in normal flow to avoid overlapping the reward/meta row
- bounty page action controls stack full-width at 375px and return inline at larger breakpoints
- mobile hamburger has accessible expanded/collapsed state and closes on route changes
- hero terminal uses a compact mobile command, smaller mobile type, full-width CTA behavior, and wrapped stats
- activity feed detail text wraps instead of clipping or pushing outside the viewport
- footer columns and token address are constrained to avoid overflow
- global overflow guards prevent accidental horizontal scrolling
- restores the shared `src/lib` modules required by existing frontend imports and narrows the root `.gitignore` `lib/` rule so frontend source libs can be tracked

Closes #824

## Solana Wallet for Payout
**Wallet:** C2z3FWAacvSYVrrkfpk6nQyNhF4t3z7t9iXRW1xfZPy1

## Type of Change
- [x] Bug fix
- [x] Responsive/mobile polish
- [x] Test addition/update

## Checklist
- [x] One PR per bounty
- [x] Bounty cards stack and wrap properly on mobile
- [x] Navigation hamburger opens, closes, and exposes accessible state
- [x] Hero terminal is readable on small screens
- [x] Footer does not overflow
- [x] No horizontal scroll at 375px or 768px in viewport QA
- [x] No hardcoded secrets or private keys

## Testing
- [x] `npm test -- mobile-responsive-polish.test.tsx`
- [x] `npm run build`
- [x] `git diff --check`
- [x] Local Chrome viewport QA at 375x812 and 768x1024 for `/` and `/bounties` with mocked bounty API data
  - `documentElement.scrollWidth === innerWidth`
  - `body.scrollWidth === innerWidth`
  - no measured elements outside the viewport bounds
  - mocked mobile bounty card rendered at 343px width with status below reward/meta content
