### PR TITLE
Add search bar to bounties page

### DIFF
--- a/frontend/src/__tests__/bounty-grid-search.test.ts
+++ b/frontend/src/__tests__/bounty-grid-search.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { matchesBountySearch } from '../components/bounty/BountyGrid';
+
+const bounty = {
+  title: 'Add wallet connect flow',
+  description: 'Build a React onboarding experience for Solana users',
+  category: 'frontend',
+  org_name: 'SolFoundry',
+  repo_name: 'client',
+  skills: ['TypeScript', 'React'],
+};
+
+describe('matchesBountySearch', () => {
+  it('matches title, description, tags, and repo metadata', () => {
+    expect(matchesBountySearch(bounty, 'wallet')).toBe(true);
+    expect(matchesBountySearch(bounty, 'onboarding')).toBe(true);
+    expect(matchesBountySearch(bounty, 'typescript')).toBe(true);
+    expect(matchesBountySearch(bounty, 'client')).toBe(true);
+  });
+
+  it('is case-insensitive and treats empty search as a match', () => {
+    expect(matchesBountySearch(bounty, 'REACT')).toBe(true);
+    expect(matchesBountySearch(bounty, '   ')).toBe(true);
+  });
+
+  it('rejects unrelated search terms', () => {
+    expect(matchesBountySearch(bounty, 'python')).toBe(false);
+  });
+});

--- a/frontend/src/components/bounty/BountyGrid.tsx
+++ b/frontend/src/components/bounty/BountyGrid.tsx
@@ -1,16 +1,55 @@
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { ChevronDown, Loader2, Plus } from 'lucide-react';
+import { ChevronDown, Loader2, Plus, Search, X } from 'lucide-react';
 import { BountyCard } from './BountyCard';
 import { useInfiniteBounties } from '../../hooks/useBounties';
 import { staggerContainer, staggerItem } from '../../lib/animations';
 
 const FILTER_SKILLS = ['All', 'TypeScript', 'Rust', 'Solidity', 'Python', 'Go', 'JavaScript'];
 
+export function matchesBountySearch(
+  bounty: {
+    title: string;
+    description: string;
+    category?: string | null;
+    org_name?: string | null;
+    repo_name?: string | null;
+    skills?: string[];
+  },
+  query: string,
+) {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return true;
+
+  const searchableText = [
+    bounty.title,
+    bounty.description,
+    bounty.category,
+    bounty.org_name,
+    bounty.repo_name,
+    ...(bounty.skills ?? []),
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+
+  return searchableText.includes(normalizedQuery);
+}
+
 export function BountyGrid() {
   const [activeSkill, setActiveSkill] = useState<string>('All');
   const [statusFilter, setStatusFilter] = useState<string>('open');
+  const [searchInput, setSearchInput] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      setDebouncedSearch(searchInput.trim().toLowerCase());
+    }, 250);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [searchInput]);
 
   const params = {
     status: statusFilter,
@@ -21,6 +60,9 @@ export function BountyGrid() {
     useInfiniteBounties(params);
 
   const allBounties = data?.pages.flatMap((p) => p.items) ?? [];
+  const visibleBounties = useMemo(() => {
+    return allBounties.filter((bounty) => matchesBountySearch(bounty, debouncedSearch));
+  }, [allBounties, debouncedSearch]);
 
   return (
     <section id="bounties" className="py-16 md:py-24">
@@ -53,8 +95,31 @@ export function BountyGrid() {
           </div>
         </div>
 
-        {/* Filter pills */}
-        <div className="flex items-center gap-2 flex-wrap mb-8">
+        {/* Search and filter pills */}
+        <div className="mb-8 space-y-4">
+          <div className="relative max-w-xl">
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-muted" />
+            <input
+              type="search"
+              value={searchInput}
+              onChange={(event) => setSearchInput(event.target.value)}
+              placeholder="Search bounties by title, description, or tags"
+              aria-label="Search bounties"
+              className="w-full rounded-xl border border-border bg-forge-900 py-2.5 pl-10 pr-11 text-sm text-text-primary placeholder:text-text-muted outline-none transition-colors duration-150 focus:border-emerald"
+            />
+            {searchInput && (
+              <button
+                type="button"
+                onClick={() => setSearchInput('')}
+                aria-label="Clear bounty search"
+                className="absolute right-2 top-1/2 inline-flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-lg text-text-muted transition-colors duration-150 hover:bg-forge-800 hover:text-text-primary"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            )}
+          </div>
+
+          <div className="flex items-center gap-2 flex-wrap">
           {FILTER_SKILLS.map((skill) => (
             <button
               key={skill}
@@ -68,6 +133,7 @@ export function BountyGrid() {
               {skill}
             </button>
           ))}
+          </div>
         </div>
 
         {/* Loading state */}
@@ -93,17 +159,21 @@ export function BountyGrid() {
         )}
 
         {/* Empty state */}
-        {!isLoading && !isError && allBounties.length === 0 && (
+        {!isLoading && !isError && visibleBounties.length === 0 && (
           <div className="text-center py-16">
             <p className="text-text-muted text-lg mb-2">No bounties found</p>
             <p className="text-text-muted text-sm">
-              {activeSkill !== 'All' ? `Try a different language filter.` : 'Check back soon for new bounties.'}
+              {debouncedSearch
+                ? 'Try a different search term or clear the search.'
+                : activeSkill !== 'All'
+                  ? 'Try a different language filter.'
+                  : 'Check back soon for new bounties.'}
             </p>
           </div>
         )}
 
         {/* Bounty grid */}
-        {!isLoading && allBounties.length > 0 && (
+        {!isLoading && visibleBounties.length > 0 && (
           <motion.div
             variants={staggerContainer}
             initial="initial"
@@ -111,7 +181,7 @@ export function BountyGrid() {
             viewport={{ once: true, margin: '-50px' }}
             className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5"
           >
-            {allBounties.map((bounty) => (
+            {visibleBounties.map((bounty) => (
               <motion.div key={bounty.id} variants={staggerItem}>
                 <BountyCard bounty={bounty} />
               </motion.div>

--- a/frontend/src/lib/animations.ts
+++ b/frontend/src/lib/animations.ts
@@ -1,0 +1,43 @@
+import type { Variants } from 'framer-motion';
+
+export const fadeIn: Variants = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.35, ease: 'easeOut' } },
+  exit: { opacity: 0, y: 8, transition: { duration: 0.2, ease: 'easeIn' } },
+};
+
+export const pageTransition: Variants = {
+  initial: { opacity: 0 },
+  animate: { opacity: 1, transition: { duration: 0.25, ease: 'easeOut' } },
+  exit: { opacity: 0, transition: { duration: 0.18, ease: 'easeIn' } },
+};
+
+export const staggerContainer: Variants = {
+  initial: {},
+  animate: {
+    transition: {
+      staggerChildren: 0.06,
+    },
+  },
+};
+
+export const staggerItem: Variants = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.28, ease: 'easeOut' } },
+};
+
+export const cardHover: Variants = {
+  rest: { y: 0, scale: 1 },
+  hover: { y: -3, scale: 1.01, transition: { duration: 0.18, ease: 'easeOut' } },
+};
+
+export const buttonHover: Variants = {
+  rest: { scale: 1 },
+  hover: { scale: 1.03, transition: { duration: 0.15, ease: 'easeOut' } },
+  tap: { scale: 0.98 },
+};
+
+export const slideInRight: Variants = {
+  initial: { opacity: 0, x: 24 },
+  animate: { opacity: 1, x: 0, transition: { duration: 0.25, ease: 'easeOut' } },
+};

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,55 @@
+export const LANG_COLORS: Record<string, string> = {
+  TypeScript: '#3178c6',
+  JavaScript: '#f1e05a',
+  Rust: '#dea584',
+  Solidity: '#aa6746',
+  Python: '#3572a5',
+  Go: '#00add8',
+  React: '#61dafb',
+  TS: '#3178c6',
+  Sol: '#9945ff',
+};
+
+export function formatCurrency(amount: number, token = 'FNDRY') {
+  const formatted =
+    amount >= 1_000_000
+      ? `${(amount / 1_000_000).toFixed(1)}M`
+      : amount >= 1_000
+        ? `${(amount / 1_000).toFixed(1)}k`
+        : amount.toLocaleString();
+
+  return `${formatted} ${token}`;
+}
+
+export function timeAgo(date: string | Date) {
+  const timestamp = new Date(date).getTime();
+  const diffMs = Date.now() - timestamp;
+  const diffMinutes = Math.floor(diffMs / 60_000);
+
+  if (diffMinutes < 1) return 'just now';
+  if (diffMinutes < 60) return `${diffMinutes}m ago`;
+
+  const diffHours = Math.floor(diffMinutes / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays < 30) return `${diffDays}d ago`;
+
+  const diffMonths = Math.floor(diffDays / 30);
+  if (diffMonths < 12) return `${diffMonths}mo ago`;
+
+  return `${Math.floor(diffMonths / 12)}y ago`;
+}
+
+export function timeLeft(date: string | Date) {
+  const timestamp = new Date(date).getTime();
+  const diffMs = timestamp - Date.now();
+
+  if (diffMs <= 0) return 'Expired';
+
+  const diffHours = Math.ceil(diffMs / 3_600_000);
+  if (diffHours < 24) return `${diffHours}h left`;
+
+  const diffDays = Math.ceil(diffHours / 24);
+  return `${diffDays}d left`;
+}


### PR DESCRIPTION
Fixes #823.

## Summary
- Add a debounced search input to the `/bounties` grid
- Filter visible bounties by title, description, category, org/repo metadata, and skills/tags
- Add a clear-search button and search-aware empty state
- Add focused tests for the search matcher
- Restore missing frontend `lib/animations` and `lib/utils` helpers so the frontend production build resolves existing imports

## Verification
- `npm test -- bounty-grid-search.test.ts`
- `npm run build`

## Notes
- The local backend was not running, so browser data-loading verification was limited; the search UI was added to the bounties page and the matcher behavior is covered by the focused unit test.