### PR TITLE
Add bounty countdown timer

### DIFF
--- a/frontend/src/__tests__/countdown-timer.test.ts
+++ b/frontend/src/__tests__/countdown-timer.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { getCountdownState } from '../components/bounty/CountdownTimer';
+
+const now = new Date('2026-05-14T12:00:00Z').getTime();
+
+describe('getCountdownState', () => {
+  it('formats days, hours, and minutes remaining', () => {
+    const state = getCountdownState('2026-05-16T14:30:00Z', now);
+
+    expect(state.label).toBe('2d 2h 30m');
+    expect(state.expired).toBe(false);
+    expect(state.warning).toBe(false);
+  });
+
+  it('marks deadlines under 24 hours as warning', () => {
+    const state = getCountdownState('2026-05-15T06:00:00Z', now);
+
+    expect(state.label).toBe('18h 0m');
+    expect(state.warning).toBe(true);
+    expect(state.urgent).toBe(false);
+  });
+
+  it('marks deadlines under 1 hour as urgent', () => {
+    const state = getCountdownState('2026-05-14T12:30:00Z', now);
+
+    expect(state.label).toBe('30m');
+    expect(state.warning).toBe(true);
+    expect(state.urgent).toBe(true);
+  });
+
+  it('shows expired when the deadline has passed', () => {
+    const state = getCountdownState('2026-05-14T11:59:00Z', now);
+
+    expect(state.label).toBe('Expired');
+    expect(state.expired).toBe(true);
+  });
+});

--- a/frontend/src/components/bounty/BountyCard.tsx
+++ b/frontend/src/components/bounty/BountyCard.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { GitPullRequest, Clock } from 'lucide-react';
+import { GitPullRequest } from 'lucide-react';
 import type { Bounty } from '../../types/bounty';
 import { cardHover } from '../../lib/animations';
-import { timeLeft, formatCurrency, LANG_COLORS } from '../../lib/utils';
+import { formatCurrency, LANG_COLORS } from '../../lib/utils';
+import { CountdownTimer } from './CountdownTimer';
 
 function TierBadge({ tier }: { tier: string }) {
   const styles: Record<string, string> = {
@@ -111,10 +112,7 @@ export function BountyCard({ bounty }: BountyCardProps) {
             {bounty.submission_count} PRs
           </span>
           {bounty.deadline && (
-            <span className="inline-flex items-center gap-1">
-              <Clock className="w-3.5 h-3.5" />
-              {timeLeft(bounty.deadline)}
-            </span>
+            <CountdownTimer deadline={bounty.deadline} compact />
           )}
         </div>
       </div>

--- a/frontend/src/components/bounty/BountyDetail.tsx
+++ b/frontend/src/components/bounty/BountyDetail.tsx
@@ -1,12 +1,13 @@
 import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { ArrowLeft, Clock, GitPullRequest, ExternalLink, Loader2, Check, Copy } from 'lucide-react';
+import { ArrowLeft, GitPullRequest, ExternalLink, Loader2, Check, Copy } from 'lucide-react';
 import type { Bounty } from '../../types/bounty';
-import { timeLeft, timeAgo, formatCurrency, LANG_COLORS } from '../../lib/utils';
+import { timeAgo, formatCurrency, LANG_COLORS } from '../../lib/utils';
 import { useAuth } from '../../hooks/useAuth';
 import { SubmissionForm } from './SubmissionForm';
 import { fadeIn } from '../../lib/animations';
+import { CountdownTimer } from './CountdownTimer';
 
 interface BountyDetailProps {
   bounty: Bounty;
@@ -138,9 +139,7 @@ export function BountyDetail({ bounty }: BountyDetailProps) {
             {bounty.deadline && (
               <div className="flex items-center justify-between text-sm">
                 <span className="text-text-muted">Deadline</span>
-                <span className="font-mono text-status-warning inline-flex items-center gap-1">
-                  <Clock className="w-3.5 h-3.5" /> {timeLeft(bounty.deadline)}
-                </span>
+                <CountdownTimer deadline={bounty.deadline} />
               </div>
             )}
             <div className="flex items-center justify-between text-sm">

--- a/frontend/src/components/bounty/CountdownTimer.tsx
+++ b/frontend/src/components/bounty/CountdownTimer.tsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Clock } from 'lucide-react';
+
+type CountdownTimerProps = {
+  deadline: string | Date;
+  compact?: boolean;
+};
+
+export function getCountdownState(deadline: string | Date, now = Date.now()) {
+  const target = new Date(deadline).getTime();
+  const diffMs = target - now;
+
+  if (!Number.isFinite(target) || diffMs <= 0) {
+    return {
+      expired: true,
+      urgent: false,
+      warning: false,
+      label: 'Expired',
+    };
+  }
+
+  const totalMinutes = Math.ceil(diffMs / 60_000);
+  const days = Math.floor(totalMinutes / 1_440);
+  const hours = Math.floor((totalMinutes % 1_440) / 60);
+  const minutes = totalMinutes % 60;
+
+  const parts = [
+    days > 0 ? `${days}d` : null,
+    hours > 0 || days > 0 ? `${hours}h` : null,
+    `${minutes}m`,
+  ].filter(Boolean);
+
+  return {
+    expired: false,
+    urgent: diffMs < 3_600_000,
+    warning: diffMs < 86_400_000,
+    label: parts.join(' '),
+  };
+}
+
+export function CountdownTimer({ deadline, compact = false }: CountdownTimerProps) {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const intervalId = window.setInterval(() => setNow(Date.now()), 60_000);
+    return () => window.clearInterval(intervalId);
+  }, []);
+
+  const countdown = useMemo(() => getCountdownState(deadline, now), [deadline, now]);
+
+  const tone = countdown.expired
+    ? 'text-text-muted'
+    : countdown.urgent
+      ? 'text-status-error'
+      : countdown.warning
+        ? 'text-status-warning'
+        : 'text-text-muted';
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1 font-mono ${compact ? 'text-xs' : 'text-sm'} ${tone}`}
+      aria-live={countdown.urgent ? 'assertive' : 'polite'}
+      title={new Date(deadline).toLocaleString()}
+    >
+      <Clock className={compact ? 'h-3.5 w-3.5' : 'h-4 w-4'} />
+      {countdown.label}
+    </span>
+  );
+}

--- a/frontend/src/lib/animations.ts
+++ b/frontend/src/lib/animations.ts
@@ -1,0 +1,39 @@
+import type { Variants } from 'framer-motion';
+
+export const fadeIn: Variants = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.35, ease: 'easeOut' } },
+  exit: { opacity: 0, y: 8, transition: { duration: 0.2, ease: 'easeIn' } },
+};
+
+export const pageTransition: Variants = {
+  initial: { opacity: 0 },
+  animate: { opacity: 1, transition: { duration: 0.25, ease: 'easeOut' } },
+  exit: { opacity: 0, transition: { duration: 0.18, ease: 'easeIn' } },
+};
+
+export const staggerContainer: Variants = {
+  initial: {},
+  animate: { transition: { staggerChildren: 0.06 } },
+};
+
+export const staggerItem: Variants = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.28, ease: 'easeOut' } },
+};
+
+export const cardHover: Variants = {
+  rest: { y: 0, scale: 1 },
+  hover: { y: -3, scale: 1.01, transition: { duration: 0.18, ease: 'easeOut' } },
+};
+
+export const buttonHover: Variants = {
+  rest: { scale: 1 },
+  hover: { scale: 1.03, transition: { duration: 0.15, ease: 'easeOut' } },
+  tap: { scale: 0.98 },
+};
+
+export const slideInRight: Variants = {
+  initial: { opacity: 0, x: 24 },
+  animate: { opacity: 1, x: 0, transition: { duration: 0.25, ease: 'easeOut' } },
+};

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,42 @@
+export const LANG_COLORS: Record<string, string> = {
+  TypeScript: '#3178c6',
+  JavaScript: '#f1e05a',
+  Rust: '#dea584',
+  Solidity: '#aa6746',
+  Python: '#3572a5',
+  Go: '#00add8',
+  React: '#61dafb',
+  TS: '#3178c6',
+  Sol: '#9945ff',
+};
+
+export function formatCurrency(amount: number, token = 'FNDRY') {
+  const formatted =
+    amount >= 1_000_000
+      ? `${(amount / 1_000_000).toFixed(1)}M`
+      : amount >= 1_000
+        ? `${(amount / 1_000).toFixed(1)}k`
+        : amount.toLocaleString();
+
+  return `${formatted} ${token}`;
+}
+
+export function timeAgo(date: string | Date) {
+  const timestamp = new Date(date).getTime();
+  const diffMs = Date.now() - timestamp;
+  const diffMinutes = Math.floor(diffMs / 60_000);
+
+  if (diffMinutes < 1) return 'just now';
+  if (diffMinutes < 60) return `${diffMinutes}m ago`;
+
+  const diffHours = Math.floor(diffMinutes / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays < 30) return `${diffDays}d ago`;
+
+  const diffMonths = Math.floor(diffDays / 30);
+  if (diffMonths < 12) return `${diffMonths}mo ago`;
+
+  return `${Math.floor(diffMonths / 12)}y ago`;
+}


### PR DESCRIPTION
Fixes #826.

## Summary
- Add a reusable `CountdownTimer` component for bounty deadlines
- Display days/hours/minutes remaining and update every minute without refresh
- Show warning styling under 24 hours and urgent styling under 1 hour
- Show `Expired` once the deadline has passed
- Render the timer on bounty cards and bounty detail pages
- Add focused tests for formatting, warning, urgent, and expired states
- Restore missing frontend `lib/animations` and `lib/utils` helpers so existing imports resolve during production build

## Verification
- `npm test -- countdown-timer.test.ts`
- `npm run build`