### PR TITLE
feat: add contributor profile stats dashboard

### DIFF
--- a/frontend/src/components/bounty/BountyGrid.tsx
+++ b/frontend/src/components/bounty/BountyGrid.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { ChevronDown, Loader2, Plus } from 'lucide-react';
+import { ChevronDown, Loader2, Plus, Search, X } from 'lucide-react';
 import { BountyCard } from './BountyCard';
 import { useInfiniteBounties } from '../../hooks/useBounties';
 import { staggerContainer, staggerItem } from '../../lib/animations';
@@ -11,6 +11,7 @@ const FILTER_SKILLS = ['All', 'TypeScript', 'Rust', 'Solidity', 'Python', 'Go', 
 export function BountyGrid() {
   const [activeSkill, setActiveSkill] = useState<string>('All');
   const [statusFilter, setStatusFilter] = useState<string>('open');
+  const [search, setSearch] = useState('');
 
   const params = {
     status: statusFilter,
@@ -21,6 +22,12 @@ export function BountyGrid() {
     useInfiniteBounties(params);
 
   const allBounties = data?.pages.flatMap((p) => p.items) ?? [];
+  const searchLower = search.trim().toLowerCase();
+  const visibleBounties = searchLower
+    ? allBounties.filter((b) =>
+        `${b.title} ${b.description ?? ''}`.toLowerCase().includes(searchLower)
+      )
+    : allBounties;
 
   return (
     <section id="bounties" className="py-16 md:py-24">
@@ -51,6 +58,27 @@ export function BountyGrid() {
               <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-text-muted pointer-events-none" />
             </div>
           </div>
+        </div>
+
+        {/* Search */}
+        <div className="relative mb-5">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted" />
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search bounties by title or description"
+            className="w-full bg-forge-800 border border-border rounded-lg pl-10 pr-10 py-2.5 text-sm text-text-primary placeholder:text-text-muted focus:border-emerald focus:ring-1 focus:ring-emerald/30 outline-none transition-all duration-150"
+          />
+          {search && (
+            <button
+              onClick={() => setSearch('')}
+              className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-text-muted hover:text-text-primary transition-colors"
+              aria-label="Clear search"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          )}
         </div>
 
         {/* Filter pills */}
@@ -93,17 +121,21 @@ export function BountyGrid() {
         )}
 
         {/* Empty state */}
-        {!isLoading && !isError && allBounties.length === 0 && (
+        {!isLoading && !isError && visibleBounties.length === 0 && (
           <div className="text-center py-16">
             <p className="text-text-muted text-lg mb-2">No bounties found</p>
             <p className="text-text-muted text-sm">
-              {activeSkill !== 'All' ? `Try a different language filter.` : 'Check back soon for new bounties.'}
+              {search
+                ? 'Try another keyword or clear search.'
+                : activeSkill !== 'All'
+                ? 'Try a different language filter.'
+                : 'Check back soon for new bounties.'}
             </p>
           </div>
         )}
 
         {/* Bounty grid */}
-        {!isLoading && allBounties.length > 0 && (
+        {!isLoading && visibleBounties.length > 0 && (
           <motion.div
             variants={staggerContainer}
             initial="initial"
@@ -111,7 +143,7 @@ export function BountyGrid() {
             viewport={{ once: true, margin: '-50px' }}
             className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5"
           >
-            {allBounties.map((bounty) => (
+            {visibleBounties.map((bounty) => (
               <motion.div key={bounty.id} variants={staggerItem}>
                 <BountyCard bounty={bounty} />
               </motion.div>

--- a/frontend/src/components/profile/ProfileDashboard.tsx
+++ b/frontend/src/components/profile/ProfileDashboard.tsx
@@ -1,22 +1,22 @@
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { motion } from 'framer-motion';
-import { Clock, GitPullRequest, DollarSign, Settings } from 'lucide-react';
-import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from 'recharts';
+import { Activity, CalendarDays, DollarSign, Flame, GitCommitHorizontal, GitPullRequest } from 'lucide-react';
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid, LineChart, Line, Legend } from 'recharts';
 import { useAuth } from '../../hooks/useAuth';
 import { useBounties } from '../../hooks/useBounties';
 import { timeAgo, formatCurrency } from '../../lib/utils';
 import { fadeIn, staggerContainer, staggerItem } from '../../lib/animations';
 import type { Bounty } from '../../types/bounty';
 
-const TABS = ['My Bounties', 'My Submissions', 'Earnings', 'Settings'] as const;
+const TABS = ['My Bounties', 'Profile Stats', 'Settings'] as const;
 type Tab = typeof TABS[number];
 
-const MONTHLY_MOCK = [
-  { month: 'Jan', usdc: 200, fndry: 0 },
-  { month: 'Feb', usdc: 500, fndry: 50000 },
-  { month: 'Mar', usdc: 150, fndry: 0 },
-  { month: 'Apr', usdc: 800, fndry: 100000 },
-];
+type GitHubWeek = {
+  week: string;
+  commits: number;
+  prs: number;
+  issues: number;
+};
 
 function BountyStatusBadge({ status }: { status: string }) {
   const styles: Record<string, string> = {
@@ -54,7 +54,7 @@ function MyBountiesTab({ bounties, loading }: { bounties: Bounty[]; loading: boo
           key={b.id}
           variants={staggerItem}
           className="flex items-center gap-4 px-4 py-3 rounded-lg bg-forge-900 border border-border hover:bg-forge-850 transition-colors cursor-pointer"
-          onClick={() => window.location.href = `/bounties/${b.id}`}
+          onClick={() => (window.location.href = `/bounties/${b.id}`)}
         >
           <div className="flex-1 min-w-0">
             <p className="text-sm font-medium text-text-primary truncate">{b.title}</p>
@@ -71,47 +71,158 @@ function MyBountiesTab({ bounties, loading }: { bounties: Bounty[]; loading: boo
   );
 }
 
-function SubmissionsTab() {
-  return (
-    <div className="text-center py-12">
-      <p className="text-text-muted text-sm">No submissions yet.</p>
-      <a href="/" className="text-sm text-emerald hover:text-emerald-light transition-colors mt-2 block">
-        Browse open bounties →
-      </a>
-    </div>
-  );
+function buildGithubWeeks(events: any[]): GitHubWeek[] {
+  const map = new Map<string, GitHubWeek>();
+  for (const e of events) {
+    const d = new Date(e.created_at);
+    const monday = new Date(d);
+    const day = monday.getUTCDay() || 7;
+    monday.setUTCDate(monday.getUTCDate() - day + 1);
+    const key = monday.toISOString().slice(5, 10);
+
+    if (!map.has(key)) map.set(key, { week: key, commits: 0, prs: 0, issues: 0 });
+    const w = map.get(key)!;
+
+    if (e.type === 'PushEvent') {
+      w.commits += Array.isArray(e.payload?.commits) ? e.payload.commits.length : 1;
+    }
+    if (e.type === 'PullRequestEvent' && e.payload?.action === 'opened') {
+      w.prs += 1;
+    }
+    if (e.type === 'IssuesEvent' && e.payload?.action === 'opened') {
+      w.issues += 1;
+    }
+  }
+
+  return Array.from(map.values())
+    .sort((a, b) => a.week.localeCompare(b.week))
+    .slice(-12);
 }
 
-function EarningsTab() {
-  const totalEarned = MONTHLY_MOCK.reduce((s, m) => s + m.usdc, 0);
+function buildEarningsHistory(bounties: Bounty[]) {
+  const monthMap = new Map<string, { month: string; earned: number }>();
+  for (const b of bounties) {
+    if (b.status !== 'completed') continue;
+    const date = new Date(b.created_at);
+    const month = date.toLocaleDateString('en-US', { month: 'short' });
+    if (!monthMap.has(month)) monthMap.set(month, { month, earned: 0 });
+    const rewardInFndry = b.reward_token === 'FNDRY' ? b.reward_amount : b.reward_amount * 100;
+    monthMap.get(month)!.earned += rewardInFndry;
+  }
+
+  const data = Array.from(monthMap.values());
+  if (!data.length) {
+    return [
+      { month: 'Jan', earned: 0 },
+      { month: 'Feb', earned: 0 },
+      { month: 'Mar', earned: 0 },
+      { month: 'Apr', earned: 0 },
+    ];
+  }
+  return data;
+}
+
+function ProfileStatsTab({ username, bounties }: { username: string; bounties: Bounty[] }) {
+  const [githubWeeks, setGithubWeeks] = useState<GitHubWeek[]>([]);
+  const [loadingGitHub, setLoadingGitHub] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+    const run = async () => {
+      setLoadingGitHub(true);
+      try {
+        const res = await fetch(`https://api.github.com/users/${username}/events/public?per_page=100`);
+        if (!res.ok) throw new Error('GitHub API unavailable');
+        const events = await res.json();
+        if (mounted) setGithubWeeks(buildGithubWeeks(events));
+      } catch {
+        if (mounted) setGithubWeeks([]);
+      } finally {
+        if (mounted) setLoadingGitHub(false);
+      }
+    };
+
+    if (username) run();
+    return () => {
+      mounted = false;
+    };
+  }, [username]);
+
+  const completed = bounties.filter((b) => b.status === 'completed').length;
+  const totalEarned = bounties
+    .filter((b) => b.status === 'completed')
+    .reduce((sum, b) => sum + (b.reward_token === 'FNDRY' ? b.reward_amount : b.reward_amount * 100), 0);
+
+  const streak = useMemo(() => {
+    const days = new Set(
+      bounties
+        .map((b) => new Date(b.created_at).toISOString().slice(0, 10))
+        .sort(),
+    );
+    const today = new Date();
+    let current = 0;
+    for (let i = 0; i < 365; i += 1) {
+      const d = new Date(today);
+      d.setDate(today.getDate() - i);
+      const key = d.toISOString().slice(0, 10);
+      if (days.has(key)) current += 1;
+      else if (i > 0) break;
+    }
+    return current;
+  }, [bounties]);
+
+  const earningHistory = useMemo(() => buildEarningsHistory(bounties), [bounties]);
+
   return (
     <div className="space-y-6">
-      <div className="grid grid-cols-3 gap-4">
-        {[
-          { label: 'Total Earned', value: `$${totalEarned}`, color: 'text-emerald' },
-          { label: 'This Month', value: '$800', color: 'text-emerald' },
-          { label: 'Pending', value: '$0', color: 'text-text-muted' },
-        ].map((s) => (
-          <div key={s.label} className="rounded-xl border border-border bg-forge-900 p-4">
-            <p className="text-xs text-text-muted mb-1">{s.label}</p>
-            <p className={`font-mono text-xl font-bold ${s.color}`}>{s.value}</p>
-          </div>
-        ))}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div className="rounded-xl border border-border bg-forge-900 p-4">
+          <p className="text-xs text-text-muted mb-1 inline-flex items-center gap-1"><DollarSign className="w-3.5 h-3.5" />Total Earned</p>
+          <p className="font-mono text-xl font-bold text-emerald">{totalEarned.toLocaleString()} FNDRY</p>
+        </div>
+        <div className="rounded-xl border border-border bg-forge-900 p-4">
+          <p className="text-xs text-text-muted mb-1 inline-flex items-center gap-1"><Activity className="w-3.5 h-3.5" />Bounties Completed</p>
+          <p className="font-mono text-xl font-bold text-text-primary">{completed}</p>
+        </div>
+        <div className="rounded-xl border border-border bg-forge-900 p-4">
+          <p className="text-xs text-text-muted mb-1 inline-flex items-center gap-1"><Flame className="w-3.5 h-3.5" />Contribution Streak</p>
+          <p className="font-mono text-xl font-bold text-text-primary">{streak} day{streak === 1 ? '' : 's'}</p>
+        </div>
       </div>
+
       <div className="rounded-xl border border-border bg-forge-900 p-4">
-        <p className="text-sm font-medium text-text-secondary mb-4">Monthly Earnings</p>
-        <ResponsiveContainer width="100%" height={180}>
-          <BarChart data={MONTHLY_MOCK} margin={{ top: 4, right: 4, bottom: 0, left: 0 }}>
-            <XAxis dataKey="month" axisLine={false} tickLine={false} tick={{ fill: '#5C5C78', fontSize: 12, fontFamily: 'JetBrains Mono' }} />
-            <YAxis hide />
-            <Tooltip
-              contentStyle={{ backgroundColor: '#16161F', border: '1px solid #1E1E2E', borderRadius: 8, fontFamily: 'JetBrains Mono', fontSize: 12 }}
-              labelStyle={{ color: '#A0A0B8' }}
-              itemStyle={{ color: '#00E676' }}
-            />
-            <Bar dataKey="usdc" radius={[4, 4, 0, 0]} fill="#00E676" opacity={0.85} />
+        <p className="text-sm font-medium text-text-secondary mb-4 inline-flex items-center gap-2"><CalendarDays className="w-4 h-4" />Earning History (FNDRY)</p>
+        <ResponsiveContainer width="100%" height={220}>
+          <BarChart data={earningHistory} margin={{ top: 4, right: 12, bottom: 0, left: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#27273a" />
+            <XAxis dataKey="month" axisLine={false} tickLine={false} tick={{ fill: '#8E8EA9', fontSize: 12, fontFamily: 'JetBrains Mono' }} />
+            <YAxis tick={{ fill: '#5C5C78', fontSize: 11 }} width={40} />
+            <Tooltip contentStyle={{ backgroundColor: '#16161F', border: '1px solid #1E1E2E', borderRadius: 8, fontFamily: 'JetBrains Mono', fontSize: 12 }} />
+            <Bar dataKey="earned" radius={[6, 6, 0, 0]} fill="#00E676" />
           </BarChart>
         </ResponsiveContainer>
+      </div>
+
+      <div className="rounded-xl border border-border bg-forge-900 p-4">
+        <p className="text-sm font-medium text-text-secondary mb-2 inline-flex items-center gap-2"><GitCommitHorizontal className="w-4 h-4" />GitHub Activity (Commits / PRs / Issues)</p>
+        {loadingGitHub ? (
+          <p className="text-sm text-text-muted py-6 text-center">Loading GitHub activity…</p>
+        ) : githubWeeks.length === 0 ? (
+          <p className="text-sm text-text-muted py-6 text-center">No public GitHub activity found for recent weeks.</p>
+        ) : (
+          <ResponsiveContainer width="100%" height={240}>
+            <LineChart data={githubWeeks} margin={{ top: 8, right: 10, bottom: 0, left: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="#27273a" />
+              <XAxis dataKey="week" axisLine={false} tickLine={false} tick={{ fill: '#8E8EA9', fontSize: 12 }} />
+              <YAxis tick={{ fill: '#5C5C78', fontSize: 11 }} width={28} />
+              <Tooltip contentStyle={{ backgroundColor: '#16161F', border: '1px solid #1E1E2E', borderRadius: 8, fontFamily: 'JetBrains Mono', fontSize: 12 }} />
+              <Legend />
+              <Line type="monotone" dataKey="commits" stroke="#00E676" strokeWidth={2} dot={false} />
+              <Line type="monotone" dataKey="prs" stroke="#7C4DFF" strokeWidth={2} dot={false} />
+              <Line type="monotone" dataKey="issues" stroke="#03A9F4" strokeWidth={2} dot={false} />
+            </LineChart>
+          </ResponsiveContainer>
+        )}
       </div>
     </div>
   );
@@ -137,11 +248,7 @@ function SettingsTab() {
       <div className="rounded-xl border border-border bg-forge-900 p-5">
         <h3 className="font-sans text-base font-semibold text-text-primary mb-2">Solana Wallet</h3>
         <p className="text-sm text-text-muted">
-          {user?.wallet_address ? (
-            <span className="font-mono">{user.wallet_address}</span>
-          ) : (
-            'No wallet linked. Link a wallet to receive FNDRY payouts.'
-          )}
+          {user?.wallet_address ? <span className="font-mono">{user.wallet_address}</span> : 'No wallet linked. Link a wallet to receive FNDRY payouts.'}
         </p>
       </div>
     </div>
@@ -162,8 +269,7 @@ export function ProfileDashboard() {
   const myBounties = bountiesData?.items.filter((b) => b.creator_id === user.id) ?? [];
 
   return (
-    <motion.div variants={fadeIn} initial="initial" animate="animate" className="max-w-4xl mx-auto px-4 py-8">
-      {/* Header */}
+    <motion.div variants={fadeIn} initial="initial" animate="animate" className="max-w-5xl mx-auto px-4 py-8">
       <div className="rounded-xl border border-border bg-forge-900 p-6 mb-6">
         <div className="flex items-start gap-5">
           {user.avatar_url ? (
@@ -175,22 +281,17 @@ export function ProfileDashboard() {
           )}
           <div className="flex-1">
             <h1 className="font-sans text-2xl font-semibold text-text-primary">{user.username}</h1>
-            <p className="mt-1 font-mono text-sm text-text-muted">
-              Joined {joinDate} · {myBounties.length} bounties created
-            </p>
+            <p className="mt-1 font-mono text-sm text-text-muted">Joined {joinDate} · {myBounties.length} bounties created</p>
           </div>
         </div>
 
-        {/* Tab switcher */}
         <div className="flex items-center gap-1 p-1 rounded-lg bg-forge-800 mt-6 w-fit">
           {TABS.map((tab) => (
             <button
               key={tab}
               onClick={() => setActiveTab(tab)}
               className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors duration-150 ${
-                activeTab === tab
-                  ? 'bg-forge-700 text-text-primary'
-                  : 'text-text-muted hover:text-text-secondary'
+                activeTab === tab ? 'bg-forge-700 text-text-primary' : 'text-text-muted hover:text-text-secondary'
               }`}
             >
               {tab}
@@ -199,11 +300,9 @@ export function ProfileDashboard() {
         </div>
       </div>
 
-      {/* Tab content */}
       <div>
         {activeTab === 'My Bounties' && <MyBountiesTab bounties={myBounties} loading={isLoading} />}
-        {activeTab === 'My Submissions' && <SubmissionsTab />}
-        {activeTab === 'Earnings' && <EarningsTab />}
+        {activeTab === 'Profile Stats' && <ProfileStatsTab username={user.username} bounties={myBounties} />}
         {activeTab === 'Settings' && <SettingsTab />}
       </div>
     </motion.div>


### PR DESCRIPTION
Closes #836\n\nImplements a contributor profile stats dashboard with:\n- GitHub activity graph (commits/PRs/issues) from GitHub public events\n- FNDRY earnings history chart over time\n- Key stats cards (total earned, bounties completed, contribution streak)\n- Integrated in Profile page via new "Profile Stats" tab\n\nNotes:\n- Current earnings are derived from completed bounties created by the user (as available in existing API payload).\n- Repo currently has unrelated baseline frontend build issues (missing lib/* modules), so full build verification is blocked by pre-existing problems.