### PR TITLE
Add bounty marketplace search bar

### DIFF
--- a/frontend/src/__tests__/bounties-api.test.ts
+++ b/frontend/src/__tests__/bounties-api.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { listBounties } from '../api/bounties';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function mockResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: () => Promise.resolve(body),
+    headers: new Headers({ 'content-type': 'application/json' }),
+    redirected: false,
+    type: 'basic' as ResponseType,
+    url: '',
+    clone: () => mockResponse(body),
+    body: null,
+    bodyUsed: false,
+    arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+    blob: () => Promise.resolve(new Blob()),
+    formData: () => Promise.resolve(new FormData()),
+    text: () => Promise.resolve(JSON.stringify(body)),
+    bytes: () => Promise.resolve(new Uint8Array()),
+  } as Response;
+}
+
+describe('bounties API', () => {
+  beforeEach(() => mockFetch.mockReset());
+
+  it('passes the free-text query parameter when listing bounties', async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse({ items: [], total: 0, limit: 12, offset: 0 }));
+
+    await listBounties({ status: 'open', skill: 'React', q: 'wallet adapter', limit: 12 });
+
+    const calledUrl = String(mockFetch.mock.calls[0][0]);
+    expect(calledUrl).toContain('/api/bounties');
+    expect(calledUrl).toContain('status=open');
+    expect(calledUrl).toContain('skill=React');
+    expect(calledUrl).toContain('q=wallet+adapter');
+  });
+});

--- a/frontend/src/api/bounties.ts
+++ b/frontend/src/api/bounties.ts
@@ -15,6 +15,8 @@ export interface BountiesListParams {
   skill?: string;
   tier?: string;
   reward_token?: string;
+  /** Free-text bounty search by title, description, tags/skills, repo, or org. */
+  q?: string;
 }
 
 export interface BountiesListResponse {

--- a/frontend/src/components/bounty/BountyGrid.tsx
+++ b/frontend/src/components/bounty/BountyGrid.tsx
@@ -1,7 +1,7 @@
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { ChevronDown, Loader2, Plus } from 'lucide-react';
+import { ChevronDown, Loader2, Plus, Search, X } from 'lucide-react';
 import { BountyCard } from './BountyCard';
 import { useInfiniteBounties } from '../../hooks/useBounties';
 import { staggerContainer, staggerItem } from '../../lib/animations';
@@ -11,16 +11,47 @@ const FILTER_SKILLS = ['All', 'TypeScript', 'Rust', 'Solidity', 'Python', 'Go', 
 export function BountyGrid() {
   const [activeSkill, setActiveSkill] = useState<string>('All');
   const [statusFilter, setStatusFilter] = useState<string>('open');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('');
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      setDebouncedSearchQuery(searchQuery.trim());
+    }, 250);
+
+    return () => window.clearTimeout(timeout);
+  }, [searchQuery]);
 
   const params = {
     status: statusFilter,
     skill: activeSkill !== 'All' ? activeSkill : undefined,
+    q: debouncedSearchQuery || undefined,
   };
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, isError } =
     useInfiniteBounties(params);
 
   const allBounties = data?.pages.flatMap((p) => p.items) ?? [];
+  const visibleBounties = useMemo(() => {
+    if (!debouncedSearchQuery) return allBounties;
+
+    const query = debouncedSearchQuery.toLowerCase();
+    return allBounties.filter((bounty) =>
+      [
+        bounty.title,
+        bounty.description,
+        bounty.category,
+        bounty.org_name,
+        bounty.repo_name,
+        bounty.github_issue_url,
+        bounty.github_repo_url,
+        ...bounty.skills,
+      ]
+        .filter(Boolean)
+        .some((value) => String(value).toLowerCase().includes(query))
+    );
+  }, [allBounties, debouncedSearchQuery]);
+  const hasActiveFilters = activeSkill !== 'All' || statusFilter !== 'open' || Boolean(debouncedSearchQuery);
 
   return (
     <section id="bounties" className="py-16 md:py-24">
@@ -53,21 +84,46 @@ export function BountyGrid() {
           </div>
         </div>
 
-        {/* Filter pills */}
-        <div className="flex items-center gap-2 flex-wrap mb-8">
-          {FILTER_SKILLS.map((skill) => (
-            <button
-              key={skill}
-              onClick={() => setActiveSkill(skill)}
-              className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors duration-150 ${
-                activeSkill === skill
-                  ? 'bg-forge-700 text-text-primary'
-                  : 'text-text-muted hover:text-text-secondary bg-forge-800'
-              }`}
-            >
-              {skill}
-            </button>
-          ))}
+        {/* Search and filter controls */}
+        <div className="mb-8 space-y-4">
+          <div className="relative max-w-2xl">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted pointer-events-none" />
+            <input
+              type="search"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder="Search bounties by title, description, tag, repo, or org..."
+              aria-label="Search bounties"
+              className="w-full rounded-xl border border-border bg-forge-900 py-3 pl-10 pr-12 text-sm text-text-primary placeholder:text-text-muted outline-none transition-colors duration-150 focus:border-emerald"
+            />
+            {searchQuery && (
+              <button
+                type="button"
+                onClick={() => setSearchQuery('')}
+                aria-label="Clear bounty search"
+                className="absolute right-3 top-1/2 -translate-y-1/2 rounded-md p-1 text-text-muted hover:bg-forge-800 hover:text-text-primary transition-colors duration-150"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            )}
+          </div>
+
+          {/* Filter pills */}
+          <div className="flex items-center gap-2 flex-wrap">
+            {FILTER_SKILLS.map((skill) => (
+              <button
+                key={skill}
+                onClick={() => setActiveSkill(skill)}
+                className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors duration-150 ${
+                  activeSkill === skill
+                    ? 'bg-forge-700 text-text-primary'
+                    : 'text-text-muted hover:text-text-secondary bg-forge-800'
+                }`}
+              >
+                {skill}
+              </button>
+            ))}
+          </div>
         </div>
 
         {/* Loading state */}
@@ -93,17 +149,19 @@ export function BountyGrid() {
         )}
 
         {/* Empty state */}
-        {!isLoading && !isError && allBounties.length === 0 && (
+        {!isLoading && !isError && visibleBounties.length === 0 && (
           <div className="text-center py-16">
             <p className="text-text-muted text-lg mb-2">No bounties found</p>
             <p className="text-text-muted text-sm">
-              {activeSkill !== 'All' ? `Try a different language filter.` : 'Check back soon for new bounties.'}
+              {hasActiveFilters
+                ? 'Try a different search term, status, or language filter.'
+                : 'Check back soon for new bounties.'}
             </p>
           </div>
         )}
 
         {/* Bounty grid */}
-        {!isLoading && allBounties.length > 0 && (
+        {!isLoading && visibleBounties.length > 0 && (
           <motion.div
             variants={staggerContainer}
             initial="initial"
@@ -111,7 +169,7 @@ export function BountyGrid() {
             viewport={{ once: true, margin: '-50px' }}
             className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5"
           >
-            {allBounties.map((bounty) => (
+            {visibleBounties.map((bounty) => (
               <motion.div key={bounty.id} variants={staggerItem}>
                 <BountyCard bounty={bounty} />
               </motion.div>

--- a/frontend/src/lib/animations.ts
+++ b/frontend/src/lib/animations.ts
@@ -1,0 +1,36 @@
+import type { Variants } from 'framer-motion';
+
+export const fadeIn: Variants = {
+  initial: { opacity: 0, y: 16 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.35, ease: 'easeOut' } },
+  exit: { opacity: 0, y: 8, transition: { duration: 0.2, ease: 'easeIn' } },
+};
+
+export const pageTransition = fadeIn;
+
+export const staggerContainer: Variants = {
+  initial: {},
+  animate: { transition: { staggerChildren: 0.06 } },
+};
+
+export const staggerItem: Variants = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.25, ease: 'easeOut' } },
+};
+
+export const cardHover: Variants = {
+  rest: { y: 0 },
+  hover: { y: -4, transition: { duration: 0.18, ease: 'easeOut' } },
+};
+
+export const buttonHover: Variants = {
+  rest: { scale: 1 },
+  hover: { scale: 1.03 },
+  tap: { scale: 0.98 },
+};
+
+export const slideInRight: Variants = {
+  initial: { opacity: 0, x: 24 },
+  animate: { opacity: 1, x: 0, transition: { duration: 0.25, ease: 'easeOut' } },
+  exit: { opacity: 0, x: 24, transition: { duration: 0.2, ease: 'easeIn' } },
+};

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,58 @@
+export const LANG_COLORS: Record<string, string> = {
+  All: '#5C5C78',
+  Rust: '#F97316',
+  TypeScript: '#3178C6',
+  React: '#61DAFB',
+  'Solana/Web3': '#14F195',
+  Python: '#3776AB',
+  Go: '#00ADD8',
+  Solidity: '#627EEA',
+};
+
+export function formatCurrency(amount: number, token = 'USDC'): string {
+  const formatted = new Intl.NumberFormat('en-US', {
+    maximumFractionDigits: amount >= 100 ? 0 : 2,
+  }).format(amount);
+  return `${formatted} ${token}`;
+}
+
+export function timeLeft(deadline?: string | null): string {
+  if (!deadline) return 'No deadline';
+
+  const target = new Date(deadline).getTime();
+  const diff = target - Date.now();
+  if (!Number.isFinite(target) || diff <= 0) return 'Expired';
+
+  const days = Math.floor(diff / 86_400_000);
+  if (days > 0) return `${days}d left`;
+
+  const hours = Math.floor(diff / 3_600_000);
+  if (hours > 0) return `${hours}h left`;
+
+  const minutes = Math.max(1, Math.floor(diff / 60_000));
+  return `${minutes}m left`;
+}
+
+export function timeAgo(value?: string | null): string {
+  if (!value) return 'Unknown';
+
+  const date = new Date(value).getTime();
+  const diff = Date.now() - date;
+  if (!Number.isFinite(date)) return 'Unknown';
+  if (diff < 60_000) return 'just now';
+
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 60) return `${minutes}m ago`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo ago`;
+
+  const years = Math.floor(months / 12);
+  return `${years}y ago`;
+}


### PR DESCRIPTION
## Summary
- Add a debounced search input to the bounty marketplace filters
- Send the free-text query through the bounties list API as `q`
- Apply client-side matching across title, description, category, org/repo, issue URLs, and skills for loaded results
- Add shared frontend helper modules needed by the current frontend imports so the production build can compile
- Add API coverage for the new bounty search query parameter

Fixes #823

## Validation
- `cd frontend && npm test -- --run src/__tests__/bounties-api.test.ts src/__tests__/apiClient.test.ts`
- `cd frontend && npm run build`

Note: the full frontend test suite still contains existing broken suites that reference files/modules not present in the repo (admin, tokenomics, bounties legacy components, Playwright e2e, etc.); the targeted tests above pass and the production build succeeds.
