### PR TITLE
feat: add bounty page search bar

### DIFF
--- a/frontend/src/api/bounties.ts
+++ b/frontend/src/api/bounties.ts
@@ -12,6 +12,7 @@ export interface BountiesListParams {
   status?: string;
   limit?: number;
   offset?: number;
+  q?: string;
   skill?: string;
   tier?: string;
   reward_token?: string;
@@ -35,6 +36,33 @@ function mapBounty(b: Bounty): Bounty {
 }
 
 export async function listBounties(params?: BountiesListParams): Promise<BountiesListResponse> {
+  if (params?.q) {
+    const limit = params.limit ?? 20;
+    const offset = params.offset ?? 0;
+    const response = await apiClient<BountiesListResponse | Bounty[]>('/api/bounties/search', {
+      params: {
+        q: params.q,
+        status: params.status,
+        tier: params.tier,
+        skills: params.skill,
+        per_page: limit,
+        page: Math.floor(offset / limit) + 1,
+      },
+    });
+
+    if (Array.isArray(response)) {
+      return { items: response.map(mapBounty), total: response.length, limit, offset };
+    }
+
+    const searchResponse = response as BountiesListResponse & { per_page?: number; page?: number };
+    return {
+      items: searchResponse.items.map(mapBounty),
+      total: searchResponse.total,
+      limit: searchResponse.per_page ?? limit,
+      offset: ((searchResponse.page ?? Math.floor(offset / limit) + 1) - 1) * (searchResponse.per_page ?? limit),
+    };
+  }
+
   const response = await apiClient<BountiesListResponse | Bounty[]>('/api/bounties', {
     params: params as Record<string, string | number | boolean | undefined>,
   });

--- a/frontend/src/components/bounty/BountyGrid.tsx
+++ b/frontend/src/components/bounty/BountyGrid.tsx
@@ -1,16 +1,45 @@
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { ChevronDown, Loader2, Plus } from 'lucide-react';
+import { ChevronDown, Loader2, Plus, Search, X } from 'lucide-react';
 import { BountyCard } from './BountyCard';
 import { useInfiniteBounties } from '../../hooks/useBounties';
 import { staggerContainer, staggerItem } from '../../lib/animations';
+import type { Bounty } from '../../types/bounty';
 
 const FILTER_SKILLS = ['All', 'TypeScript', 'Rust', 'Solidity', 'Python', 'Go', 'JavaScript'];
+
+function bountyMatchesQuery(bounty: Bounty, query: string) {
+  if (!query) return true;
+
+  const haystack = [
+    bounty.title,
+    bounty.description,
+    bounty.category,
+    bounty.org_name,
+    bounty.repo_name,
+    ...(bounty.skills ?? []),
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+
+  return haystack.includes(query);
+}
 
 export function BountyGrid() {
   const [activeSkill, setActiveSkill] = useState<string>('All');
   const [statusFilter, setStatusFilter] = useState<string>('open');
+  const [searchInput, setSearchInput] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      setDebouncedSearch(searchInput.trim().toLowerCase());
+    }, 250);
+
+    return () => window.clearTimeout(timeout);
+  }, [searchInput]);
 
   const params = {
     status: statusFilter,
@@ -21,6 +50,11 @@ export function BountyGrid() {
     useInfiniteBounties(params);
 
   const allBounties = data?.pages.flatMap((p) => p.items) ?? [];
+  const filteredBounties = useMemo(
+    () => allBounties.filter((bounty) => bountyMatchesQuery(bounty, debouncedSearch)),
+    [allBounties, debouncedSearch]
+  );
+  const hasSearch = debouncedSearch.length > 0;
 
   return (
     <section id="bounties" className="py-16 md:py-24">
@@ -51,6 +85,36 @@ export function BountyGrid() {
               <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-text-muted pointer-events-none" />
             </div>
           </div>
+        </div>
+
+        {/* Search */}
+        <div className="relative mb-4 max-w-2xl">
+          <label htmlFor="bounty-search" className="sr-only">
+            Search bounties
+          </label>
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted pointer-events-none" />
+          <input
+            id="bounty-search"
+            type="search"
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+            placeholder="Search by title, description, tag, or repo..."
+            className="w-full rounded-lg border border-border bg-forge-900 py-2.5 pl-9 pr-10 text-sm text-text-primary placeholder:text-text-muted outline-none transition-colors duration-150 focus:border-emerald"
+            aria-label="Search bounties"
+          />
+          {searchInput && (
+            <button
+              type="button"
+              onClick={() => {
+                setSearchInput('');
+                setDebouncedSearch('');
+              }}
+              className="absolute right-2 top-1/2 -translate-y-1/2 rounded-md p-1 text-text-muted transition-colors duration-150 hover:bg-forge-800 hover:text-text-primary"
+              aria-label="Clear bounty search"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          )}
         </div>
 
         {/* Filter pills */}
@@ -93,17 +157,21 @@ export function BountyGrid() {
         )}
 
         {/* Empty state */}
-        {!isLoading && !isError && allBounties.length === 0 && (
+        {!isLoading && !isError && filteredBounties.length === 0 && (
           <div className="text-center py-16">
             <p className="text-text-muted text-lg mb-2">No bounties found</p>
             <p className="text-text-muted text-sm">
-              {activeSkill !== 'All' ? `Try a different language filter.` : 'Check back soon for new bounties.'}
+              {hasSearch
+                ? `No results match “${searchInput.trim()}”. Clear search or try another keyword.`
+                : activeSkill !== 'All'
+                  ? `Try a different language filter.`
+                  : 'Check back soon for new bounties.'}
             </p>
           </div>
         )}
 
         {/* Bounty grid */}
-        {!isLoading && allBounties.length > 0 && (
+        {!isLoading && filteredBounties.length > 0 && (
           <motion.div
             variants={staggerContainer}
             initial="initial"
@@ -111,7 +179,7 @@ export function BountyGrid() {
             viewport={{ once: true, margin: '-50px' }}
             className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5"
           >
-            {allBounties.map((bounty) => (
+            {filteredBounties.map((bounty) => (
               <motion.div key={bounty.id} variants={staggerItem}>
                 <BountyCard bounty={bounty} />
               </motion.div>

--- a/frontend/src/components/bounty/BountyGrid.tsx
+++ b/frontend/src/components/bounty/BountyGrid.tsx
@@ -5,27 +5,8 @@ import { ChevronDown, Loader2, Plus, Search, X } from 'lucide-react';
 import { BountyCard } from './BountyCard';
 import { useInfiniteBounties } from '../../hooks/useBounties';
 import { staggerContainer, staggerItem } from '../../lib/animations';
-import type { Bounty } from '../../types/bounty';
 
 const FILTER_SKILLS = ['All', 'TypeScript', 'Rust', 'Solidity', 'Python', 'Go', 'JavaScript'];
-
-function bountyMatchesQuery(bounty: Bounty, query: string) {
-  if (!query) return true;
-
-  const haystack = [
-    bounty.title,
-    bounty.description,
-    bounty.category,
-    bounty.org_name,
-    bounty.repo_name,
-    ...(bounty.skills ?? []),
-  ]
-    .filter(Boolean)
-    .join(' ')
-    .toLowerCase();
-
-  return haystack.includes(query);
-}
 
 export function BountyGrid() {
   const [activeSkill, setActiveSkill] = useState<string>('All');
@@ -41,19 +22,19 @@ export function BountyGrid() {
     return () => window.clearTimeout(timeout);
   }, [searchInput]);
 
-  const params = {
-    status: statusFilter,
-    skill: activeSkill !== 'All' ? activeSkill : undefined,
-  };
+  const params = useMemo(
+    () => ({
+      status: statusFilter,
+      skill: activeSkill !== 'All' ? activeSkill : undefined,
+      q: debouncedSearch || undefined,
+    }),
+    [activeSkill, debouncedSearch, statusFilter]
+  );
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, isError } =
     useInfiniteBounties(params);
 
-  const allBounties = data?.pages.flatMap((p) => p.items) ?? [];
-  const filteredBounties = useMemo(
-    () => allBounties.filter((bounty) => bountyMatchesQuery(bounty, debouncedSearch)),
-    [allBounties, debouncedSearch]
-  );
+  const bounties = data?.pages.flatMap((p) => p.items) ?? [];
   const hasSearch = debouncedSearch.length > 0;
 
   return (
@@ -157,7 +138,7 @@ export function BountyGrid() {
         )}
 
         {/* Empty state */}
-        {!isLoading && !isError && filteredBounties.length === 0 && (
+        {!isLoading && !isError && bounties.length === 0 && (
           <div className="text-center py-16">
             <p className="text-text-muted text-lg mb-2">No bounties found</p>
             <p className="text-text-muted text-sm">
@@ -171,7 +152,7 @@ export function BountyGrid() {
         )}
 
         {/* Bounty grid */}
-        {!isLoading && filteredBounties.length > 0 && (
+        {!isLoading && bounties.length > 0 && (
           <motion.div
             variants={staggerContainer}
             initial="initial"
@@ -179,7 +160,7 @@ export function BountyGrid() {
             viewport={{ once: true, margin: '-50px' }}
             className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5"
           >
-            {filteredBounties.map((bounty) => (
+            {bounties.map((bounty) => (
               <motion.div key={bounty.id} variants={staggerItem}>
                 <BountyCard bounty={bounty} />
               </motion.div>

--- a/frontend/src/lib/animations.ts
+++ b/frontend/src/lib/animations.ts
@@ -1,0 +1,38 @@
+import type { Variants } from 'framer-motion';
+
+export const fadeIn: Variants = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.25, ease: 'easeOut' } },
+  exit: { opacity: 0, y: 8, transition: { duration: 0.15, ease: 'easeIn' } },
+};
+
+export const pageTransition: Variants = {
+  initial: { opacity: 0, y: 16 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.3, ease: 'easeOut' } },
+  exit: { opacity: 0, y: -8, transition: { duration: 0.2, ease: 'easeIn' } },
+};
+
+export const staggerContainer: Variants = {
+  initial: {},
+  animate: { transition: { staggerChildren: 0.06 } },
+};
+
+export const staggerItem: Variants = {
+  initial: { opacity: 0, y: 10 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.22, ease: 'easeOut' } },
+};
+
+export const cardHover = {
+  whileHover: { y: -4, transition: { duration: 0.15 } },
+  whileTap: { scale: 0.99 },
+};
+
+export const buttonHover = {
+  whileHover: { scale: 1.02 },
+  whileTap: { scale: 0.98 },
+};
+
+export const slideInRight: Variants = {
+  initial: { opacity: 0, x: 20 },
+  animate: { opacity: 1, x: 0, transition: { duration: 0.25, ease: 'easeOut' } },
+};

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,51 @@
+import type { RewardToken } from '../types/bounty';
+
+export const LANG_COLORS: Record<string, string> = {
+  TypeScript: '#3b82f6',
+  JavaScript: '#eab308',
+  Rust: '#f97316',
+  Solidity: '#a855f7',
+  Python: '#22c55e',
+  Go: '#06b6d4',
+  React: '#38bdf8',
+  default: '#5C5C78',
+};
+
+export function formatCurrency(amount: number, token: RewardToken | string = 'FNDRY'): string {
+  const value = Number.isFinite(amount) ? amount : 0;
+  const formatted = new Intl.NumberFormat('en-US', {
+    maximumFractionDigits: value >= 100 ? 0 : 2,
+  }).format(value);
+  return `${formatted} ${token}`;
+}
+
+export function timeAgo(dateLike?: string | null): string {
+  if (!dateLike) return 'unknown';
+  const timestamp = new Date(dateLike).getTime();
+  if (Number.isNaN(timestamp)) return 'unknown';
+  const seconds = Math.max(0, Math.floor((Date.now() - timestamp) / 1000));
+  if (seconds < 60) return 'just now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo ago`;
+  return `${Math.floor(months / 12)}y ago`;
+}
+
+export function timeLeft(dateLike?: string | null): string {
+  if (!dateLike) return 'No deadline';
+  const timestamp = new Date(dateLike).getTime();
+  if (Number.isNaN(timestamp)) return 'No deadline';
+  const seconds = Math.floor((timestamp - Date.now()) / 1000);
+  if (seconds <= 0) return 'Expired';
+  const days = Math.floor(seconds / 86400);
+  if (days > 0) return `${days}d left`;
+  const hours = Math.floor(seconds / 3600);
+  if (hours > 0) return `${hours}h left`;
+  const minutes = Math.max(1, Math.floor(seconds / 60));
+  return `${minutes}m left`;
+}


### PR DESCRIPTION
## Summary
- add a debounced search input to the bounties page
- filter bounties by title, description, category, org/repo, and skills
- add clear-search behavior and search-aware empty-state messaging
- add missing shared frontend utility modules required by the current app build

Closes #823

## Test Plan
- npm run build

## Notes
- Existing bounty-board tests reference legacy components under components/bounties/* that are absent on main; I did not change those unrelated test imports.

## Payout
- Payout target: github:MolhamHamwi
- **Wallet:** AhqbFaPBPLMMiaLDzA9WhQcyvv4hMxiteLhPk3NhG1iG
