### PR TITLE
fix: Mobile Responsive Polish (#833)

### DIFF
--- a/frontend/src/components/bounty/BountyCard.tsx
+++ b/frontend/src/components/bounty/BountyCard.tsx
@@ -61,11 +61,11 @@ export function BountyCard({ bounty }: BountyCardProps) {
       initial="rest"
       whileHover="hover"
       onClick={() => navigate(`/bounties/${bounty.id}`)}
-      className="relative rounded-xl border border-border bg-forge-900 p-5 cursor-pointer transition-colors duration-200 overflow-hidden group"
+      className="relative rounded-xl border border-border bg-forge-900 p-4 sm:p-5 cursor-pointer transition-colors duration-200 overflow-hidden group"
     >
       {/* Row 1: Repo + Tier */}
       <div className="flex items-center justify-between text-sm">
-        <div className="flex items-center gap-2 min-w-0">
+        <div className="flex items-center gap-2 min-w-0 flex-1">
           {bounty.org_avatar_url && (
             <img src={bounty.org_avatar_url} className="w-5 h-5 rounded-full flex-shrink-0" alt="" />
           )}
@@ -78,17 +78,17 @@ export function BountyCard({ bounty }: BountyCardProps) {
       </div>
 
       {/* Row 2: Title */}
-      <h3 className="mt-3 font-sans text-base font-semibold text-text-primary leading-snug line-clamp-2">
+      <h3 className="mt-3 font-sans text-sm sm:text-base font-semibold text-text-primary leading-snug line-clamp-2">
         {bounty.title}
       </h3>
 
       {/* Row 3: Language dots */}
       {skills.length > 0 && (
-        <div className="flex items-center gap-3 mt-3">
+        <div className="flex items-center gap-3 mt-3 flex-wrap">
           {skills.map((lang) => (
             <span key={lang} className="inline-flex items-center gap-1.5 text-xs text-text-muted">
               <span
-                className="w-2.5 h-2.5 rounded-full"
+                className="w-2.5 h-2.5 rounded-full flex-shrink-0"
                 style={{ backgroundColor: LANG_COLORS[lang] ?? '#888' }}
               />
               {lang}
@@ -98,21 +98,21 @@ export function BountyCard({ bounty }: BountyCardProps) {
       )}
 
       {/* Separator */}
-      <div className="mt-4 border-t border-border/50" />
+      <div className="mt-3 sm:mt-4 border-t border-border/50" />
 
       {/* Row 4: Reward + Meta */}
-      <div className="flex items-center justify-between mt-3">
-        <span className="font-mono text-lg font-semibold text-emerald">
+      <div className="flex items-center justify-between mt-2 sm:mt-3 gap-2">
+        <span className="font-mono text-base sm:text-lg font-semibold text-emerald whitespace-nowrap">
           {formatCurrency(bounty.reward_amount, bounty.reward_token)}
         </span>
-        <div className="flex items-center gap-3 text-xs text-text-muted">
-          <span className="inline-flex items-center gap-1">
-            <GitPullRequest className="w-3.5 h-3.5" />
-            {bounty.submission_count} PRs
+        <div className="flex items-center gap-2 sm:gap-3 text-xs text-text-muted flex-shrink-0">
+          <span className="inline-flex items-center gap-1 whitespace-nowrap">
+            <GitPullRequest className="w-3.5 h-3.5 flex-shrink-0" />
+            {bounty.submission_count}
           </span>
           {bounty.deadline && (
-            <span className="inline-flex items-center gap-1">
-              <Clock className="w-3.5 h-3.5" />
+            <span className="inline-flex items-center gap-1 whitespace-nowrap">
+              <Clock className="w-3.5 h-3.5 flex-shrink-0" />
               {timeLeft(bounty.deadline)}
             </span>
           )}
@@ -120,7 +120,7 @@ export function BountyCard({ bounty }: BountyCardProps) {
       </div>
 
       {/* Status badge */}
-      <span className={`absolute bottom-4 right-5 text-xs font-medium inline-flex items-center gap-1 ${statusColor}`}>
+      <span className={`absolute bottom-3 sm:bottom-4 right-3 sm:right-5 text-xs font-medium inline-flex items-center gap-1 ${statusColor}`}>
         <span className={`w-1.5 h-1.5 rounded-full ${dotColor}`} />
         {statusLabel}
       </span>

--- a/frontend/src/components/bounty/BountyGrid.tsx
+++ b/frontend/src/components/bounty/BountyGrid.tsx
@@ -54,7 +54,7 @@ export function BountyGrid() {
         </div>
 
         {/* Filter pills */}
-        <div className="flex items-center gap-2 flex-wrap mb-8">
+        <div className="flex items-center gap-2 mb-8 overflow-x-auto no-scrollbar pb-2">
           {FILTER_SKILLS.map((skill) => (
             <button
               key={skill}

--- a/frontend/src/components/home/HeroSection.tsx
+++ b/frontend/src/components/home/HeroSection.tsx
@@ -112,7 +112,7 @@ export function HeroSection() {
 
         {/* Terminal body */}
         <div className="p-5 font-mono text-sm leading-relaxed">
-          <div className="overflow-hidden">
+          <div className="overflow-x-auto no-scrollbar">
             <span className="text-emerald">$ </span>
             <span className="text-text-secondary overflow-hidden whitespace-nowrap inline-block animate-typewriter">
               forge bounty --reward 100 --lang typescript --tier 2
@@ -154,7 +154,7 @@ export function HeroSection() {
         initial={{ opacity: 0, y: 16 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ delay: 0.3, duration: 0.5 }}
-        className="font-display text-4xl md:text-5xl font-bold text-text-primary tracking-wider text-center mt-10"
+        className="font-display text-2xl sm:text-3xl md:text-5xl font-bold text-text-primary tracking-wider text-center mt-10 px-2"
       >
         THE AI-POWERED BOUNTY{' '}
         <span className="text-emerald">FORGE</span>


### PR DESCRIPTION
## Summary\n\nFixes **#833 — Mobile Responsive Polish** (T1, 150K FNDRY).\n\n### Changes\n- **BountyCard**: Responsive padding (p4 mobile/p5 desktop), smaller title on mobile, flex-wrap for skills, gap adjustments\n- **BountyGrid**: Horizontal scrollable filter pills on mobile (no-scrollbar), remove flex-wrap to allow overflow scroll\n- **HeroSection**: Terminal command wraps in overflow-x-auto, headline scales down on mobile (text-2xl sm:text-3xl md:text-5xl), added horizontal padding\n- **CSS**: Added global overflow-x:hidden + no-scrollbar utility class\n\n### Testing\n- Tested at 375px and 768px breakpoints\n- No horizontal scroll on any page\n- All content readable without zooming\n\nCloses #833\n\n**Wallet:** HUFz3mnXkSDzfxfRgiKsZ6w5zgfcwShigHrYGxvgrjAF