### PR TITLE
feat: wire Activity Feed to real API data (#822)

### DIFF
--- a/frontend/src/api/activity.ts
+++ b/frontend/src/api/activity.ts
@@ -1,0 +1,31 @@
+import { apiClient } from '../services/apiClient';
+
+export interface ActivityEvent {
+  id: string;
+  type: 'completed' | 'submitted' | 'posted' | 'review';
+  username: string;
+  avatar_url?: string | null;
+  detail: string;
+  timestamp: string;
+}
+
+export interface ActivityResponse {
+  events: ActivityEvent[];
+}
+
+/**
+ * Fetch recent activity events from the backend.
+ * Returns an empty array if the endpoint is unavailable (graceful fallback).
+ */
+export async function listActivity(limit = 4): Promise<ActivityEvent[]> {
+  try {
+    const response = await apiClient<ActivityResponse | ActivityEvent[]>('/api/activity', {
+      params: { limit },
+    });
+    if (Array.isArray(response)) return response;
+    return response.events ?? [];
+  } catch {
+    // Endpoint may not exist yet — return empty so the caller falls back to mock data
+    return [];
+  }
+}

--- a/frontend/src/components/home/ActivityFeed.tsx
+++ b/frontend/src/components/home/ActivityFeed.tsx
@@ -2,15 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { slideInRight } from '../../lib/animations';
 import { timeAgo } from '../../lib/utils';
-
-interface ActivityEvent {
-  id: string;
-  type: 'completed' | 'submitted' | 'posted' | 'review';
-  username: string;
-  avatar_url?: string | null;
-  detail: string;
-  timestamp: string;
-}
+import type { ActivityEvent } from '../../api/activity';
 
 // Mock events for when API doesn't return activity
 const MOCK_EVENTS: ActivityEvent[] = [

--- a/frontend/src/hooks/useActivity.ts
+++ b/frontend/src/hooks/useActivity.ts
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query';
+import { listActivity } from '../api/activity';
+import type { ActivityEvent } from '../api/activity';
+
+const POLL_INTERVAL = 30_000; // 30 seconds
+
+/**
+ * Fetch recent activity events with automatic 30-second polling.
+ * Returns `{ data, isLoading, isError }`.  `data` is empty when the
+ * endpoint is unavailable — callers should fall back to mock data.
+ */
+export function useActivity(limit = 4) {
+  return useQuery<ActivityEvent[]>({
+    queryKey: ['activity', limit],
+    queryFn: () => listActivity(limit),
+    refetchInterval: POLL_INTERVAL,
+    refetchIntervalInBackground: true,
+    staleTime: POLL_INTERVAL,
+    retry: false,
+    placeholderData: [],
+  });
+}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -5,12 +5,15 @@ import { ActivityFeed } from '../components/home/ActivityFeed';
 import { HowItWorksCondensed } from '../components/home/HowItWorksCondensed';
 import { FeaturedBounties } from '../components/home/FeaturedBounties';
 import { WhySolFoundry } from '../components/home/WhySolFoundry';
+import { useActivity } from '../hooks/useActivity';
 
 export function HomePage() {
+  const { data: events } = useActivity();
+
   return (
     <PageLayout noFooter={false}>
       <HeroSection />
-      <ActivityFeed />
+      <ActivityFeed events={events} />
       <HowItWorksCondensed />
       <FeaturedBounties />
       <WhySolFoundry />


### PR DESCRIPTION
## Summary

Wires the home page Activity Feed to fetch real events from `GET /api/activity` instead of showing hardcoded mock data.

**Resolves #822**

## Changes

- **`frontend/src/api/activity.ts`** — New API client for `/api/activity` endpoint with graceful fallback
- **`frontend/src/hooks/useActivity.ts`** — React Query hook with 30-second auto-polling
- **`frontend/src/components/home/ActivityFeed.tsx`** — Imports shared `ActivityEvent` type from API module
- **`frontend/src/pages/HomePage.tsx`** — Wires `useActivity()` hook, passes real events to `<ActivityFeed />`

## Acceptance Criteria

- [x] Activity feed shows real events from the API
- [x] Events update without page refresh (30s polling via `refetchInterval`)
- [x] Shows mock data as fallback when API is unavailable
- [x] Graceful error handling

## Technical Notes

- Uses the same `apiClient` pattern as `bounties.ts` and `leaderboard.ts`
- React Query `placeholderData: []` prevents loading flash
- `retry: false` avoids noisy retries when the endpoint doesn't exist yet
- Mock data preserved as fallback until the backend endpoint is deployed