### PR TITLE
feat: add bounty countdown timer

### DIFF
--- a/frontend/src/__tests__/bounty-countdown.test.tsx
+++ b/frontend/src/__tests__/bounty-countdown.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { BountyCountdown, getCountdownParts } from '../components/bounty/BountyCountdown';
+
+describe('BountyCountdown', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-13T12:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders days, hours, and minutes for active bounties', () => {
+    render(<BountyCountdown deadline="2026-06-15T14:30:00.000Z" />);
+
+    expect(screen.getByLabelText('Bounty deadline countdown: 2d 2h 30m')).toBeInTheDocument();
+  });
+
+  it('marks deadlines under 24 hours as warning', () => {
+    const parts = getCountdownParts('2026-06-14T11:59:00.000Z', Date.now());
+
+    expect(parts?.urgency).toBe('warning');
+  });
+
+  it('marks deadlines under 1 hour as urgent', () => {
+    const parts = getCountdownParts('2026-06-13T12:30:00.000Z', Date.now());
+
+    expect(parts?.urgency).toBe('urgent');
+  });
+
+  it('shows expired after the deadline passes', () => {
+    render(<BountyCountdown deadline="2026-06-13T11:59:00.000Z" />);
+
+    expect(screen.getByLabelText('Bounty deadline countdown: Expired')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/bounty-countdown.test.tsx
+++ b/frontend/src/__tests__/bounty-countdown.test.tsx
@@ -30,6 +30,18 @@ describe('BountyCountdown', () => {
     expect(parts?.urgency).toBe('urgent');
   });
 
+  it('shows one minute for active deadlines under one minute', () => {
+    render(<BountyCountdown deadline="2026-06-13T12:00:30.000Z" />);
+
+    expect(screen.getByLabelText('Bounty deadline countdown: 1m')).toBeInTheDocument();
+  });
+
+  it('shows one minute at the exact 60 second boundary', () => {
+    render(<BountyCountdown deadline="2026-06-13T12:01:00.000Z" />);
+
+    expect(screen.getByLabelText('Bounty deadline countdown: 1m')).toBeInTheDocument();
+  });
+
   it('shows expired after the deadline passes', () => {
     render(<BountyCountdown deadline="2026-06-13T11:59:00.000Z" />);
 

--- a/frontend/src/components/bounty/BountyCard.tsx
+++ b/frontend/src/components/bounty/BountyCard.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { GitPullRequest, Clock } from 'lucide-react';
+import { GitPullRequest } from 'lucide-react';
 import type { Bounty } from '../../types/bounty';
 import { cardHover } from '../../lib/animations';
-import { timeLeft, formatCurrency, LANG_COLORS } from '../../lib/utils';
+import { formatCurrency, LANG_COLORS } from '../../lib/utils';
+import { BountyCountdown } from './BountyCountdown';
 
 function TierBadge({ tier }: { tier: string }) {
   const styles: Record<string, string> = {
@@ -111,10 +112,7 @@ export function BountyCard({ bounty }: BountyCardProps) {
             {bounty.submission_count} PRs
           </span>
           {bounty.deadline && (
-            <span className="inline-flex items-center gap-1">
-              <Clock className="w-3.5 h-3.5" />
-              {timeLeft(bounty.deadline)}
-            </span>
+            <BountyCountdown deadline={bounty.deadline} size="compact" />
           )}
         </div>
       </div>

--- a/frontend/src/components/bounty/BountyCountdown.tsx
+++ b/frontend/src/components/bounty/BountyCountdown.tsx
@@ -1,0 +1,95 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Clock } from 'lucide-react';
+
+export type CountdownUrgency = 'normal' | 'warning' | 'urgent' | 'expired';
+
+interface CountdownParts {
+  days: number;
+  hours: number;
+  minutes: number;
+  totalMs: number;
+  urgency: CountdownUrgency;
+}
+
+interface BountyCountdownProps {
+  deadline?: string | null;
+  size?: 'compact' | 'default';
+  showIcon?: boolean;
+  className?: string;
+}
+
+export function getCountdownParts(deadline?: string | null, now = Date.now()): CountdownParts | null {
+  if (!deadline) return null;
+
+  const deadlineMs = new Date(deadline).getTime();
+  if (Number.isNaN(deadlineMs)) return null;
+
+  const totalMs = deadlineMs - now;
+  if (totalMs <= 0) {
+    return { days: 0, hours: 0, minutes: 0, totalMs, urgency: 'expired' };
+  }
+
+  const totalMinutes = Math.max(0, Math.floor(totalMs / 60_000));
+  const days = Math.floor(totalMinutes / 1_440);
+  const hours = Math.floor((totalMinutes % 1_440) / 60);
+  const minutes = totalMinutes % 60;
+
+  const urgency: CountdownUrgency =
+    totalMs < 60 * 60_000 ? 'urgent' : totalMs < 24 * 60 * 60_000 ? 'warning' : 'normal';
+
+  return { days, hours, minutes, totalMs, urgency };
+}
+
+function formatCountdown(parts: CountdownParts): string {
+  if (parts.urgency === 'expired') return 'Expired';
+
+  if (parts.days > 0) {
+    return `${parts.days}d ${parts.hours}h ${parts.minutes}m`;
+  }
+
+  if (parts.hours > 0) {
+    return `${parts.hours}h ${parts.minutes}m`;
+  }
+
+  return `${parts.minutes}m`;
+}
+
+const urgencyClasses: Record<CountdownUrgency, string> = {
+  normal: 'border-border bg-forge-800/70 text-text-secondary',
+  warning: 'border-status-warning/40 bg-status-warning/10 text-status-warning',
+  urgent: 'border-status-error/40 bg-status-error/10 text-status-error animate-pulse',
+  expired: 'border-text-muted/30 bg-forge-800 text-text-muted',
+};
+
+export function BountyCountdown({
+  deadline,
+  size = 'default',
+  showIcon = true,
+  className = '',
+}: BountyCountdownProps) {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (!deadline) return undefined;
+
+    const interval = window.setInterval(() => setNow(Date.now()), 1_000);
+    return () => window.clearInterval(interval);
+  }, [deadline]);
+
+  const parts = useMemo(() => getCountdownParts(deadline, now), [deadline, now]);
+  if (!parts) return null;
+
+  const sizeClasses = size === 'compact' ? 'px-2 py-0.5 text-xs' : 'px-3 py-2 text-sm';
+  const iconSize = size === 'compact' ? 'w-3.5 h-3.5' : 'w-4 h-4';
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full border font-mono font-medium transition-colors ${sizeClasses} ${urgencyClasses[parts.urgency]} ${className}`}
+      title={`Deadline: ${new Date(deadline ?? '').toLocaleString()}`}
+      aria-label={`Bounty deadline countdown: ${formatCountdown(parts)}`}
+    >
+      {showIcon && <Clock className={iconSize} aria-hidden="true" />}
+      {formatCountdown(parts)}
+    </span>
+  );
+}

--- a/frontend/src/components/bounty/BountyCountdown.tsx
+++ b/frontend/src/components/bounty/BountyCountdown.tsx
@@ -29,7 +29,7 @@ export function getCountdownParts(deadline?: string | null, now = Date.now()): C
     return { days: 0, hours: 0, minutes: 0, totalMs, urgency: 'expired' };
   }
 
-  const totalMinutes = Math.max(0, Math.floor(totalMs / 60_000));
+  const totalMinutes = Math.max(1, Math.floor(totalMs / 60_000));
   const days = Math.floor(totalMinutes / 1_440);
   const hours = Math.floor((totalMinutes % 1_440) / 60);
   const minutes = totalMinutes % 60;
@@ -72,7 +72,17 @@ export function BountyCountdown({
   useEffect(() => {
     if (!deadline) return undefined;
 
-    const interval = window.setInterval(() => setNow(Date.now()), 1_000);
+    const deadlineMs = new Date(deadline).getTime();
+    if (Number.isNaN(deadlineMs)) return undefined;
+
+    const interval = window.setInterval(() => {
+      const nextNow = Date.now();
+      setNow(nextNow);
+      if (nextNow >= deadlineMs) {
+        window.clearInterval(interval);
+      }
+    }, 1_000);
+
     return () => window.clearInterval(interval);
   }, [deadline]);
 

--- a/frontend/src/components/bounty/BountyDetail.tsx
+++ b/frontend/src/components/bounty/BountyDetail.tsx
@@ -1,12 +1,13 @@
 import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { ArrowLeft, Clock, GitPullRequest, ExternalLink, Loader2, Check, Copy } from 'lucide-react';
+import { ArrowLeft, GitPullRequest, ExternalLink, Loader2, Check, Copy } from 'lucide-react';
 import type { Bounty } from '../../types/bounty';
-import { timeLeft, timeAgo, formatCurrency, LANG_COLORS } from '../../lib/utils';
+import { timeAgo, formatCurrency, LANG_COLORS } from '../../lib/utils';
 import { useAuth } from '../../hooks/useAuth';
 import { SubmissionForm } from './SubmissionForm';
 import { fadeIn } from '../../lib/animations';
+import { BountyCountdown } from './BountyCountdown';
 
 interface BountyDetailProps {
   bounty: Bounty;
@@ -138,9 +139,7 @@ export function BountyDetail({ bounty }: BountyDetailProps) {
             {bounty.deadline && (
               <div className="flex items-center justify-between text-sm">
                 <span className="text-text-muted">Deadline</span>
-                <span className="font-mono text-status-warning inline-flex items-center gap-1">
-                  <Clock className="w-3.5 h-3.5" /> {timeLeft(bounty.deadline)}
-                </span>
+                <BountyCountdown deadline={bounty.deadline} />
               </div>
             )}
             <div className="flex items-center justify-between text-sm">

--- a/frontend/src/lib/animations.ts
+++ b/frontend/src/lib/animations.ts
@@ -1,0 +1,38 @@
+import type { Variants } from 'framer-motion';
+
+export const fadeIn: Variants = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.25, ease: 'easeOut' } },
+  exit: { opacity: 0, y: 8, transition: { duration: 0.15, ease: 'easeIn' } },
+};
+
+export const pageTransition: Variants = {
+  initial: { opacity: 0, y: 16 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.3, ease: 'easeOut' } },
+  exit: { opacity: 0, y: -8, transition: { duration: 0.2, ease: 'easeIn' } },
+};
+
+export const staggerContainer: Variants = {
+  initial: {},
+  animate: { transition: { staggerChildren: 0.06 } },
+};
+
+export const staggerItem: Variants = {
+  initial: { opacity: 0, y: 10 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.22, ease: 'easeOut' } },
+};
+
+export const cardHover = {
+  whileHover: { y: -4, transition: { duration: 0.15 } },
+  whileTap: { scale: 0.99 },
+};
+
+export const buttonHover = {
+  whileHover: { scale: 1.02 },
+  whileTap: { scale: 0.98 },
+};
+
+export const slideInRight: Variants = {
+  initial: { opacity: 0, x: 20 },
+  animate: { opacity: 1, x: 0, transition: { duration: 0.25, ease: 'easeOut' } },
+};

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,51 @@
+import type { RewardToken } from '../types/bounty';
+
+export const LANG_COLORS: Record<string, string> = {
+  TypeScript: '#3b82f6',
+  JavaScript: '#eab308',
+  Rust: '#f97316',
+  Solidity: '#a855f7',
+  Python: '#22c55e',
+  Go: '#06b6d4',
+  React: '#38bdf8',
+  default: '#5C5C78',
+};
+
+export function formatCurrency(amount: number, token: RewardToken | string = 'FNDRY'): string {
+  const value = Number.isFinite(amount) ? amount : 0;
+  const formatted = new Intl.NumberFormat('en-US', {
+    maximumFractionDigits: value >= 100 ? 0 : 2,
+  }).format(value);
+  return `${formatted} ${token}`;
+}
+
+export function timeAgo(dateLike?: string | null): string {
+  if (!dateLike) return 'unknown';
+  const timestamp = new Date(dateLike).getTime();
+  if (Number.isNaN(timestamp)) return 'unknown';
+  const seconds = Math.max(0, Math.floor((Date.now() - timestamp) / 1000));
+  if (seconds < 60) return 'just now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo ago`;
+  return `${Math.floor(months / 12)}y ago`;
+}
+
+export function timeLeft(dateLike?: string | null): string {
+  if (!dateLike) return 'No deadline';
+  const timestamp = new Date(dateLike).getTime();
+  if (Number.isNaN(timestamp)) return 'No deadline';
+  const seconds = Math.floor((timestamp - Date.now()) / 1000);
+  if (seconds <= 0) return 'Expired';
+  const days = Math.floor(seconds / 86400);
+  if (days > 0) return `${days}d left`;
+  const hours = Math.floor(seconds / 3600);
+  if (hours > 0) return `${hours}h left`;
+  const minutes = Math.max(1, Math.floor(seconds / 60));
+  return `${minutes}m left`;
+}


### PR DESCRIPTION
## Summary
- Adds a reusable real-time bounty countdown timer with normal, warning, urgent, and expired states.
- Shows the timer on bounty cards and the bounty detail sidebar.
- Adds focused unit coverage for countdown formatting and urgency thresholds.

/claim #826

## Test Plan
- npm test -- bounty-countdown
- npm run build

## Payout
- Payout target: github:MolhamHamwi
- **Wallet:** AhqbFaPBPLMMiaLDzA9WhQcyvv4hMxiteLhPk3NhG1iG
