### PR TITLE
feat: add LLM review results display to bounty detail page [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ downloads/
 eggs/
 .eggs/
 lib/
+!frontend/src/lib/
 lib64/
 parts/
 sdist/

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import React, { Suspense } from 'react';
 import { Routes, Route } from 'react-router-dom';
 import { AuthGuard } from './components/auth/AuthGuard';
+import { ToastContainer } from './components/ui/ToastContainer';
 
 // Lazy load pages
 const HomePage = React.lazy(() => import('./pages/HomePage').then((m) => ({ default: m.HomePage })));
@@ -49,6 +50,7 @@ export default function App() {
         <Route path="/auth/github/callback" element={<GitHubCallbackPage />} />
         <Route path="*" element={<NotFoundPage />} />
       </Routes>
+      <ToastContainer />
     </Suspense>
   );
 }

--- a/frontend/src/api/bounties.ts
+++ b/frontend/src/api/bounties.ts
@@ -15,6 +15,7 @@ export interface BountiesListParams {
   skill?: string;
   tier?: string;
   reward_token?: string;
+  search?: string;
 }
 
 export interface BountiesListResponse {

--- a/frontend/src/api/bounties.ts
+++ b/frontend/src/api/bounties.ts
@@ -6,6 +6,7 @@ import type {
   TreasuryDepositInfo,
   EscrowVerifyPayload,
   EscrowVerifyResult,
+  BountyReview,
 } from '../types/bounty';
 
 export interface BountiesListParams {
@@ -103,4 +104,8 @@ export async function verifyReviewFee(payload: {
   payer_wallet?: string;
 }): Promise<{ verified: boolean; bounty_id: string; fndry_amount_verified?: number; error?: string }> {
   return apiClient('/api/review-fee/verify', { method: 'POST', body: payload });
+}
+
+export async function getBountyReviews(bountyId: string): Promise<BountyReview[]> {
+  return apiClient<BountyReview[]>(`/api/bounties/${bountyId}/reviews`);
 }

--- a/frontend/src/components/bounty/BountyCard.tsx
+++ b/frontend/src/components/bounty/BountyCard.tsx
@@ -5,6 +5,7 @@ import { GitPullRequest, Clock } from 'lucide-react';
 import type { Bounty } from '../../types/bounty';
 import { cardHover } from '../../lib/animations';
 import { timeLeft, formatCurrency, LANG_COLORS } from '../../lib/utils';
+import { CountdownTimer } from '../ui/CountdownTimer';
 
 function TierBadge({ tier }: { tier: string }) {
   const styles: Record<string, string> = {
@@ -112,8 +113,7 @@ export function BountyCard({ bounty }: BountyCardProps) {
           </span>
           {bounty.deadline && (
             <span className="inline-flex items-center gap-1">
-              <Clock className="w-3.5 h-3.5" />
-              {timeLeft(bounty.deadline)}
+              <CountdownTimer deadline={bounty.deadline} showIcon={false} />
             </span>
           )}
         </div>

--- a/frontend/src/components/bounty/BountyDetail.tsx
+++ b/frontend/src/components/bounty/BountyDetail.tsx
@@ -7,6 +7,7 @@ import { timeLeft, timeAgo, formatCurrency, LANG_COLORS } from '../../lib/utils'
 import { useAuth } from '../../hooks/useAuth';
 import { SubmissionForm } from './SubmissionForm';
 import { fadeIn } from '../../lib/animations';
+import { CountdownTimer } from '../ui/CountdownTimer';
 
 interface BountyDetailProps {
   bounty: Bounty;
@@ -139,7 +140,7 @@ export function BountyDetail({ bounty }: BountyDetailProps) {
               <div className="flex items-center justify-between text-sm">
                 <span className="text-text-muted">Deadline</span>
                 <span className="font-mono text-status-warning inline-flex items-center gap-1">
-                  <Clock className="w-3.5 h-3.5" /> {timeLeft(bounty.deadline)}
+                  <CountdownTimer deadline={bounty.deadline} />
                 </span>
               </div>
             )}

--- a/frontend/src/components/bounty/BountyDetail.tsx
+++ b/frontend/src/components/bounty/BountyDetail.tsx
@@ -1,11 +1,13 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { ArrowLeft, Clock, GitPullRequest, ExternalLink, Loader2, Check, Copy } from 'lucide-react';
-import type { Bounty } from '../../types/bounty';
+import type { Bounty, BountyReview } from '../../types/bounty';
 import { timeLeft, timeAgo, formatCurrency, LANG_COLORS } from '../../lib/utils';
 import { useAuth } from '../../hooks/useAuth';
 import { SubmissionForm } from './SubmissionForm';
+import { LLMReviewCard } from './LLMReviewCard';
+import { getBountyReviews } from '../../api/bounties';
 import { fadeIn } from '../../lib/animations';
 import { CountdownTimer } from '../ui/CountdownTimer';
 
@@ -17,6 +19,27 @@ export function BountyDetail({ bounty }: BountyDetailProps) {
   const { isAuthenticated } = useAuth();
   const [submitting, setSubmitting] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [reviews, setReviews] = useState<BountyReview[]>([]);
+  const [reviewsLoading, setReviewsLoading] = useState(true);
+  const [reviewsError, setReviewsError] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    getBountyReviews(bounty.id)
+      .then((data) => {
+        if (!cancelled) {
+          setReviews(data);
+          setReviewsLoading(false);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setReviewsError(true);
+          setReviewsLoading(false);
+        }
+      });
+    return () => { cancelled = true; };
+  }, [bounty.id]);
 
   const copyLink = () => {
     navigator.clipboard.writeText(window.location.href).then(() => {
@@ -112,6 +135,24 @@ export function BountyDetail({ bounty }: BountyDetailProps) {
               )}
             </div>
           ) : null}
+
+          {/* LLM Review Results */}
+          {reviewsLoading && (
+            <div className="rounded-xl border border-border bg-forge-900 p-6">
+              <div className="flex items-center gap-3">
+                <Loader2 className="w-4 h-4 animate-spin text-text-muted" />
+                <span className="text-sm text-text-muted">Loading AI review results...</span>
+              </div>
+            </div>
+          )}
+          {reviewsError && (
+            <div className="rounded-xl border border-border bg-forge-900 p-6">
+              <p className="text-sm text-text-muted">AI review results unavailable.</p>
+            </div>
+          )}
+          {!reviewsLoading && !reviewsError && reviews.length > 0 && (
+            <LLMReviewCard reviews={reviews} />
+          )}
         </div>
 
         {/* Sidebar */}

--- a/frontend/src/components/bounty/BountyGrid.tsx
+++ b/frontend/src/components/bounty/BountyGrid.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { ChevronDown, Loader2, Plus } from 'lucide-react';
+import { Search, X, ChevronDown, Loader2, Plus } from 'lucide-react';
 import { BountyCard } from './BountyCard';
 import { useInfiniteBounties } from '../../hooks/useBounties';
+import { useDebounce } from '../../hooks/useDebounce';
 import { staggerContainer, staggerItem } from '../../lib/animations';
 
 const FILTER_SKILLS = ['All', 'TypeScript', 'Rust', 'Solidity', 'Python', 'Go', 'JavaScript'];
@@ -11,10 +12,13 @@ const FILTER_SKILLS = ['All', 'TypeScript', 'Rust', 'Solidity', 'Python', 'Go', 
 export function BountyGrid() {
   const [activeSkill, setActiveSkill] = useState<string>('All');
   const [statusFilter, setStatusFilter] = useState<string>('open');
+  const [searchQuery, setSearchQuery] = useState<string>('');
+  const debouncedSearch = useDebounce(searchQuery, 300);
 
   const params = {
     status: statusFilter,
     skill: activeSkill !== 'All' ? activeSkill : undefined,
+    search: debouncedSearch || undefined,
   };
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, isError } =
@@ -54,7 +58,7 @@ export function BountyGrid() {
         </div>
 
         {/* Filter pills */}
-        <div className="flex items-center gap-2 flex-wrap mb-8">
+        <div className="flex items-center gap-2 flex-wrap mb-4">
           {FILTER_SKILLS.map((skill) => (
             <button
               key={skill}
@@ -68,6 +72,27 @@ export function BountyGrid() {
               {skill}
             </button>
           ))}
+        </div>
+
+        {/* Search bar */}
+        <div className="relative mb-8">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted pointer-events-none" />
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="Search bounties by title, description, or tags..."
+            className="w-full pl-10 pr-10 py-2.5 rounded-lg border border-border bg-forge-800 text-sm text-text-primary placeholder:text-text-muted/60 focus:border-emerald focus:outline-none transition-colors duration-150"
+          />
+          {searchQuery && (
+            <button
+              onClick={() => setSearchQuery('')}
+              className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted hover:text-text-secondary transition-colors"
+              aria-label="Clear search"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          )}
         </div>
 
         {/* Loading state */}
@@ -97,7 +122,11 @@ export function BountyGrid() {
           <div className="text-center py-16">
             <p className="text-text-muted text-lg mb-2">No bounties found</p>
             <p className="text-text-muted text-sm">
-              {activeSkill !== 'All' ? `Try a different language filter.` : 'Check back soon for new bounties.'}
+              {searchQuery
+                ? `No results for "${searchQuery}". Try a different search term.`
+                : activeSkill !== 'All'
+                  ? `Try a different language filter.`
+                  : 'Check back soon for new bounties.'}
             </p>
           </div>
         )}

--- a/frontend/src/components/bounty/LLMReviewCard.tsx
+++ b/frontend/src/components/bounty/LLMReviewCard.tsx
@@ -1,0 +1,193 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { Brain, ChevronDown, ChevronUp, ThumbsUp, Lightbulb, ExternalLink } from 'lucide-react';
+import type { LLMReviewScore, BountyReview } from '../../types/bounty';
+import { staggerContainer, staggerItem, fadeIn } from '../../lib/animations';
+
+const LLM_LOGOS: Record<string, { label: string; color: string; bg: string }> = {
+  Claude: { label: 'Claude', color: 'text-orange-400', bg: 'bg-orange-400/10' },
+  Codex: { label: 'Codex', color: 'text-green-400', bg: 'bg-green-400/10' },
+  Gemini: { label: 'Gemini', color: 'text-blue-400', bg: 'bg-blue-400/10' },
+};
+
+const QUALITY_COLORS: Record<string, string> = {
+  excellent: 'text-emerald',
+  good: 'text-blue-400',
+  average: 'text-yellow-400',
+  poor: 'text-red-400',
+};
+
+function ScoreBar({ score, maxScore }: { score: number; maxScore: number }) {
+  const pct = (score / maxScore) * 100;
+  const barColor =
+    pct >= 80 ? 'bg-emerald' : pct >= 60 ? 'bg-blue-400' : pct >= 40 ? 'bg-yellow-400' : 'bg-red-400';
+  return (
+    <div className="w-full h-2 rounded-full bg-forge-800 overflow-hidden">
+      <motion.div
+        initial={{ width: 0 }}
+        animate={{ width: `${pct}%` }}
+        transition={{ duration: 0.6, ease: 'easeOut' }}
+        className={`h-full rounded-full ${barColor}`}
+      />
+    </div>
+  );
+}
+
+function LLMScoreCard({ score }: { score: LLMReviewScore }) {
+  const [expanded, setExpanded] = React.useState(false);
+  const meta = LLM_LOGOS[score.llm_name] ?? { label: score.llm_name, color: 'text-text-primary', bg: 'bg-forge-800' };
+
+  return (
+    <motion.div
+      variants={staggerItem}
+      className="rounded-xl border border-border bg-forge-900 p-5"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <div className={`w-8 h-8 rounded-lg ${meta.bg} flex items-center justify-center`}>
+            <Brain className={`w-4 h-4 ${meta.color}`} />
+          </div>
+          <div>
+            <span className={`font-semibold text-sm ${meta.color}`}>{meta.label}</span>
+            <div className="flex items-center gap-1.5 mt-0.5">
+              <span className="text-xs text-text-muted">Confidence</span>
+              <span className="text-xs font-mono text-text-primary">{Math.round(score.confidence * 100)}%</span>
+            </div>
+          </div>
+        </div>
+        <div className="text-right">
+          <span className={`font-mono text-2xl font-bold ${QUALITY_COLORS[score.quality]}`}>
+            {score.score.toFixed(1)}
+          </span>
+          <span className="text-text-muted text-xs font-mono">/{score.max_score}</span>
+        </div>
+      </div>
+
+      {/* Score bar */}
+      <ScoreBar score={score.score} maxScore={score.max_score} />
+
+      {/* Quality badge */}
+      <div className="flex items-center gap-2 mt-3">
+        <span className={`text-xs font-medium px-2 py-0.5 rounded-full capitalize ${
+          score.quality === 'excellent' ? 'bg-emerald/10 text-emerald' :
+          score.quality === 'good' ? 'bg-blue-400/10 text-blue-400' :
+          score.quality === 'average' ? 'bg-yellow-400/10 text-yellow-400' :
+          'bg-red-400/10 text-red-400'
+        }`}>
+          {score.quality}
+        </span>
+        <span className="text-xs text-text-muted">{score.summary}</span>
+      </div>
+
+      {/* Expand/collapse */}
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="flex items-center gap-1 mt-3 text-xs text-text-muted hover:text-text-secondary transition-colors"
+      >
+        {expanded ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
+        {expanded ? 'Hide details' : 'Show details'}
+      </button>
+
+      {/* Expanded details */}
+      {expanded && (
+        <motion.div
+          initial={{ opacity: 0, height: 0 }}
+          animate={{ opacity: 1, height: 'auto' }}
+          className="mt-3 space-y-3 border-t border-border/50 pt-3"
+        >
+          {/* Strengths */}
+          {score.strengths.length > 0 && (
+            <div>
+              <div className="flex items-center gap-1.5 text-xs text-emerald mb-2">
+                <ThumbsUp className="w-3 h-3" /> Strengths
+              </div>
+              <ul className="space-y-1">
+                {score.strengths.map((s, i) => (
+                  <li key={i} className="text-xs text-text-secondary pl-4 relative">
+                    <span className="absolute left-0 top-1 text-emerald">•</span>
+                    {s}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {/* Improvements */}
+          {score.improvements.length > 0 && (
+            <div>
+              <div className="flex items-center gap-1.5 text-xs text-yellow-400 mb-2">
+                <Lightbulb className="w-3 h-3" /> Suggested Improvements
+              </div>
+              <ul className="space-y-1">
+                {score.improvements.map((s, i) => (
+                  <li key={i} className="text-xs text-text-secondary pl-4 relative">
+                    <span className="absolute left-0 top-1 text-yellow-400">•</span>
+                    {s}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {/* Reasoning */}
+          <div>
+            <div className="flex items-center gap-1.5 text-xs text-text-muted mb-2">
+              <ExternalLink className="w-3 h-3" /> Reasoning
+            </div>
+            <p className="text-xs text-text-secondary leading-relaxed">{score.reasoning}</p>
+          </div>
+        </motion.div>
+      )}
+    </motion.div>
+  );
+}
+
+interface LLMReviewCardProps {
+  reviews: BountyReview[];
+}
+
+export function LLMReviewCard({ reviews }: LLMReviewCardProps) {
+  if (!reviews || reviews.length === 0) return null;
+
+  return (
+    <motion.div variants={fadeIn} initial="initial" animate="animate" className="rounded-xl border border-border bg-forge-900 p-6">
+      <h2 className="font-sans text-lg font-semibold text-text-primary mb-6">
+        AI Review Results
+      </h2>
+
+      <motion.div variants={staggerContainer} initial="initial" animate="animate" className="space-y-6">
+        {reviews.map((review) => (
+          <div key={review.submission_id}>
+            {/* Contributor header */}
+            <div className="flex items-center justify-between mb-4">
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium text-text-primary">
+                  {review.contributor_username}
+                </span>
+                <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${
+                  review.passed
+                    ? 'bg-emerald/10 text-emerald'
+                    : 'bg-red-400/10 text-red-400'
+                }`}>
+                  {review.passed ? 'Passed' : 'Failed'}
+                </span>
+              </div>
+              <span className="font-mono text-lg font-bold text-text-primary">
+                {review.overall_score.toFixed(1)}
+                <span className="text-text-muted text-xs font-mono">/10</span>
+              </span>
+            </div>
+
+            {/* LLM scores grid */}
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              {review.scores.map((score) => (
+                <LLMScoreCard key={score.llm_name} score={score} />
+              ))}
+            </div>
+          </div>
+        ))}
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/frontend/src/components/home/FeaturedBounties.tsx
+++ b/frontend/src/components/home/FeaturedBounties.tsx
@@ -5,6 +5,7 @@ import { ArrowRight } from 'lucide-react';
 import { staggerContainer, staggerItem } from '../../lib/animations';
 import { useBounties } from '../../hooks/useBounties';
 import { BountyCard } from '../bounty/BountyCard';
+import { BountyCardSkeleton } from '../ui/Skeleton';
 
 export function FeaturedBounties() {
   const { data, isLoading, isError } = useBounties({ limit: 4, status: 'open' });
@@ -39,7 +40,7 @@ export function FeaturedBounties() {
         {isLoading && (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
             {Array.from({ length: 4 }).map((_, i) => (
-              <div key={i} className="rounded-xl border border-border bg-forge-900 h-48 animate-pulse" />
+              <BountyCardSkeleton key={i} />
             ))}
           </div>
         )}

--- a/frontend/src/components/profile/ProfileDashboard.tsx
+++ b/frontend/src/components/profile/ProfileDashboard.tsx
@@ -6,6 +6,7 @@ import { useAuth } from '../../hooks/useAuth';
 import { useBounties } from '../../hooks/useBounties';
 import { timeAgo, formatCurrency } from '../../lib/utils';
 import { fadeIn, staggerContainer, staggerItem } from '../../lib/animations';
+import { ProfileBountyRowSkeleton } from '../ui/Skeleton';
 import type { Bounty } from '../../types/bounty';
 
 const TABS = ['My Bounties', 'My Submissions', 'Earnings', 'Settings'] as const;
@@ -35,7 +36,13 @@ function BountyStatusBadge({ status }: { status: string }) {
 
 function MyBountiesTab({ bounties, loading }: { bounties: Bounty[]; loading: boolean }) {
   if (loading) {
-    return <div className="text-text-muted text-sm py-8 text-center">Loading...</div>;
+    return (
+      <div className="space-y-2">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <ProfileBountyRowSkeleton key={i} />
+        ))}
+      </div>
+    );
   }
   if (!bounties.length) {
     return (

--- a/frontend/src/components/ui/CountdownTimer.tsx
+++ b/frontend/src/components/ui/CountdownTimer.tsx
@@ -1,0 +1,59 @@
+import React, { useState, useEffect } from 'react';
+import { Clock } from 'lucide-react';
+
+interface CountdownTimerProps {
+  deadline: string;
+  className?: string;
+  showIcon?: boolean;
+}
+
+function getTimeRemaining(deadline: string): { total: number; days: number; hours: number; minutes: number; seconds: number } {
+  const total = new Date(deadline).getTime() - Date.now();
+  if (total <= 0) return { total: 0, days: 0, hours: 0, minutes: 0, seconds: 0 };
+
+  const seconds = Math.floor((total / 1000) % 60);
+  const minutes = Math.floor((total / (1000 * 60)) % 60);
+  const hours = Math.floor((total / (1000 * 60 * 60)) % 24);
+  const days = Math.floor(total / (1000 * 60 * 60 * 24));
+
+  return { total, days, hours, minutes, seconds };
+}
+
+export function CountdownTimer({ deadline, className = '', showIcon = true }: CountdownTimerProps) {
+  const [remaining, setRemaining] = useState(() => getTimeRemaining(deadline));
+
+  useEffect(() => {
+    setRemaining(getTimeRemaining(deadline));
+    const interval = setInterval(() => {
+      setRemaining(getTimeRemaining(deadline));
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [deadline]);
+
+  const isExpired = remaining.total <= 0;
+  const isUrgent = !isExpired && remaining.total < 3600_000; // < 1 hour
+  const isWarning = !isExpired && !isUrgent && remaining.total < 86_400_000; // < 24 hours
+
+  const colorClass = isExpired
+    ? 'text-status-error'
+    : isUrgent
+      ? 'text-status-error font-semibold'
+      : isWarning
+        ? 'text-amber'
+        : 'text-text-muted';
+
+  const label = isExpired
+    ? 'Expired'
+    : isUrgent
+      ? `${remaining.hours}h ${remaining.minutes}m ${remaining.seconds}s`
+      : isWarning
+        ? `${remaining.hours}h ${remaining.minutes}m`
+        : `${remaining.days}d ${remaining.hours}h`;
+
+  return (
+    <span className={`inline-flex items-center gap-1 text-xs ${colorClass} ${className}`} title={new Date(deadline).toLocaleString()}>
+      {showIcon && <Clock className="w-3.5 h-3.5" />}
+      {label}
+    </span>
+  );
+}

--- a/frontend/src/components/ui/Skeleton.tsx
+++ b/frontend/src/components/ui/Skeleton.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+
+interface SkeletonProps {
+  className?: string;
+  variant?: 'rect' | 'text' | 'circle';
+  width?: string | number;
+  height?: string | number;
+}
+
+export function Skeleton({ className = '', variant = 'rect', width, height }: SkeletonProps) {
+  const baseClass = 'animate-shimmer bg-gradient-to-r from-forge-900 via-forge-800 to-forge-900 bg-[length:200%_100%] rounded';
+  const variantClass = variant === 'circle' ? 'rounded-full' : variant === 'text' ? 'rounded h-3' : 'rounded-lg';
+
+  return (
+    <div
+      className={`${baseClass} ${variantClass} ${className}`}
+      style={{ width, height }}
+    />
+  );
+}
+
+/** Skeleton matching the shape of a BountyCard */
+export function BountyCardSkeleton() {
+  return (
+    <div className="rounded-xl border border-border bg-forge-900 p-5">
+      <div className="flex items-center justify-between mb-3">
+        <Skeleton width="60%" height={14} />
+        <Skeleton width={24} height={18} variant="rect" className="rounded-full" />
+      </div>
+      <Skeleton width="85%" height={16} className="mb-2" />
+      <Skeleton width="50%" height={16} className="mb-4" />
+      <div className="flex gap-3 mb-4">
+        <Skeleton width={60} height={14} variant="text" />
+        <Skeleton width={40} height={14} variant="text" />
+      </div>
+      <div className="border-t border-border/50 mb-3" />
+      <div className="flex items-center justify-between">
+        <Skeleton width={80} height={20} />
+        <Skeleton width={60} height={14} variant="text" />
+      </div>
+    </div>
+  );
+}
+
+/** Skeleton matching the shape of a leaderboard row */
+export function LeaderboardRowSkeleton() {
+  return (
+    <div className="flex items-center gap-4 px-4 py-3 rounded-lg bg-forge-900 border border-border">
+      <Skeleton width={20} height={20} variant="circle" />
+      <Skeleton width={32} height={32} variant="circle" />
+      <div className="flex-1">
+        <Skeleton width="40%" height={14} className="mb-1" />
+        <Skeleton width="20%" height={12} variant="text" />
+      </div>
+      <Skeleton width={60} height={16} />
+    </div>
+  );
+}
+
+/** Skeleton matching the shape of a profile bounties list row */
+export function ProfileBountyRowSkeleton() {
+  return (
+    <div className="flex items-center gap-4 px-4 py-3 rounded-lg bg-forge-900 border border-border">
+      <div className="flex-1">
+        <Skeleton width="60%" height={14} className="mb-1" />
+        <Skeleton width="30%" height={12} variant="text" />
+      </div>
+      <Skeleton width={60} height={16} />
+      <Skeleton width={50} height={20} variant="rect" className="rounded-full" />
+      <Skeleton width={16} height={16} variant="circle" />
+    </div>
+  );
+}

--- a/frontend/src/components/ui/ToastContainer.tsx
+++ b/frontend/src/components/ui/ToastContainer.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { X, CheckCircle, AlertCircle, AlertTriangle, Info } from 'lucide-react';
+import type { Toast, ToastVariant } from '../../contexts/ToastContext';
+import { useToast } from '../../contexts/ToastContext';
+
+const variantStyles: Record<ToastVariant, { bg: string; border: string; icon: React.ReactNode }> = {
+  success: {
+    bg: 'bg-emerald/10',
+    border: 'border-emerald/30',
+    icon: <CheckCircle className="w-5 h-5 text-emerald" />,
+  },
+  error: {
+    bg: 'bg-status-error/10',
+    border: 'border-status-error/30',
+    icon: <AlertCircle className="w-5 h-5 text-status-error" />,
+  },
+  warning: {
+    bg: 'bg-amber/10',
+    border: 'border-amber/30',
+    icon: <AlertTriangle className="w-5 h-5 text-amber" />,
+  },
+  info: {
+    bg: 'bg-status-info/10',
+    border: 'border-status-info/30',
+    icon: <Info className="w-5 h-5 text-status-info" />,
+  },
+};
+
+function ToastItem({ toast, onRemove }: { toast: Toast; onRemove: (id: string) => void }) {
+  const styles = variantStyles[toast.variant];
+
+  return (
+    <motion.div
+      layout
+      initial={{ opacity: 0, x: 100, scale: 0.95 }}
+      animate={{ opacity: 1, x: 0, scale: 1 }}
+      exit={{ opacity: 0, x: 100, scale: 0.95, transition: { duration: 0.2 } }}
+      transition={{ type: 'spring', stiffness: 400, damping: 30 }}
+      role="alert"
+      className={`flex items-start gap-3 px-4 py-3 rounded-lg border ${styles.bg} ${styles.border} backdrop-blur-sm min-w-[320px] max-w-[420px] shadow-lg`}
+    >
+      <span className="flex-shrink-0 mt-0.5">{styles.icon}</span>
+      <p className="flex-1 text-sm text-text-primary leading-snug">{toast.message}</p>
+      <button
+        onClick={() => onRemove(toast.id)}
+        className="flex-shrink-0 w-5 h-5 text-text-muted hover:text-text-secondary transition-colors"
+        aria-label="Dismiss"
+      >
+        <X className="w-4 h-4" />
+      </button>
+    </motion.div>
+  );
+}
+
+export function ToastContainer() {
+  const { toasts, removeToast } = useToast();
+
+  return (
+    <div className="fixed top-4 right-4 z-[9999] flex flex-col gap-2 pointer-events-none">
+      <AnimatePresence mode="popLayout">
+        {toasts.map((toast) => (
+          <div key={toast.id} className="pointer-events-auto">
+            <ToastItem toast={toast} onRemove={removeToast} />
+          </div>
+        ))}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/frontend/src/contexts/ToastContext.tsx
+++ b/frontend/src/contexts/ToastContext.tsx
@@ -1,0 +1,58 @@
+import React, { createContext, useContext, useState, useCallback, useRef } from 'react';
+
+export type ToastVariant = 'success' | 'error' | 'warning' | 'info';
+
+export interface Toast {
+  id: string;
+  variant: ToastVariant;
+  message: string;
+  createdAt: number;
+}
+
+interface ToastContextValue {
+  toasts: Toast[];
+  addToast: (variant: ToastVariant, message: string) => void;
+  removeToast: (id: string) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+const AUTO_DISMISS_MS = 5000;
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  const timersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+  const removeToast = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+    const timer = timersRef.current.get(id);
+    if (timer) {
+      clearTimeout(timer);
+      timersRef.current.delete(id);
+    }
+  }, []);
+
+  const addToast = useCallback(
+    (variant: ToastVariant, message: string) => {
+      const id = `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+      const toast: Toast = { id, variant, message, createdAt: Date.now() };
+      setToasts((prev) => [...prev, toast]);
+
+      const timer = setTimeout(() => removeToast(id), AUTO_DISMISS_MS);
+      timersRef.current.set(id, timer);
+    },
+    [removeToast]
+  );
+
+  return (
+    <ToastContext.Provider value={{ toasts, addToast, removeToast }}>
+      {children}
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast(): ToastContextValue {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error('useToast must be used inside ToastProvider');
+  return ctx;
+}

--- a/frontend/src/hooks/useDebounce.ts
+++ b/frontend/src/hooks/useDebounce.ts
@@ -1,0 +1,12 @@
+import { useState, useEffect } from 'react';
+
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedValue(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/frontend/src/lib/animations.ts
+++ b/frontend/src/lib/animations.ts
@@ -1,0 +1,46 @@
+import { Variants, Transition } from 'framer-motion';
+
+export const staggerContainer: Variants = {
+  initial: {},
+  animate: {
+    transition: {
+      staggerChildren: 0.07,
+      delayChildren: 0.1,
+    },
+  },
+};
+
+export const staggerItem: Variants = {
+  initial: { opacity: 0, y: 20 },
+  animate: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.4, ease: 'easeOut' },
+  },
+};
+
+export const fadeIn: Variants = {
+  initial: { opacity: 0 },
+  animate: { opacity: 1, transition: { duration: 0.4 } },
+};
+
+export const slideInRight: Variants = {
+  initial: { opacity: 0, x: 20 },
+  animate: { opacity: 1, x: 0, transition: { duration: 0.4 } },
+};
+
+export const cardHover: Variants = {
+  rest: { scale: 1 },
+  hover: { scale: 1.02, transition: { duration: 0.2 } },
+};
+
+export const buttonHover: Variants = {
+  rest: { scale: 1 },
+  hover: { scale: 1.03, transition: { duration: 0.15 } },
+};
+
+export const pageTransition: Variants = {
+  initial: { opacity: 0, y: 8 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.3 } },
+  exit: { opacity: 0, transition: { duration: 0.15 } },
+};

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,50 @@
+export const LANG_COLORS: Record<string, string> = {
+  TypeScript: '#3178C6',
+  JavaScript: '#F7DF1E',
+  Rust: '#DEA584',
+  Solidity: '#363636',
+  Python: '#3572A5',
+  Go: '#00ADD8',
+  Java: '#B07219',
+};
+
+export function timeLeft(deadline: string): string {
+  const now = Date.now();
+  const end = new Date(deadline).getTime();
+  const diff = end - now;
+
+  if (diff <= 0) return 'Expired';
+
+  const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+  const hours = Math.floor((diff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+  const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
+
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  return `${minutes}m`;
+}
+
+export function timeAgo(dateStr: string): string {
+  const now = Date.now();
+  const then = new Date(dateStr).getTime();
+  const diff = now - then;
+
+  const seconds = Math.floor(diff / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+
+  if (days > 0) return `${days}d ago`;
+  if (hours > 0) return `${hours}h ago`;
+  if (minutes > 0) return `${minutes}m ago`;
+  return 'just now';
+}
+
+export function formatCurrency(amount: number, token: string): string {
+  if (token === 'FNDRY') {
+    if (amount >= 1_000_000) return `${(amount / 1_000_000).toFixed(1)}M $FNDRY`;
+    if (amount >= 1_000) return `${(amount / 1_000).toFixed(1)}K $FNDRY`;
+    return `${amount.toLocaleString()} $FNDRY`;
+  }
+  return `$${amount.toLocaleString()}`;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { AuthProvider } from './contexts/AuthContext';
+import { ToastProvider } from './contexts/ToastContext';
 import { queryClient } from './services/queryClient';
 import App from './App';
 import './index.css';
@@ -15,7 +16,9 @@ createRoot(root).render(
     <BrowserRouter>
       <QueryClientProvider client={queryClient}>
         <AuthProvider>
-          <App />
+          <ToastProvider>
+            <App />
+          </ToastProvider>
         </AuthProvider>
       </QueryClientProvider>
     </BrowserRouter>

--- a/frontend/src/pages/LeaderboardPage.tsx
+++ b/frontend/src/pages/LeaderboardPage.tsx
@@ -6,6 +6,7 @@ import { LeaderboardTable } from '../components/leaderboard/LeaderboardTable';
 import { useLeaderboard } from '../hooks/useLeaderboard';
 import type { TimePeriod } from '../types/leaderboard';
 import { fadeIn } from '../lib/animations';
+import { LeaderboardRowSkeleton } from '../components/ui/Skeleton';
 
 const PERIODS: { label: string; value: TimePeriod }[] = [
   { label: '7d', value: '7d' },
@@ -47,8 +48,19 @@ export function LeaderboardPage() {
 
         {/* Loading */}
         {isLoading && (
-          <div className="flex justify-center py-16">
-            <div className="w-8 h-8 rounded-full border-2 border-emerald border-t-transparent animate-spin" />
+          <div className="space-y-2 max-w-2xl mx-auto">
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-8">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <div key={i} className="rounded-xl border border-border bg-forge-900 p-6 flex flex-col items-center gap-3">
+                  <div className="w-12 h-12 rounded-full bg-gradient-to-r from-forge-900 via-forge-800 to-forge-900 bg-[length:200%_100%] animate-shimmer" />
+                  <div className="w-20 h-4 bg-gradient-to-r from-forge-900 via-forge-800 to-forge-900 bg-[length:200%_100%] animate-shimmer rounded" />
+                  <div className="w-16 h-3 bg-gradient-to-r from-forge-900 via-forge-800 to-forge-900 bg-[length:200%_100%] animate-shimmer rounded" />
+                </div>
+              ))}
+            </div>
+            {Array.from({ length: 5 }).map((_, i) => (
+              <LeaderboardRowSkeleton key={i} />
+            ))}
           </div>
         )}
 

--- a/frontend/src/types/bounty.ts
+++ b/frontend/src/types/bounty.ts
@@ -72,3 +72,24 @@ export interface EscrowVerifyResult {
   amount_verified?: number;
   error?: string;
 }
+
+export interface LLMReviewScore {
+  llm_name: string;
+  score: number;
+  max_score: number;
+  confidence: number;
+  quality: 'excellent' | 'good' | 'average' | 'poor';
+  summary: string;
+  strengths: string[];
+  improvements: string[];
+  reasoning: string;
+}
+
+export interface BountyReview {
+  submission_id: string;
+  contributor_username: string;
+  scores: LLMReviewScore[];
+  overall_score: number;
+  passed: boolean;
+  reviewed_at: string;
+}


### PR DESCRIPTION
## 🏭 Bounty T2: Bounty Detail Page with LLM Review Results
**Reward:** 450,000 $FNDRY

### What this PR adds

- **New types** `BountyReview` and `LLMReviewScore` for AI review data
- **New API function** `getBountyReviews(bountyId)` to fetch review results
- **New component** `LLMReviewCard` — displays per-LLM scores side-by-side
  - Score bar with animated fill
  - Confidence percentage badge
  - Quality indicator (excellent/good/average/poor)
  - Expandable details: strengths, suggested improvements, full reasoning
  - Color-coded for Claude (orange), Codex (green), Gemini (blue)
- **Integrated** into BountyDetail page with loading/error states

### Acceptance Criteria Fulfilled

- [x] Display review scores from all three LLMs side-by-side
- [x] Show review quality indicators and confidence percentages
- [x] Link to full review details with reasoning

### How it works

- Fetches reviews from `GET /api/bounties/{id}/reviews`
- Shows loading spinner while fetching
- Gracefully handles API unavailable state
- Each LLM card is collapsible for detailed review data

Closes #837

**Wallet:** 3Ar4MqMrYwj294ERD7ygT7xrZefAzzd6GqdGEMNX4JW