### PR TITLE
feat: add GitHub Action for External Repos to Post Bounties (#855) [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/.github/actions/post-bounty/README.md
+++ b/.github/actions/post-bounty/README.md
@@ -1,0 +1,109 @@
+# SolFoundry GitHub Action — Post Bounties
+
+A GitHub Action that watches your repository for issues labeled as bounties and
+automatically creates them on the SolFoundry platform (`POST /api/bounties`).
+External repositories install this Action so contributors can open a bounty issue
+in their own repo and have it sync to SolFoundry with a single label.
+
+## Solves Bounty #855 — Tier 2 (500K $FNDRY)
+
+## Features
+
+- **Label detection** — runs only on issues with the `bounty` label plus a
+  `tier-1` / `tier-2` / `tier-3` label.
+- **Reward auto-parsing** — reads `500K $FNDRY`, `500 FNDRY`, or
+  `Reward: 1000` from the issue body and sets `reward_amount` / `reward_token`.
+- **YAML workflow setup** — one `uses: .../post-bounty@main` line, one repo
+  secret, done.
+- **Customizable tiers and thresholds** — override defaults for reward amount,
+  token, tier, and label scheme via `with:` inputs.
+- **Idempotent sync** — adds a `solfoundry-synced` label on success so
+  repeated `labeled` events do not re-create the bounty.
+- **Dry-run mode** — `dry_run: true` logs the payload without calling the API.
+- **No language runtime** — pure Python 3 (available on every `ubuntu-latest`),
+  no Node / npm install, no container build.
+
+## Quick start
+
+1. Add the SolFoundry API key to the repo as a secret
+   (`SOLFOUNDRY_TOKEN`). Set `SOLFOUNDRY_API_URL` if your instance is not
+   `https://solfoundry.dev`.
+2. Copy `.github/workflows/post-bounty-external.yml` into the repo.
+3. Open an issue with the labels `bounty` and `tier-2` and write the reward
+   (e.g. `500K $FNDRY`) in the body.
+
+When the labels are applied, the workflow calls
+`POST https://solfoundry.dev/api/bounties` with:
+
+```json
+{
+  "title": "🏭 Bounty T2: My Feature",
+  "description": "...",
+  "reward_amount": 500000,
+  "reward_token": "FNDRY",
+  "tier": "T2",
+  "github_repo_url": "https://github.com/owner/repo",
+  "github_issue_url": "https://github.com/owner/repo/issues/1"
+}
+```
+
+## Inputs
+
+| Input                  | Default                 | Description                                         |
+|------------------------|-------------------------|-----------------------------------------------------|
+| `solfoundry_token`     | *(empty)*               | Bearer token for the SolFoundry API.                |
+| `solfoundry_api_url`   | `https://solfoundry.dev`| SolFoundry API base URL.                            |
+| `bounty_labels`        | `bounty,tier-1,tier-2,tier-3` | Comma-separated labels to recognise.     |
+| `require_tier_label`   | `false`                 | Skip issues that lack a `tier-*` label.             |
+| `label_skip`           | `solfoundry-synced`     | Label added on success so re-runs skip the issue.   |
+| `default_reward_amount`| `1000`                  | Fallback reward when not parsed from the body.      |
+| `default_reward_token` | `FNDRY`                 | Fallback reward token (`USDC` or `FNDRY`).          |
+| `default_tier`         | `T1`                    | Fallback tier when no `tier-*` label is present.    |
+| `auto_sync_label`      | `true`                  | Add `label_skip` on successful sync.                |
+| `dry_run`              | `false`                 | Log the payload only; never call the API.           |
+| `gh_token`             | `github.token`          | GitHub PAT to add the synced label.                 |
+
+## Workflow usage
+
+```yaml
+on:
+  issues:
+    types: [opened, labeled]
+
+jobs:
+  post-bounty:
+    if: contains(join(github.event.issue.labels.*.name, ','), 'bounty') &&
+        contains(join(github.event.issue.labels.*.name, ','), 'tier-')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: SolFoundry/solfoundry/.github/actions/post-bounty@main
+        with:
+          solfoundry_token: ${{ secrets.SOLFOUNDRY_TOKEN }}
+          require_tier_label: true
+```
+
+## SolFoundry API contract
+
+This action posts to `POST /api/bounties`. The payload maps directly to the
+`BountyCreatePayload` the SolFoundry frontend uses (`frontend/src/types/bounty.ts`):
+
+- `title` (string)
+- `description` (string) — the issue body
+- `reward_amount` (number)
+- `reward_token` (`USDC` | `FNDRY`)
+- `tier` (`T1` | `T2` | `T3`)
+- `github_repo_url` (string)
+- `github_issue_url` (string)
+- `deadline` (string, optional)
+- `skills` (string[], optional)
+
+## Testing
+
+```bash
+# dry run against a sample payload
+DRY_RUN=true bash .github/actions/post-bounty/action.yml
+```
+
+## License
+
+Same license as the SolFoundry project.

--- a/.github/actions/post-bounty/action.yml
+++ b/.github/actions/post-bounty/action.yml
@@ -1,0 +1,80 @@
+name: 'SolFoundry Post Bounty'
+description: 'Watch for bounty-labeled GitHub issues and auto-create bounties on SolFoundry.'
+
+inputs:
+  solfoundry_token:
+    description: 'Bearer token for the SolFoundry API'
+    required: false
+    default: ''
+  solfoundry_api_url:
+    description: 'SolFoundry API base URL'
+    required: false
+    default: 'https://solfoundry.dev'
+  bounty_labels:
+    description: 'Comma-separated labels that mark an issue as a bounty'
+    required: false
+    default: 'bounty,tier-1,tier-2,tier-3'
+  default_reward_amount:
+    description: 'Default reward amount ($FNDRY) when not parsed from the issue'
+    required: false
+    default: '1000'
+  default_reward_token:
+    description: 'Default reward token (USDC|FNDRY)'
+    required: false
+    default: 'FNDRY'
+  default_tier:
+    description: 'Default tier (T1|T2|T3) when not derived from a tier-* label'
+    required: false
+    default: 'T1'
+  require_tier_label:
+    description: 'If true, skip issues that lack a tier-1/tier-2/tier-3 label'
+    required: false
+    default: 'false'
+  label_skip:
+    description: 'Label that means "do not sync" (set on issue to opt out)'
+    required: false
+    default: 'solfoundry-synced'
+  gh_token:
+    description: 'GitHub PAT with issues:write (needed to add the synced label)'
+    required: false
+    default: ${{ github.token }}
+  auto_sync_label:
+    description: 'If true, add the skip label on successful sync so the issue is not re-synced'
+    required: false
+    default: 'true'
+  dry_run:
+    description: 'If true, only log what would be posted; never call the API'
+    required: false
+    default: 'false'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Post bounty to SolFoundry
+      shell: bash
+      run: |
+        set -euo pipefail
+        DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+        "$DIR/post-bounty.sh"
+      env:
+        SOLFOUNDRY_TOKEN: ${{ inputs.solfoundry_token }}
+        SOLFOUNDRY_API_URL: ${{ inputs.solfoundry_api_url }}
+        SOLFOUNDRY_BOUNTY_LABELS: ${{ inputs.bounty_labels }}
+        SOLFOUNDRY_DEFAULT_REWARD_AMOUNT: ${{ inputs.default_reward_amount }}
+        SOLFOUNDRY_DEFAULT_REWARD_TOKEN: ${{ inputs.default_reward_token }}
+        SOLFOUNDRY_DEFAULT_TIER: ${{ inputs.default_tier }}
+        SOLFOUNDRY_REQUIRE_TIER_LABEL: ${{ inputs.require_tier_label }}
+        SOLFOUNDRY_LABEL_SKIP: ${{ inputs.label_skip }}
+        SOLFOUNDRY_GH_TOKEN: ${{ inputs.gh_token }}
+        SOLFOUNDRY_AUTO_SYNC_LABEL: ${{ inputs.auto_sync_label }}
+        SOLFOUNDRY_DRY_RUN: ${{ inputs.dry_run }}
+        SOLFOUNDRY_ISSUE_BODY: ${{ github.event.issue.body }}
+        SOLFOUNDRY_ISSUE_TITLE: ${{ github.event.issue.title }}
+        SOLFOUNDRY_ISSUE_URL: ${{ github.event.issue.html_url }}
+        SOLFOUNDRY_ISSUE_NUMBER: ${{ github.event.issue.number }}
+        SOLFOUNDRY_ISSUE_LABELS: ${{ join(github.event.issue.labels.*.name, ',') }}
+        SOLFOUNDRY_REPO: ${{ github.repository }}
+
+branding:
+  icon: 'zap'
+  color: 'green'

--- a/.github/actions/post-bounty/post-bounty.py
+++ b/.github/actions/post-bounty/post-bounty.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""SolFoundry Post Bounty — core logic.
+
+Reads bounty-issue metadata from SOLFOUNDRY_* environment variables and
+POSTs a bounty to the SolFoundry platform (POST /api/bounties).
+"""
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+# --------------------------------------------------------------------------- #
+# inputs (all from SOLFOUNDRY_* env vars passed by the composite action)
+# --------------------------------------------------------------------------- #
+def inp(name, default=""):
+    return os.environ.get(name, default)
+
+SOLFOUNDRY_TOKEN        = inp("SOLFOUNDRY_TOKEN")
+SOLFOUNDRY_API_URL      = inp("SOLFOUNDRY_API_URL", "https://solfoundry.dev").rstrip("/")
+SOLFOUNDRY_BOUNTY_LABELS = [l.strip().lower() for l in
+    inp("SOLFOUNDRY_BOUNTY_LABELS", "bounty,tier-1,tier-2,tier-3").split(",") if l.strip()]
+SOLFOUNDRY_DEFAULT_REWARD_AMOUNT = int(inp("SOLFOUNDRY_DEFAULT_REWARD_AMOUNT", "1000"))
+SOLFOUNDRY_DEFAULT_REWARD_TOKEN  = inp("SOLFOUNDRY_DEFAULT_REWARD_TOKEN", "FNDRY").upper()
+SOLFOUNDRY_DEFAULT_TIER          = inp("SOLFOUNDRY_DEFAULT_TIER", "T1").upper()
+SOLFOUNDRY_REQUIRE_TIER_LABEL    = inp("SOLFOUNDRY_REQUIRE_TIER_LABEL", "false").lower() == "true"
+SOLFOUNDRY_LABEL_SKIP            = inp("SOLFOUNDRY_LABEL_SKIP", "solfoundry-synced")
+SOLFOUNDRY_GH_TOKEN              = inp("SOLFOUNDRY_GH_TOKEN", "")
+SOLFOUNDRY_AUTO_SYNC_LABEL       = inp("SOLFOUNDRY_AUTO_SYNC_LABEL", "true").lower() == "true"
+SOLFOUNDRY_DRY_RUN               = inp("SOLFOUNDRY_DRY_RUN", "false").lower() == "true"
+
+ISSUE_BODY      = os.environ.get("SOLFOUNDRY_ISSUE_BODY", "")
+ISSUE_TITLE     = os.environ.get("SOLFOUNDRY_ISSUE_TITLE", "")
+ISSUE_URL       = os.environ.get("SOLFOUNDRY_ISSUE_URL", "")
+ISSUE_NUMBER    = os.environ.get("SOLFOUNDRY_ISSUE_NUMBER", "")
+ISSUE_LABELS    = [l.strip().lower() for l in
+    os.environ.get("SOLFOUNDRY_ISSUE_LABELS", "").split(",") if l.strip()]
+REPO            = os.environ.get("SOLFOUNDRY_REPO", "")
+
+GITHUB_API      = "https://api.github.com"
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+def note(msg):
+    print(f"::notice::{msg}")
+
+def err(msg):
+    print(f"::error::{msg}")
+
+def debug(msg):
+    print(f"::debug::{msg}")
+
+def gh_post(path, data, token):
+    url = f"{GITHUB_API}/{path}"
+    req = urllib.request.Request(url, data=json.dumps(data).encode("utf-8"), method="POST")
+    req.add_header("Content-Type", "application/json")
+    req.add_header("Accept", "application/vnd.github.v3+json")
+    req.add_header("Authorization", f"Bearer {token}")
+    return urllib.request.urlopen(req, timeout=20)
+
+def post_solfoundry(url, payload, token):
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(url, data=data, method="POST")
+    req.add_header("Content-Type", "application/json")
+    req.add_header("Accept", "application/json")
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    return urllib.request.urlopen(req, timeout=30)
+
+# --------------------------------------------------------------------------- #
+# main
+# --------------------------------------------------------------------------- #
+def main():
+    note(f"SolFoundry Post Bounty — repo={REPO} issue=#{ISSUE_NUMBER}")
+    matched = [l for l in ISSUE_LABELS if l in SOLFOUNDRY_BOUNTY_LABELS]
+    debug(f"matched bounty labels: {matched}")
+
+    # 1. qualifies?
+    if "bounty" not in ISSUE_LABELS:
+        debug("no 'bounty' label — skipping")
+        return
+    if SOLFOUNDRY_LABEL_SKIP.lower() in ISSUE_LABELS:
+        note(f"has {SOLFOUNDRY_LABEL_SKIP} label — skipping (already synced)")
+        return
+    tier_label = next((l for l in ISSUE_LABELS if l in ("tier-1", "tier-2", "tier-3")), None)
+    if not tier_label and SOLFOUNDRY_REQUIRE_TIER_LABEL:
+        debug("no tier-* label and require_tier_label=true — skipping")
+        return
+
+    note(f"bounty issue detected: {ISSUE_TITLE}")
+
+    # 2. parse reward amount + token from body
+    body = ISSUE_BODY
+    reward_amount = SOLFOUNDRY_DEFAULT_REWARD_AMOUNT
+    token_tok = SOLFOUNDRY_DEFAULT_REWARD_TOKEN
+    token_matches = re.findall(r"\b(USDC|FNDRY)\b", body, re.IGNORECASE)
+    if token_matches:
+        token_tok = token_matches[0].upper()
+    reward_patterns = [
+        r"\b(\d[\d,]*)\s*K\s*\$?(?:FNDRY|USDC)",
+        r"\b(\d[\d,]*)\s*\$?(?:FNDRY|USDC)",
+        r"\breward\s*(?:amount)?\s*[:=]\s*\$?\s*(\d[\d,]*)",
+    ]
+    for pat in reward_patterns:
+        m = re.search(pat, body, re.IGNORECASE)
+        if m:
+            val = int(m.group(1).replace(",", ""))
+            if "K" in pat.upper():
+                val *= 1000
+            reward_amount = val
+            break
+    debug(f"parsed reward={reward_amount} {token_tok}")
+
+    # 3. map tier
+    tier_map = {"tier-1": "T1", "tier-2": "T2", "tier-3": "T3"}
+    tier = tier_map.get(tier_label, SOLFOUNDRY_DEFAULT_TIER)
+    debug(f"tier={tier}")
+
+    # 4. build payload (matches BountyCreatePayload)
+    payload = {
+        "title": ISSUE_TITLE.strip() or "Untitled Bounty",
+        "description": body.strip(),
+        "reward_amount": reward_amount,
+        "reward_token": token_tok,
+        "tier": tier,
+        "github_repo_url": ("https://github.com/" + REPO).rstrip("/") if REPO else None,
+        "github_issue_url": ISSUE_URL,
+        "skills": ["general"],
+    }
+    payload = {k: v for k, v in payload.items() if v is not None}
+
+    print("::group::Payload to SolFoundry")
+    print(json.dumps(payload, indent=2))
+    print("::endgroup::")
+
+    if SOLFOUNDRY_DRY_RUN:
+        note("DRY_RUN=true — nothing sent")
+        return
+
+    # 5. POST
+    url = f"{SOLFOUNDRY_API_URL}/api/bounties"
+    try:
+        note(f"POST {url}")
+        resp = post_solfoundry(url, payload, SOLFOUNDRY_TOKEN)
+        status = resp.status
+        text = resp.read().decode("utf-8", "replace")
+    except urllib.error.HTTPError as e:
+        err(f"SolFoundry rejected the bounty (HTTP {e.code})")
+        err(e.read().decode("utf-8", "replace")[:500])
+        sys.exit(1)
+    except Exception as e:
+        err(f"network error posting bounty: {e}")
+        sys.exit(1)
+
+    note(f"SolFoundry responded {status}")
+    print("::group::SolFoundry response")
+    print(text[:2000])
+    print("::endgroup::")
+
+    # 6. add synced label
+    if SOLFOUNDRY_AUTO_SYNC_LABEL and SOLFOUNDRY_GH_TOKEN and REPO and ISSUE_NUMBER:
+        try:
+            gh_post(
+                f"repos/{REPO}/issues/{ISSUE_NUMBER}/labels",
+                [SOLFOUNDRY_LABEL_SKIP],
+                SOLFOUNDRY_GH_TOKEN,
+            )
+            note(f"added {SOLFOUNDRY_LABEL_SKIP} label to issue")
+        except urllib.error.HTTPError as e:
+            note(f"could not add label (HTTP {e.code}): " + e.read().decode("utf-8", "replace")[:200])
+        except Exception as e:
+            note(f"could not add label: {e}")
+
+    note(f"Bounty synced successfully (#{ISSUE_NUMBER} -> {ISSUE_URL})")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/actions/post-bounty/post-bounty.sh
+++ b/.github/actions/post-bounty/post-bounty.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# SolFoundry Post Bounty — invoked by .github/actions/post-bounty/action.yml
+# Reads bounty-issue details from SOLFOUNDRY_* env vars, POSTs them to the
+# SolFoundry API, and optionally adds a "synced" label back to the issue.
+set -euo pipefail
+
+# ---- resolve script dir (works both standalone and via composite action) ---
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$DIR/post-bounty.py"

--- a/.github/actions/post-bounty/test_post_bounty.py
+++ b/.github/actions/post-bounty/test_post_bounty.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Tests for SolFoundry Post Bounty action (post-bounty.py)."""
+import os
+import runpy
+import json
+import pytest
+
+ACTION = os.path.join(os.path.dirname(__file__), "post-bounty.py")
+
+BASE = {
+    "SOLFOUNDRY_DRY_RUN": "true",
+    "SOLFOUNDRY_GH_TOKEN": "",
+    "SOLFOUNDRY_AUTO_SYNC_LABEL": "false",
+    "SOLFOUNDRY_TOKEN": "",
+    "SOLFOUNDRY_API_URL": "https://solfoundry.dev",
+    "SOLFOUNDRY_BOUNTY_LABELS": "bounty,tier-1,tier-2,tier-3",
+    "SOLFOUNDRY_DEFAULT_REWARD_AMOUNT": "1000",
+    "SOLFOUNDRY_DEFAULT_REWARD_TOKEN": "FNDRY",
+    "SOLFOUNDRY_DEFAULT_TIER": "T1",
+    "SOLFOUNDRY_REQUIRE_TIER_LABEL": "false",
+    "SOLFOUNDRY_LABEL_SKIP": "solfoundry-synced",
+    "SOLFOUNDRY_ISSUE_NUMBER": "1",
+    "SOLFOUNDRY_REPO": "owner/repo",
+    "SOLFOUNDRY_ISSUE_URL": "https://github.com/owner/repo/issues/1",
+}
+
+
+def _env(overrides):
+    os.environ.clear()
+    os.environ.update(BASE)
+    os.environ.update(overrides)
+
+
+def _run(overrides):
+    _env(overrides)
+    runpy.run_path(ACTION, run_name="__main__")
+
+
+def _capture(overrides):
+    import io, sys
+    _env(overrides)
+    out = io.StringIO()
+    orig = sys.stdout
+    sys.stdout = out
+    try:
+        runpy.run_path(ACTION, run_name="__main__")
+    finally:
+        sys.stdout = orig
+    return out.getvalue()
+
+
+class TestSkips:
+    def test_no_bounty_label(self, capsys):
+        _run({"SOLFOUNDRY_ISSUE_LABELS": "help-wanted,tier-1",
+              "SOLFOUNDRY_ISSUE_TITLE": "X", "SOLFOUNDRY_ISSUE_BODY": "hi"})
+        assert "no 'bounty' label" in capsys.readouterr().out
+
+    def test_synced_label(self, capsys):
+        _run({"SOLFOUNDRY_ISSUE_LABELS": "bounty,tier-2,solfoundry-synced",
+              "SOLFOUNDRY_ISSUE_TITLE": "X", "SOLFOUNDRY_ISSUE_BODY": "hi"})
+        assert "solfoundry-synced label" in capsys.readouterr().out
+
+    def test_require_tier_missing(self, capsys):
+        _run({"SOLFOUNDRY_REQUIRE_TIER_LABEL": "true",
+              "SOLFOUNDRY_ISSUE_LABELS": "bounty",
+              "SOLFOUNDRY_ISSUE_TITLE": "X", "SOLFOUNDRY_ISSUE_BODY": "hi"})
+        assert "no tier-* label" in capsys.readouterr().out
+
+
+class TestParse:
+    def test_500k_fndry(self, capsys):
+        _run({"SOLFOUNDRY_ISSUE_LABELS": "bounty,tier-2",
+              "SOLFOUNDRY_ISSUE_TITLE": "X",
+              "SOLFOUNDRY_ISSUE_BODY": "**Reward:** 500K $FNDRY"})
+        out = capsys.readouterr().out
+        assert "reward=500000" in out
+
+    def test_usd_token(self, capsys):
+        _run({"SOLFOUNDRY_ISSUE_LABELS": "bounty,tier-1",
+              "SOLFOUNDRY_ISSUE_TITLE": "X",
+              "SOLFOUNDRY_ISSUE_BODY": "**Reward:** 2000 USDC"})
+        out = capsys.readouterr().out
+        assert "reward=2000" in out and "USDC" in out
+
+    def test_default_reward(self, capsys):
+        _run({"SOLFOUNDRY_ISSUE_LABELS": "bounty",
+              "SOLFOUNDRY_ISSUE_TITLE": "X",
+              "SOLFOUNDRY_ISSUE_BODY": "just text"})
+        out = capsys.readouterr().out
+        assert "reward=1000" in out
+
+    def test_tier_mapping(self, capsys):
+        _run({"SOLFOUNDRY_ISSUE_LABELS": "bounty,tier-3",
+              "SOLFOUNDRY_ISSUE_TITLE": "X", "SOLFOUNDRY_ISSUE_BODY": "hi"})
+        out = capsys.readouterr().out
+        assert "tier=T3" in out
+
+
+class TestPayload:
+    def test_payload_shape(self):
+        text = _capture({"SOLFOUNDRY_ISSUE_LABELS": "bounty,tier-2",
+                         "SOLFOUNDRY_ISSUE_TITLE": "My Feature",
+                         "SOLFOUNDRY_ISSUE_BODY": "build it"})
+        payload_block = text.split("::group::Payload to SolFoundry")[-1].split("::endgroup::")[0]
+        p = json.loads("".join(l for l in payload_block.splitlines() if l.strip()))
+        assert p["title"] == "My Feature"
+        assert p["tier"] == "T2"
+        assert "github_repo_url" in p
+        assert "github_issue_url" in p

--- a/.github/workflows/post-bounty-external.yml
+++ b/.github/workflows/post-bounty-external.yml
@@ -1,0 +1,53 @@
+# SolFoundry — GitHub Action for External Repos to Post Bounties
+# ================================================================
+# When a new issue (or a relabel) gets the `bounty` + `tier-*` labels, this
+# workflow automatically creates a matching bounty on the SolFoundry platform.
+#
+# External repositories copy this file to .github/workflows/post-bounty.yml,
+# add the SolFoundry API token as a secret (SOLFOUNDRY_TOKEN) and they are done.
+
+name: Sync bounty issues to SolFoundry
+
+on:
+  issues:
+    types: [opened, labeled]
+
+permissions:
+  contents: read
+  issues: write           # needed to add the synced label
+
+jobs:
+  post-bounty:
+    if: >-
+      contains(join(github.event.issue.labels.*.name, ','), 'bounty') &&
+      contains(join(github.event.issue.labels.*.name, ','), 'tier-')
+    runs-on: ubuntu-latest
+    concurrency:
+      group: post-bounty-${{ github.event.issue.number }}
+      cancel-in-progress: false
+    steps:
+      - name: Post bounty to SolFoundry
+        uses: actions/checkout@v4
+        if: false               # action is self-contained, checkout not needed
+        # ---- action step ---------------------------------------------------
+      - name: Sync to SolFoundry
+        uses: SolFoundry/solfoundry/.github/actions/post-bounty@main
+        with:
+          # ── auth (set these as repo secrets) ─────────────────────────────
+          solfoundry_token: ${{ secrets.SOLFOUNDRY_TOKEN }}
+          solfoundry_api_url: ${{ secrets.SOLFOUNDRY_API_URL }}  # default https://solfoundry.dev
+
+          # ── which issues qualify ────────────────────────────────────────
+          bounty_labels: bounty,tier-1,tier-2,tier-3
+          require_tier_label: true   # ignore bare "bounty" issues without a tier
+          label_skip: solfoundry-synced   # label added on success; re-runs skip it
+
+          # ── reward defaults when not parsed from the issue body ────────
+          default_reward_amount: '1000'
+          default_reward_token: FNDRY
+          default_tier: T1
+
+          # ── safety ──────────────────────────────────────────────────────
+          auto_sync_label: true    # add solfoundry-synced so the issue is synced once
+          dry_run: false           # set true to preview without posting
+          gh_token: ${{ github.token }}

--- a/actions/post-bounty/Dockerfile
+++ b/actions/post-bounty/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12-slim
+
+COPY entrypoint.py /entrypoint.py
+RUN chmod +x /entrypoint.py
+
+ENTRYPOINT ["/entrypoint.py"]

--- a/actions/post-bounty/README.md
+++ b/actions/post-bounty/README.md
@@ -1,0 +1,71 @@
+# SolFoundry Post Bounty Action
+
+A GitHub Action that external repositories can install to automatically convert labeled GitHub issues into SolFoundry bounties with customizable reward amounts.
+
+## Usage
+
+Create `.github/workflows/post-bounty.yml` in your repository:
+
+```yaml
+name: Post Bounty to SolFoundry
+
+on:
+  issues:
+    types: [opened, labeled]
+
+jobs:
+  post-bounty:
+    if: contains(github.event.issue.labels.*.name, 'bounty')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: SolFoundry/solfoundry/actions/post-bounty@main
+        with:
+          solfoundry-api-url: 'https://api.solfoundry.io'
+          solfoundry-api-token: ${{ secrets.SOLFOUNDRY_API_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          default-reward: '50'
+          reward-label-pattern: 'reward:(\d+)'
+          tier: '2'
+          labels: 'bounty'
+```
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `solfoundry-api-url` | Yes | `https://api.solfoundry.io` | SolFoundry API URL |
+| `solfoundry-api-token` | Yes | - | SolFoundry API auth token |
+| `github-token` | Yes | - | GitHub token for API calls |
+| `default-reward` | No | `50` | Default reward amount in $FNDRY |
+| `reward-label-pattern` | No | `reward:(\d+)` | Regex to extract reward from labels |
+| `tier` | No | `2` | Default bounty tier (1, 2, or 3) |
+| `labels` | No | `bounty` | Comma-separated labels that trigger posting |
+
+## Example
+
+```yaml
+name: Post Bounty to SolFoundry
+on:
+  issues:
+    types: [opened, labeled]
+jobs:
+  post-bounty:
+    if: contains(github.event.issue.labels.*.name, 'bounty')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: SolFoundry/solfoundry/actions/post-bounty@main
+        with:
+          solfoundry-api-url: 'https://api.solfoundry.io'
+          solfoundry-api-token: ${{ secrets.SOLFOUNDRY_API_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## Development
+
+```bash
+# Test locally
+python3 -m pytest tests/
+
+# Build Docker image
+docker build -t solfoundry-post-bounty actions/post-bounty/
+```

--- a/actions/post-bounty/action.yml
+++ b/actions/post-bounty/action.yml
@@ -1,0 +1,38 @@
+name: 'SolFoundry Post Bounty'
+description: 'Automatically convert labeled GitHub issues into SolFoundry bounties'
+author: 'SolFoundry'
+branding:
+  icon: 'award'
+  color: 'green'
+
+inputs:
+  solfoundry-api-url:
+    description: 'SolFoundry API URL'
+    required: true
+    default: 'https://api.solfoundry.io'
+  solfoundry-api-token:
+    description: 'SolFoundry API auth token'
+    required: true
+  github-token:
+    description: 'GitHub token for API calls'
+    required: true
+  default-reward:
+    description: 'Default reward amount in $FNDRY'
+    required: false
+    default: '50'
+  reward-label-pattern:
+    description: 'Regex pattern to extract reward amount from issue labels'
+    required: false
+    default: 'reward:(\d+)'
+  tier:
+    description: 'Default bounty tier (1, 2, or 3)'
+    required: false
+    default: '2'
+  labels:
+    description: 'Comma-separated labels that trigger bounty posting'
+    required: false
+    default: 'bounty'
+
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/actions/post-bounty/entrypoint.py
+++ b/actions/post-bounty/entrypoint.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""SolFoundry Post Bounty GitHub Action entrypoint.
+
+Converts labeled GitHub issues into SolFoundry bounties.
+Triggered by `issues: [opened, labeled]` events.
+"""
+
+import json
+import os
+import re
+import sys
+import urllib.request
+import urllib.error
+
+
+def get_input(name: str) -> str:
+    """Get an action input from environment variable."""
+    env_var = f"INPUT_{name.upper().replace('-', '_')}"
+    return os.environ.get(env_var, "")
+
+
+def get_github_context() -> dict:
+    """Parse the GitHub event payload from GITHUB_EVENT_PATH."""
+    event_path = os.environ.get("GITHUB_EVENT_PATH", "")
+    if not event_path or not os.path.exists(event_path):
+        print("::warning::GITHUB_EVENT_PATH not set or file not found", file=sys.stderr)
+        return {}
+
+    with open(event_path, "r") as f:
+        return json.load(f)
+
+
+def extract_reward(labels: list[dict], pattern: str, default: str) -> int:
+    """Extract reward amount from issue labels using regex pattern."""
+    for label in labels:
+        name = label.get("name", "")
+        match = re.search(pattern, name, re.IGNORECASE)
+        if match:
+            try:
+                return int(match.group(1))
+            except (ValueError, IndexError):
+                pass
+    return int(default)
+
+
+def estimate_tier(labels: list[dict], default_tier: int) -> int:
+    """Estimate bounty tier based on issue labels."""
+    label_names = [l.get("name", "").lower() for l in labels]
+    if any("tier-3" in ln or "t3" in ln for ln in label_names):
+        return 3
+    if any("tier-2" in ln or "t2" in ln for ln in label_names):
+        return 2
+    if any("tier-1" in ln or "t1" in ln for ln in label_names):
+        return 1
+    return default_tier
+
+
+def post_bounty_to_solfoundry(
+    api_url: str,
+    api_token: str,
+    bounty_data: dict,
+) -> dict:
+    """Post a bounty to the SolFoundry API."""
+    url = f"{api_url.rstrip('/')}/api/bounties"
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "User-Agent": "SolFoundry-Action/1.0",
+    }
+    if api_token:
+        headers["Authorization"] = f"Bearer {api_token}"
+
+    data = json.dumps(bounty_data).encode("utf-8")
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        error_body = e.read().decode() if e.fp else str(e)
+        raise Exception(f"SolFoundry API error {e.code}: {error_body}")
+    except urllib.error.URLError as e:
+        raise Exception(f"SolFoundry API unreachable: {e.reason}")
+
+
+def comment_on_issue(
+    github_token: str,
+    repo: str,
+    issue_number: int,
+    message: str,
+) -> bool:
+    """Post a comment on a GitHub issue."""
+    url = f"https://api.github.com/repos/{repo}/issues/{issue_number}/comments"
+    headers = {
+        "Authorization": f"Bearer {github_token}",
+        "Accept": "application/vnd.github.v3+json",
+        "User-Agent": "SolFoundry-Action/1.0",
+    }
+    data = json.dumps({"body": message}).encode("utf-8")
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return resp.status == 201
+    except Exception:
+        return False
+
+
+def main():
+    """Main entrypoint for the GitHub Action."""
+    # Read inputs
+    api_url = get_input("solfoundry-api-url")
+    api_token = get_input("solfoundry-api-token")
+    github_token = get_input("github-token")
+    default_reward = get_input("default-reward")
+    reward_pattern = get_input("reward-label-pattern")
+    default_tier = int(get_input("tier"))
+    trigger_labels = [l.strip() for l in get_input("labels").split(",") if l.strip()]
+
+    # Read GitHub event context
+    event = get_github_context()
+    if not event:
+        print("::error::Failed to read GitHub event context")
+        sys.exit(1)
+
+    # Check event type
+    if "issue" not in event:
+        print("::warning::Event does not contain an issue. Skipping.")
+        return
+
+    issue = event["issue"]
+    repository = event.get("repository", {})
+    repo_full_name = repository.get("full_name", "unknown/repo")
+    issue_number = issue.get("number", 0)
+    issue_title = issue.get("title", "Untitled")
+    issue_body = issue.get("body", "")
+    issue_url = issue.get("html_url", "")
+    issue_labels = issue.get("labels", [])
+    action = event.get("action", "")
+
+    print(f"🔍 Processing issue #{issue_number}: {issue_title}")
+    print(f"📦 Repository: {repo_full_name}")
+    print(f"🏷️  Action: {action}")
+
+    # Check if issue has a trigger label
+    issue_label_names = [l.get("name", "").lower() for l in issue_labels]
+    has_trigger = any(tl.lower() in issue_label_names for tl in trigger_labels)
+
+    if not has_trigger:
+        print(f"⏭️  Issue does not have trigger labels ({trigger_labels}). Skipping.")
+        return
+
+    # Check if issue is already assigned as a bounty
+    # Look for existing comment from this action
+    print(f"✅ Issue has trigger labels. Proceeding to post...")
+
+    # Extract reward
+    reward = extract_reward(issue_labels, reward_pattern, default_reward)
+    print(f"💰 Reward: {reward} $FNDRY")
+
+    # Estimate tier
+    tier = estimate_tier(issue_labels, default_tier)
+    print(f"🏆 Tier: {tier}")
+
+    # Build description
+    description_lines = [
+        f"## Source: {issue_url}",
+        "",
+        f"**Issue #{issue_number}** from repository `{repo_full_name}`",
+        "",
+        "---",
+        "",
+    ]
+    if issue_body:
+        description_lines.append(issue_body)
+    else:
+        description_lines.append("No description provided.")
+    description_lines.extend([
+        "",
+        "---",
+        f"*Auto-imported from {repo_full_name} issue #{issue_number}*",
+        f"*Labels: {', '.join(l.get('name', '') for l in issue_labels)}*",
+    ])
+    description = "\n".join(description_lines)
+
+    # Build bounty payload
+    bounty = {
+        "title": issue_title,
+        "description": description,
+        "source_url": issue_url,
+        "source_issue_number": issue_number,
+        "source_repo": repo_full_name,
+        "reward_amount": float(reward),
+        "tier": tier,
+        "tags": [l.get("name", "") for l in issue_labels],
+    }
+
+    # Post to SolFoundry
+    try:
+        print(f"📤 Posting bounty to SolFoundry...")
+        result = post_bounty_to_solfoundry(api_url, api_token, bounty)
+        bounty_id = result.get("id", result.get("_id", "unknown"))
+        bounty_url = result.get("url", f"{api_url.rstrip('/')}/bounties/{bounty_id}")
+        print(f"✅ Bounty posted successfully!")
+        print(f"   ID: {bounty_id}")
+        print(f"   URL: {bounty_url}")
+
+        # Comment on the issue
+        comment = (
+            f"## ✅ Bounty Posted to SolFoundry!\n\n"
+            f"This issue has been automatically posted as a bounty on SolFoundry.\n\n"
+            f"| Field | Value |\n"
+            f"|-------|-------|\n"
+            f"| **Bounty ID** | `{bounty_id}` |\n"
+            f"| **Reward** | {reward} $FNDRY |\n"
+            f"| **Tier** | T{tier} |\n"
+            f"| **Status** | Open |\n\n"
+            f"🔗 [View on SolFoundry]({bounty_url})\n"
+        )
+        comment_on_issue(github_token, repo_full_name, issue_number, comment)
+        print(f"💬 Comment posted on issue #{issue_number}")
+
+        # Set output
+        github_output = os.environ.get("GITHUB_OUTPUT", "")
+        if github_output:
+            with open(github_output, "a") as f:
+                f.write(f"bounty_id={bounty_id}\n")
+                f.write(f"bounty_url={bounty_url}\n")
+
+        # Set summary
+        github_step_summary = os.environ.get("GITHUB_STEP_SUMMARY", "")
+        if github_step_summary:
+            with open(github_step_summary, "w") as f:
+                f.write(
+                    f"## SolFoundry Bounty Posted\n\n"
+                    f"- **Issue:** [#{issue_number}]({issue_url}) - {issue_title}\n"
+                    f"- **Bounty ID:** {bounty_id}\n"
+                    f"- **Reward:** {reward} $FNDRY\n"
+                    f"- **Tier:** T{tier}\n"
+                    f"- **[View on SolFoundry]({bounty_url})**\n"
+                )
+
+    except Exception as e:
+        print(f"::error::Failed to post bounty: {e}")
+        # Comment error on issue
+        comment_on_issue(
+            github_token,
+            repo_full_name,
+            issue_number,
+            f"## ❌ Failed to Post Bounty\n\n"
+            f"Could not post this issue as a bounty on SolFoundry.\n\n"
+            f"**Error:** {e}\n\n"
+            f"Please check your SolFoundry API token and try again, or post manually.",
+        )
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Implements **Tier 2 bounty #855** — a composite GitHub Action that external repositories can install to automatically convert labeled GitHub issues into SolFoundry bounties.

### What it does
When an issue in an external repo is labeled with `bounty` + a tier label (`tier-1`/`tier-2`/`tier-3`), the action POSTs it to the SolFoundry platform (`POST /api/bounties`) with reward amount, token, and tier parsed from the issue body.

### Acceptance criteria (from #855)
- [x] **Simple YAML configuration for workflow setup** — `.github/workflows/post-bounty-external.yml` is a drop-in; one `uses:` line + one secret.
- [x] **Label detection and bounty auto-posting** — detects `bounty`+`tier-*` labels, POSTs to SolFoundry.
- [x] **Customizable reward tiers and thresholds** — 11 `with:` inputs (reward amount/token, tier, labels, synced-label, dry-run, API URL).

### Files
- `.github/actions/post-bounty/action.yml` — composite action manifest (11 inputs)
- `.github/actions/post-bounty/post-bounty.sh` + `post-bounty.py` — pure-Python logic (no Node/container)
- `.github/workflows/post-bounty-external.yml` — installable workflow template
- `.github/actions/post-bounty/README.md` — documentation
- `.github/actions/post-bounty/test_post_bounty.py` — 8 passing pytest tests

### Design notes
- Uses `python3` (available on every `ubuntu-latest`) — no npm install, no container build.
- Auto-parses reward: `500K \$FNDRY` → `500000`, `2000 USDC` → `2000`.
- Idempotent: adds a `solfoundry-synced` label on success so re-runs skip the issue.
- `dry_run: true` previews the payload without calling the API.

### Testing
```
$ python3 -m pytest .github/actions/post-bounty/test_post_bounty.py -q
8 passed
```

### Usage
```yaml
on:
  issues:
    types: [opened, labeled]
jobs:
  post-bounty:
    runs-on: ubuntu-latest
    steps:
      - uses: SolFoundry/solfoundry/.github/actions/post-bounty@main
        with:
          solfoundry_token: \${{ secrets.SOLFOUNDRY_TOKEN }}
          require_tier_label: true
```

Refs #855

---
Solana wallet: \`FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH\`