### PR TITLE
feat: Discord notification bot for bounty updates [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,3 +34,10 @@ VITE_API_URL=http://localhost:8000
 # Deploy health-check URLs (set as GitHub repository variables, not secrets)
 STAGING_HEALTH_URL=https://staging-api.solfoundry.org/health
 PRODUCTION_HEALTH_URL=https://api.solfoundry.org/health
+
+# Discord Bot — Bounty Notifications (see automaton/discord_bot/README.md)
+DISCORD_WEBHOOK_URL=
+# GITHUB_TOKEN is already defined above; also reused by the Discord bot
+# SOLFOWNDRY_REPO=SolFoundry/solfoundry
+# POLL_INTERVAL=300
+# LAST_SEEN_FILE=.last_seen_bounties.json

--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,6 @@ data/
 *.sqlite
 *.db
 *.sqlite3
+
+# Discord bot last-seen state (contains no secrets but is local runtime state)
+.last_seen_bounties.json

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+# SolFoundry Makefile — common convenience targets.
+
+# ---------------------------------------------------------------------------
+# Discord bounty bot
+# ---------------------------------------------------------------------------
+.PHONY: poll poll-once discord-bot-test
+
+poll: ## Run the Discord bounty notification daemon (env vars required)
+	python -m automaton.discord_bot
+
+poll-once: ## Poll once and exit (useful for cron / dry-runs)
+	python -m automaton.discord_bot --poll-once
+
+discord-bot-test: ## Run unit tests for the Discord bot
+	python -m pytest tests/test_discord_bot.py -v

--- a/automaton/README.md
+++ b/automaton/README.md
@@ -8,5 +8,22 @@ Concrete assets for the Phase 3 bounty live alongside it:
 - `infra/k8s` — Kubernetes manifests (for example HPA)
 - `monitoring/` — Docker Compose stack (Prometheus, Grafana, Loki, Alertmanager, Blackbox)
 - `scripts/` — Rollback, backup, and Anchor verification helpers
-- `docs/deployment-and-monitoring.md` — Architecture, procedures, and monitoring guide
-- `docs/runbooks/incident-response.md` — Incident response
+- ``docs/deployment-and-monitoring.md`` — Architecture, procedures, and monitoring guide
+- ``docs/runbooks/incident-response.md`` — Incident response
+- ``discord_bot/`` — Discord webhook bot for bounty notifications
+
+## Discord Bot for Bounty Notifications
+
+The ``automaton/discord_bot/`` module posts new/updated bounties to a Discord
+channel via an incoming webhook (no OAuth bot token needed).
+
+```bash
+export DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/YOUR/WEBHOOK"
+python -m automaton.discord_bot            # daemon loop
+python -m automaton.discord_bot --poll-once # single poll (for cron)
+make poll                                   # via Makefile
+```
+
+Configuration lives in ``.env`` (``DISCORD_WEBHOOK_URL`` required;
+``GITHUB_TOKEN``, ``SOLFOWNDRY_REPO``, ``POLL_INTERVAL``, ``LAST_SEEN_FILE``
+optional).  See ``automaton/discord_bot/README.md`` for details.

--- a/automaton/discord_bot/README.md
+++ b/automaton/discord_bot/README.md
@@ -1,0 +1,100 @@
+# Discord Bot for Bounty Notifications
+# ``automaton/discord_bot/``
+
+A lightweight Python daemon that polls the SolFoundry GitHub issues for
+``bounty``-labeled issues, detects newly created or updated bounties, and posts
+rich embed messages to a Discord channel via a webhook (no full bot token or
+OAuth needed).
+
+This module is part of the ``automaton/`` directory — higher-level deployment
+automation and notification services.
+
+## Features
+
+- Polls the GitHub Issues search API for `repo:SolFoundry/solfoundry label:bounty`.
+- Tracks what it has already notified via a local JSON file
+  (``LAST_SEEN_FILE``), so a restart never reposts the same bounty.
+- Sends rich Discord embeds containing the bounty title, reward, tier label,
+  domain, assignees, and a link to the issue.
+- Distinguishes *new* bounties from *updated* bounties (state changes, label
+  changes, etc.) and colours the embed accordingly.
+
+## Quick start
+
+### 1. Install dependencies
+
+```bash
+cd automaton/discord_bot
+pip install -r requirements.txt
+```
+
+``requests`` and ``python-dotenv`` are the only runtime dependencies.
+
+### 2. Configure
+
+Copy the example environment file and set the required webhook URL:
+
+```bash
+cd /Users/water/dev/solfoundry          # repo root
+cp .env.example .env
+```
+
+Edit ``.env`` and set ``DISCORD_WEBHOOK_URL`` (required).  The other values
+are optional and default sensibly:
+
+| Variable | Required | Default | Purpose |
+|---|---|---|---|
+| ``DISCORD_WEBHOOK_URL`` | Yes | _(none)_ | Discord incoming-webhook URL |
+| ``GITHUB_TOKEN`` | No | _(none)_ | Personal access token (raises rate-limit ceiling) |
+| ``SOLFOWNDRY_REPO`` | No | ``SolFoundry/solfoundry`` | GitHub ``owner/repo`` to watch |
+| ``POLL_INTERVAL`` | No | ``300`` | Seconds between polls |
+| ``LAST_SEEN_FILE`` | No | ``.last_seen_bounties.json`` | Where to store last-seen state |
+
+### 3. Run
+
+```bash
+cd /Users/water/dev/solfoundry
+export DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/YOUR/WEBHOOK"
+python -m automaton.discord_bot      # daemon loop
+# or
+python -m automaton.discord_bot --poll-once   # poll once and exit
+# or via the Makefile
+make poll
+make poll-once
+```
+
+With ``--poll-once`` the poller is suitable for cron.
+
+## Tests
+
+```bash
+python -m pytest tests/test_discord_bot.py -v
+# or
+make discord-bot-test
+```
+
+Tests are pure-unit: they exercise parsing, embed-building, persistence, and
+poller orchestration with no real GitHub / Discord calls.
+
+## How it works
+
+1. **``config.py``** — reads the env vars / ``.env`` file.
+2. **``github_client.py``** — fetches all open bounty issues (paginated).
+3. **``embeds.py``** — parses a GitHub issue into structured metadata and
+   builds a Discord embed.
+4. **``persistence.py``** — the ``SeenState`` JSON file that makes polling
+   idempotent.
+5. **``webhook.py``** — POSTs the embed to the Discord webhook.
+6. **``poller.py``** — orchestrates the loop (or single poll).
+7. **``__main__.py``** — the ``python -m automaton.discord_bot`` entry point.
+
+Run ``--verbose`` / ``-v`` for DEBUG logging.
+
+## Notes for maintainers
+
+- Use ``--poll-once`` inside a systemd timer or cron rather than leaving a
+  daemon running if the host is ephemeral.
+- The ``.last_seen_bounties.json`` file is safe to delete; the next poll
+  will simply re-notify everything.
+- Webhook URLs are credentials — never commit ``.env`` or the ``.last_seen_*.json``.
+  Both are already listed in ``.gitignore``.

--- a/automaton/discord_bot/__init__.py
+++ b/automaton/discord_bot/__init__.py
@@ -1,0 +1,14 @@
+"""Discord Bot for Bounty Notifications.
+
+Polls the SolFoundry GitHub issues for bounty-labeled issues, detects newly
+created or updated bounties, and posts rich embed messages to a Discord
+channel via a webhook.
+
+Usage:
+    export DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/..."
+    python -m automaton.discord_bot            # run the polling daemon
+    python -m automaton.discord_bot --poll-once # poll once and exit
+    make poll                                   # run via Makefile
+"""
+
+__version__ = "0.1.0"

--- a/automaton/discord_bot/__main__.py
+++ b/automaton/discord_bot/__main__.py
@@ -1,0 +1,5 @@
+"""Allow ``python -m automaton.discord_bot`` to start the poller."""
+
+from automaton.discord_bot.poller import main
+
+main()

--- a/automaton/discord_bot/config.py
+++ b/automaton/discord_bot/config.py
@@ -1,0 +1,68 @@
+"""Configuration loader for the Discord bounty bot.
+
+All configuration is read from environment variables (or a `.env` file if
+``python-dotenv`` is installed). No secrets are hardcoded.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional
+
+try:  # python-dotenv is optional but recommended
+    from dotenv import load_dotenv
+
+    load_dotenv()
+except ImportError:  # type: ignore[misc]
+    load_dotenv = None  # noqa: F841
+
+
+class Config:
+    """Read-only config snapshot for the Discord bot."""
+
+    def __init__(self) -> None:
+        self.discord_webhook_url: str = self._env("DISCORD_WEBHOOK_URL")
+        self.github_token: Optional[str] = self._opt("GITHUB_TOKEN")
+        self.solfoundry_repo: str = self._opt("SOLFOWNDRY_REPO") or "SolFoundry/solfoundry"
+        self.poll_interval: int = self._int("POLL_INTERVAL", default=300)
+        self.last_seen_file: str = self._opt("LAST_SEEN_FILE") or ".last_seen_bounties.json"
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _env(name: str) -> str:
+        value = os.environ.get(name, "")
+        if not value:
+            raise RuntimeError(
+                f"Required environment variable {name!r} is not set. "
+                "Export it or add it to your .env file."
+            )
+        return value
+
+    @staticmethod
+    def _opt(name: str) -> Optional[str]:
+        return os.environ.get(name) or None
+
+    @staticmethod
+    def _int(name: str, default: int) -> int:
+        raw = os.environ.get(name)
+        if raw is None:
+            return default
+        try:
+            value = int(raw)
+        except ValueError:
+            raise RuntimeError(
+                f"Environment variable {name!r} must be an integer, got {raw!r}"
+            )
+        if value < 1:
+            raise RuntimeError(
+                f"Environment variable {name!r} must be a positive integer, got {value}"
+            )
+        return value
+
+
+def get_config() -> Config:
+    """Build and return the bot configuration."""
+    return Config()

--- a/automaton/discord_bot/embeds.py
+++ b/automaton/discord_bot/embeds.py
@@ -1,0 +1,154 @@
+"""Parse GitHub issue data and build Discord embed payloads.
+
+This module is intentionally free of network / file-IO dependencies so it can
+be unit-tested in isolation.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+
+# Tier labels mapped to a Discord-friendly colour and label.
+TIER_META: dict[str, tuple[int, str]] = {
+    "tier-1": (0x43B581, "T1 — Open Race"),  # green
+    "tier-2": (0xFAA61A, "T2 — Gated"),      # amber
+    "tier-3": (0xED4245, "T3 — Claim-Based"),  # red
+}
+
+
+def parse_bounty(issue: dict[str, Any]) -> dict[str, Any]:
+    """Extract bounty metadata from a GitHub issue dict.
+
+    Args:
+        issue: A GitHub API issue object (list endpoint payload item).
+
+    Returns:
+        A dict with normalized fields: ``number``, ``title``, ``html_url``,
+        ``state``, ``reward``, ``tier``, ``domain``, ``assignees``,
+        ``created_at``, ``updated_at``, ``labels``.
+    """
+    labels = {label["name"].lower() for label in issue.get("labels", [])}
+    body = issue.get("body") or ""
+
+    # Reward can come from the structured "Reward:" line in the issue body.
+    reward = _extract_first(body, r"\*\*Reward:\*\*\s*([^\n|]+)")
+    if not reward:
+        # Fallback to labels like "100K $FNDRY" — not guaranteed, so keep None.
+        reward = None
+
+    tier = _tier_from_labels(labels)
+    domain = _domain_from_labels(labels)
+
+    assignees = [
+        assignee["login"]
+        for assignee in issue.get("assignees", [])
+        if assignee and assignee.get("login")
+    ]
+
+    return {
+        "number": int(issue["number"]),
+        "title": issue.get("title", ""),
+        "html_url": issue.get("html_url", ""),
+        "state": issue.get("state", "open"),
+        "reward": reward,
+        "tier": tier,
+        "domain": domain,
+        "assignees": assignees,
+        "created_at": issue.get("created_at"),
+        "updated_at": issue.get("updated_at"),
+        "labels": sorted(labels),
+    }
+
+
+def build_embed(bounty: dict[str, Any], action: str = "new") -> dict[str, Any]:
+    """Build a Discord rich-embed payload for a bounty.
+
+    Args:
+        bounty: Parsed bounty dict from :func:`parse_bounty`.
+        action: One of ``"new"``, ``"updated"``, or ``"closed"``.
+
+    Returns:
+        A JSON-serialisable embed dict (no top-level ``embeds`` wrapper —
+        the caller wraps it).
+    """
+    tier_label, colour = _tier_colour_and_label(bounty.get("tier"))
+
+    description = _action_phrase(action)
+    fields: list[dict[str, Any]] = [
+        {"name": "Reward", "value": bounty.get("reward") or "Not specified", "inline": True},
+        {"name": "Tier", "value": tier_label, "inline": True},
+        {
+            "name": "Domain",
+            "value": bounty.get("domain") or "General",
+            "inline": True,
+        },
+        {"name": "Assignees", "value": _join_or_none(bounty.get("assignees")), "inline": False},
+    ]
+
+    return {
+        "title": bounty["title"],
+        "url": bounty["html_url"],
+        "description": description,
+        "color": colour,
+        "fields": fields,
+        "footer": {
+            "text": f"SolFoundry • Issue #{bounty['number']} • "
+                    f"{_friendly_time(bounty.get('updated_at') or bounty.get('created_at'))}"
+        },
+        "thumbnail": {"url": "https://raw.githubusercontent.com/SolFoundry/solfoundry/main/assets/logo.png"},
+    }
+
+
+def _extract_first(text: str, pattern: str) -> Optional[str]:
+    m = re.search(pattern, text)
+    return m.group(1).strip() if m else None
+
+
+def _tier_from_labels(labels: set[str]) -> Optional[str]:
+    for key in ("tier-3", "tier-2", "tier-1"):
+        if key in labels:
+            return key
+    return None
+
+
+def _domain_from_labels(labels: set[str]) -> Optional[str]:
+    # Domain-specific labels that map nicely to a single string.
+    order = ["frontend", "backend", "agent", "integration", "docs", "creative", "smart-contract"]
+    for domain in order:
+        if domain in labels:
+            return domain.capitalize()
+    return None
+
+
+def _tier_colour_and_label(tier: Optional[str]) -> tuple[str, int]:
+    meta = TIER_META.get(tier) if tier else None
+    if meta is None:
+        return "Unknown tier", 0x808080
+    return meta[1], meta[0]
+
+
+def _join_or_none(values: list[str] | None) -> str:
+    values = values or []
+    return ", ".join(values) if values else "No one (open for grabs)"
+
+
+def _action_phrase(action: str) -> str:
+    phrases = {
+        "new": "🆕 **New bounty posted!**",
+        "updated": "🔄 **Bounty updated!**",
+        "closed": "🔒 **Bounty closed!**",
+    }
+    return phrases.get(action, "📢 **Bounty change**")
+
+
+def _friendly_time(iso: str | None) -> str:
+    if not iso:
+        return "Just now"
+    try:
+        dt = datetime.fromisoformat(iso.replace("Z", "+00:00"))
+        return dt.strftime("%Y-%m-%d %H:%M UTC")
+    except (ValueError, TypeError):
+        return iso

--- a/automaton/discord_bot/github_client.py
+++ b/automaton/discord_bot/github_client.py
@@ -1,0 +1,93 @@
+"""Thin wrapper around the GitHub Issues REST API.
+
+Fetches issues for a repository that carry the ``bounty`` label.  Supports
+optional bearer-token authentication so we stay within the unauthenticated
+rate limit when a token is provided.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+import requests
+
+log = logging.getLogger(__name__)
+
+
+def fetch_bounty_issues(
+    repo: str,
+    token: Optional[str] = None,
+    state: str = "open",
+    per_page: int = 100,
+) -> list[dict[str, Any]]:
+    """Fetch all issues in *repo* that have the ``bounty`` label.
+
+    The GitHub search API is used because the list endpoint cannot filter by
+    multiple labels reliably and search returns paginated results easily.
+
+    Args:
+        repo: ``owner/repo`` string, e.g. ``SolFoundry/solfoundry``.
+        token: Optional bearer token (raises ``RuntimeError`` on missing token
+            only if you intend to authenticate).
+        state: ``open`` or ``closed``.
+        per_page: Items per page (max 100).
+
+    Returns:
+        A flat list of issue dicts, newest first.
+    """
+    url = "https://api.github.com/search/issues"
+    headers: dict[str, str] = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "solfoundry-discord-bot/0.1",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    params: dict[str, str] = {
+        "q": f"repo:{repo} label:bounty is:issue state:{state}",
+        "sort": "created",
+        "order": "desc",
+        "per_page": str(per_page),
+    }
+
+    issues: list[dict[str, Any]] = []
+    page = 1
+    while url:
+        log.debug("Fetching issues page %d", page)
+        resp = requests.get(url, headers=headers, params=params)
+        resp.raise_for_status()
+        data = resp.json()
+
+        # The search API returns results under ``items``.
+        page_items = data.get("items", [])
+        issues.extend(page_items)
+        total_count = data.get("total_count", 0)
+        log.info(
+            "GitHub returned %d item(s) (of %d total) on page %d",
+            len(page_items),
+            total_count,
+            page,
+        )
+
+        # Move to next page via the Link header.
+        link = resp.headers.get("Link", "")
+        url = _next_page_url(link)
+        page += 1
+        if not page_items or len(issues) >= total_count:
+            break
+
+    return issues
+
+
+def _next_page_url(link_header: str) -> Optional[str]:
+    """Return the next page URL from a GitHub ``Link`` header, or ``None``."""
+    if not link_header:
+        return None
+    for part in link_header.split(","):
+        part = part.strip()
+        if 'rel="next"' in part:
+            start = part.index("<") + 1
+            end = part.index(">")
+            return part[start:end]
+    return None

--- a/automaton/discord_bot/persistence.py
+++ b/automaton/discord_bot/persistence.py
@@ -1,0 +1,73 @@
+"""Persistent record of the last-seen state for each bounty issue.
+
+Stores a simple JSON file mapping ``issue_number`` -> last ``updated_at``
+ISO timestamp.  This is what makes the poller idempotent: on restart it
+re-reads the file and skips anything it has already notified on.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+log = logging.getLogger(__name__)
+
+
+class SeenState:
+    """Thread-unsafe (sufficient for a single-threaded poller) seen-file cache."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def has_seen(self, issue_number: int, updated_at: Optional[str]) -> bool:
+        """Return ``True`` if *issue_number* was last seen at *updated_at*.
+
+        When *updated_at* is ``None``, this checks whether the issue has ever
+        been recorded at all (i.e. is the key present in the file).
+        """
+        last = self._load()
+        if updated_at is None:
+            return issue_number in last
+        return last.get(issue_number) == updated_at
+
+    def mark_seen(self, issue_number: int, updated_at: Optional[str]) -> None:
+        """Record that *issue_number* was seen at *updated_at*."""
+        last = self._load()
+        last[issue_number] = updated_at
+        self._save(last)
+
+    def clear(self) -> None:
+        """Remove the seen-file entirely."""
+        if self.path.exists():
+            self.path.unlink()
+            log.info("Cleared seen file %s", self.path)
+
+    def size(self) -> int:
+        """Return the number of seen issues."""
+        return len(self._load())
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+    def _load(self) -> dict[int, Any]:
+        if not self.path.exists():
+            return {}
+        try:
+            with self.path.open("r", encoding="utf-8") as fh:
+                raw = json.load(fh)
+            return {int(k): v for k, v in raw.items()}
+        except (json.JSONDecodeError, OSError) as exc:
+            log.warning("Failed to load seen file %s (%s); starting fresh", self.path, exc)
+            return {}
+
+    def _save(self, data: dict[int, Any]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("w", encoding="utf-8") as fh:
+            json.dump(data, fh, indent=2, sort_keys=True)
+        log.debug("Saved seen file %s (%d entries)", self.path, len(data))

--- a/automaton/discord_bot/poller.py
+++ b/automaton/discord_bot/poller.py
@@ -1,0 +1,151 @@
+"""Poller that drives the Discord notification loop.
+
+On each tick it fetches all open bounty issues from GitHub, compares them
+against the persisted ``seen`` state, and posts an embed for anything that is
+new or changed.  The poller loops forever by default (with SIGINT /
+SIGTERM handling) so it can run as a daemon.
+"""
+
+from __future__ import annotations
+
+import logging
+import signal
+import time
+from typing import Any, Callable
+
+from automaton.discord_bot import config, embeds, github_client, persistence, webhook
+
+log = logging.getLogger(__name__)
+
+
+class Poller:
+    """Thin wrapper to make the core loop testable without real network / IO."""
+
+    def __init__(
+        self,
+        config_holder: config.Config,
+        seen: persistence.SeenState,
+        *,
+        fetch_issues: Callable[..., list[dict[str, Any]]] = github_client.fetch_bounty_issues,
+        send_embed: Callable[..., dict[str, Any]] = webhook.send_to_webhook,
+    ) -> None:
+        self.config = config_holder
+        self.seen = seen
+        self._fetch_issues = fetch_issues
+        self._send_embed = send_embed
+        self._running = True
+
+    # ------------------------------------------------------------------
+    # Core logic
+    # ------------------------------------------------------------------
+    def tick(self) -> tuple[int, int]:
+        """Run a single poll cycle.
+
+        Returns:
+            A ``(created, updated)`` count of issues notified this tick.
+        """
+        issues = self._fetch_issues(
+            repo=self.config.solfoundry_repo,
+            token=self.config.github_token,
+            state="open",
+        )
+        created = 0
+        updated = 0
+        for raw_issue in issues:
+            number = int(raw_issue["number"])
+            updated_at = raw_issue.get("updated_at")
+
+            if self.seen.has_seen(number, updated_at):
+                continue
+
+            # Decide whether this is the first time we've seen the issue at
+            # all (``new``) or a follow-up state change (``updated``).
+            if self.seen.has_seen(number, None):
+                action = "updated"
+            else:
+                action = "new"
+
+            bounty = embeds.parse_bounty(raw_issue)
+            embed_payload = embeds.build_embed(bounty, action=action)
+            try:
+                self._send_embed(
+                    webhook_url=self.config.discord_webhook_url,
+                    embed=embed_payload,
+                    content=f"Issue #{number} ({bounty['title']})",
+                )
+            except Exception:
+                log.exception("Failed to post Discord embed for issue #%d", number)
+            self.seen.mark_seen(number, updated_at)
+
+            if action == "new":
+                created += 1
+            else:
+                updated += 1
+
+        log.info("Tick complete — %d new, %d updated", created, updated)
+        return created, updated
+
+    def run(self) -> None:
+        """Start the polling loop and block until interrupted."""
+        log.info(
+            "Starting Discord bounty poller (interval=%ds, repo=%s)",
+            self.config.poll_interval,
+            self.config.solfoundry_repo,
+        )
+        log.info("Seen file: %s", self.seen.path)
+
+        handler = lambda *_: setattr(self, "_running", False)
+        signal.signal(signal.SIGINT, handler)
+        signal.signal(signal.SIGTERM, handler)
+
+        while self._running:
+            try:
+                self.tick()
+            except Exception:
+                log.exception("Error during poll tick")
+
+            if self._running:
+                time.sleep(self.config.poll_interval)
+
+        log.info("Poller stopped")
+
+    def poll_once(self) -> tuple[int, int]:
+        """Convenience for one-off / ``--poll-once`` runs."""
+        return self.tick()
+
+
+def main() -> None:
+    """CLI entry point.
+
+    Reads config from env / ``.env``, builds the poller, and either runs the
+    daemon loop or performs a single poll and exits.
+    """
+    import argparse
+    import sys
+
+    parser = argparse.ArgumentParser(description="Discord bounty notification poller")
+    parser.add_argument(
+        "--poll-once",
+        action="store_true",
+        help="Poll once and exit instead of running a daemon loop",
+    )
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", help="Enable DEBUG logging",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+
+    cfg = config.get_config()
+    seen = persistence.SeenState(cfg.last_seen_file)
+    poller = Poller(cfg, seen)
+
+    if args.poll_once:
+        created, updated = poller.poll_once()
+        print(f"Poll once: {created} new, {updated} updated")
+        return
+
+    poller.run()

--- a/automaton/discord_bot/requirements.txt
+++ b/automaton/discord_bot/requirements.txt
@@ -1,0 +1,2 @@
+requests>=2.31,<3
+python-dotenv>=1.0,<2

--- a/automaton/discord_bot/webhook.py
+++ b/automaton/discord_bot/webhook.py
@@ -1,0 +1,56 @@
+"""Send messages to Discord via a webhook.
+
+Discord webhooks are simpler than full bot tokens — no OAuth, no install.
+We just POST JSON to a webhook URL and Discord posts it.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+import requests
+
+log = logging.getLogger(__name__)
+
+
+def send_to_webhook(
+    webhook_url: str,
+    embed: dict[str, Any],
+    content: Optional[str] = None,
+    username: str = "SolFoundry Bounty Bot",
+) -> dict[str, Any]:
+    """Post a single embed to a Discord webhook.
+
+    Args:
+        webhook_url: The Discord webhook URL.
+        embed: A single Discord embed dict (not the top-level ``embeds``
+            list — this function wraps it).
+        content: Optional plain-text message body to include alongside the
+            embed.
+        username: The bot name shown on the webhook post.
+
+    Returns:
+        The JSON response body from Discord (empty on success).
+
+    Raises:
+        requests.RequestException: On network / HTTP errors.
+        RuntimeError: If Discord returns a non-2xx status.
+    """
+    payload: dict[str, Any] = {
+        "username": username,
+        "embeds": [embed],
+    }
+    if content:
+        payload["content"] = content
+
+    log.info("Sending embed to Discord webhook %s", webhook_url[:40] + "...")
+    resp = requests.post(webhook_url, json=payload, timeout=30)
+    resp.raise_for_status()
+    # Discord returns 204 No Content on success; body is empty.
+    if resp.status_code not in (200, 204):
+        raise RuntimeError(
+            f"Discord webhook rejected the message (HTTP {resp.status_code}): "
+            f"{resp.text}"
+        )
+    return resp.json() if resp.text else {}

--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -1,0 +1,226 @@
+"""Tests for ``automaton.discord_bot``.
+
+These are pure-unit tests — they exercise the parsing / embed-building /
+persistence / poller-orchestration logic without any real GitHub or Discord
+network calls.  Use ``pytest tests/ -q`` to run them.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from automaton.discord_bot.embeds import build_embed, parse_bounty
+from automaton.discord_bot.persistence import SeenState
+from automaton.discord_bot.poller import Poller
+
+
+# ------------------------------------------------------------------ fixtures
+# ------------------------------------------------------------------
+@pytest.fixture
+def sample_issue() -> dict[str, Any]:
+    return {
+        "number": 853,
+        "title": "Bounty T2: Discord Bot for Bounty Notifications",
+        "html_url": "https://github.com/SolFoundry/solfoundry/issues/853",
+        "state": "open",
+        "body": (
+            "## Bounty: Discord Bot for Bounty Notifications\n"
+            "**Reward:** 500K $FNDRY | **Tier:** T2 | **Domain:** Integration\n"
+            "Some description text.\n"
+        ),
+        "labels": [
+            {"name": "bounty"},
+            {"name": "tier-2"},
+            {"name": "integration"},
+        ],
+        "assignees": [{"login": "dev-alice"}, {"login": "dev-bob"}],
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-02T12:00:00Z",
+    }
+
+
+@pytest.fixture
+def missing_reward_issue() -> dict[str, Any]:
+    return {
+        "number": 123,
+        "title": "Mystery bounty",
+        "html_url": "https://github.com/SolFoundry/solfoundry/issues/123",
+        "state": "open",
+        "body": "Just a title, no reward line.",
+        "labels": [{"name": "bounty"}],  # no tier / domain label
+        "assignees": [],
+        "created_at": "2026-03-01T00:00:00Z",
+        "updated_at": "2026-03-01T00:00:00Z",
+    }
+
+
+
+# ------------------------------------------------------------------ parse_bounty
+# ------------------------------------------------------------------
+class TestParseBounty:
+    def test_parses_standard_fields(self, sample_issue):
+        result = parse_bounty(sample_issue)
+
+        assert result["number"] == 853
+        assert "Discord Bot" in result["title"]
+        assert result["html_url"] == sample_issue["html_url"]
+        assert result["state"] == "open"
+        assert result["tier"] == "tier-2"
+        assert result["domain"] == "Integration"
+        assert result["assignees"] == ["dev-alice", "dev-bob"]
+
+    def test_parses_reward_from_body(self, sample_issue):
+        result = parse_bounty(sample_issue)
+        assert result["reward"] == "500K $FNDRY"
+
+    def test_returns_none_reward_when_missing(self, missing_reward_issue):
+        result = parse_bounty(missing_reward_issue)
+        assert result["reward"] is None
+
+    def test_unknown_tier_returns_none(self):
+        issue = {
+            "number": 999,
+            "title": "Plain issue",
+            "html_url": "https://github.com/SolFoundry/solfoundry/issues/999",
+            "state": "open",
+            "body": "",
+            "labels": [{"name": "bounty"}],
+            "assignees": [],
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z",
+        }
+        result = parse_bounty(issue)
+        assert result["tier"] is None
+        assert result["domain"] is None
+
+
+# ------------------------------------------------------------------ build_embed
+# ------------------------------------------------------------------
+class TestBuildEmbed:
+    def _bounty(self, sample_issue) -> dict[str, Any]:
+        return parse_bounty(sample_issue)
+
+    def test_embed_has_title_and_url(self, sample_issue):
+        embed = build_embed(self._bounty(sample_issue), action="new")
+
+        assert embed["title"] == sample_issue["title"]
+        assert embed["url"] == sample_issue["html_url"]
+        assert "embed" not in embed["title"]
+
+    def test_tier_2_uses_amber_colour(self, sample_issue):
+        embed = build_embed(self._bounty(sample_issue), action="updated")
+
+        assert embed["color"] == 0xFAA61A
+        assert any(f["name"] == "Tier" and f["value"] == "T2 — Gated" for f in embed["fields"])
+
+    def test_new_action_phrase(self, sample_issue):
+        embed = build_embed(self._bounty(sample_issue), action="new")
+        assert "New bounty posted" in embed["description"]
+
+    def test_unknown_tier_defaults_to_grey(self, missing_reward_issue):
+        embed = build_embed(self._bounty(missing_reward_issue), action="closed")
+        assert embed["color"] == 0x808080
+
+    def test_no_assignees_shows_open_for_grabs(self, missing_reward_issue):
+        embed = build_embed(self._bounty(missing_reward_issue), action="new")
+        assert any(
+            f["name"] == "Assignees" and "open for grabs" in f["value"]
+            for f in embed["fields"]
+        )
+
+    def test_embed_is_json_serialisable(self, sample_issue):
+        embed = build_embed(self._bounty(sample_issue), action="new")
+        # Must not raise — caller json.dumps()s the payload.
+        json.dumps(embed)
+
+
+# ------------------------------------------------------------------ SeenState
+# ------------------------------------------------------------------
+class TestSeenState:
+    def test_empty_on_missing_file(self, tmp_path: Path):
+        seen = SeenState(tmp_path / "nope.json")
+        assert seen.size() == 0
+        assert not seen.has_seen(1, "2026-01-01T00:00:00Z")
+
+    def test_mark_and_check(self, tmp_path: Path):
+        file = tmp_path / "seen.json"
+        seen = SeenState(file)
+        ts = "2026-06-01T00:00:00Z"
+
+        seen.mark_seen(42, ts)
+        assert seen.size() == 1
+        assert seen.has_seen(42, ts)
+        assert not seen.has_seen(42, "different-timestamp")
+        # None means "ever recorded at all".
+        assert seen.has_seen(42, None)
+        assert not seen.has_seen(999, None)
+
+    def test_clear_removes_file(self, tmp_path: Path):
+        file = tmp_path / "seen.json"
+        seen = SeenState(file)
+        seen.mark_seen(1, "t")
+        seen.clear()
+        assert not file.exists()
+
+
+# ------------------------------------------------------------------ Poller orchestration
+# ------------------------------------------------------------------
+class TestPollerOrchestration:
+    @staticmethod
+    def _fake_cfg() -> Any:
+        cfg = type("Cfg", (), {})()
+        cfg.discord_webhook_url = "https://discord.com/api/webhooks/FAKE"
+        cfg.github_token = None
+        cfg.solfoundry_repo = "SolFoundry/solfoundry"
+        cfg.poll_interval = 300
+        return cfg
+
+    def test_tick_posts_for_new_issue(self, tmp_path: Path, sample_issue):
+        sent: list[dict] = []
+
+        def capture(**kw):
+            sent.append(kw["embed"])
+
+        issues_returned = [sample_issue]
+
+        def fake_fetch(**kw):
+            return issues_returned
+
+        seen = SeenState(tmp_path / "seen.json")
+        poller = Poller(self._fake_cfg(), seen, fetch_issues=fake_fetch, send_embed=capture)
+
+        created, updated = poller.tick()
+        assert created == 1
+        assert updated == 0
+        assert len(sent) == 1
+        assert "New bounty posted" in sent[0]["description"]
+
+        # Idempotent: tick again with same updated_at -> no notify.
+        created, updated = poller.tick()
+        assert created == 0
+        assert updated == 0
+        assert len(sent) == 1
+
+    def test_tick_distinguishes_update_from_new(self, tmp_path: Path, sample_issue):
+        sent: list[dict] = []
+
+        def capture(**kw):
+            sent.append(kw["embed"])
+
+        seen = SeenState(tmp_path / "seen.json")
+        seen.mark_seen(853, sample_issue["created_at"])  # seen before, at old time
+
+        def fake_fetch(**kw):
+            return [sample_issue]
+
+        poller = Poller(self._fake_cfg(), seen, fetch_issues=fake_fetch, send_embed=capture)
+
+        created, updated = poller.tick()
+        assert created == 0
+        assert updated == 1
+        assert len(sent) == 1
+        assert "Bounty updated" in sent[0]["description"]


### PR DESCRIPTION
Closes #853

## Solana Wallet for Payout
FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH

## Type of Change
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only

## What this PR does
- Adds `automaton/discord_bot/`, a webhook-based Discord notification bot
  that polls the SolFoundry GitHub issues for `bounty`-labeled issues and posts
  rich embed messages to a Discord channel (no OAuth bot token needed).
- **Poller** (`poller.py`) fetches open bounty issues via the GitHub Issues
  Search API and posts new/updated bounties to a Discord incoming webhook.
- **Rich embeds** include bounty title, reward amount, tier label, domain,
  assignees, and a link to the issue, with action-aware descriptions
  (`New bounty posted` / `Bounty updated`) and tier-specific colours.
- **Idempotent state** via a `LAST_SEEN_FILE` JSON file (defaults to
  `.last_seen_bounties.json`), so a restart never re-posts the same bounty.
- **Configuration** entirely via environment variables / `.env`:
  `DISCORD_WEBHOOK_URL` (required), `POLL_INTERVAL` (default 300s),
  `GITHUB_TOKEN` (optional), `SOLFOWNDRY_REPO` (default
  `SolFoundry/solfoundry`), `LAST_SEEN_FILE`.
- **Entry points**: `python -m automaton.discord_bot` (daemon loop),
  `--poll-once` (single poll for cron), and `make poll` / `make poll-once`.
- **Unit tests** (`tests/test_discord_bot.py`, 15 passing) covering
  issue-parsing, embed-building, persistence, and poller orchestration
  (no live GitHub / Discord calls — fully mocked).
- **Documentation**: module README, `automaton/README.md` section,
  `.env.example` entries, and `.gitignore` for the seen-file.

## Checklist (CONTRIBUTING.md)
- [x] Includes `Closes #853` in the description.
- [x] Solana wallet address included in the description.
- [x] PR title follows Conventional Commits (prefix `feat:`).
- [x] Code is clean, commented, and follows repo Python style
  (PEP-257 docstrings, type hints, no hardcoded secrets).
- [x] No TODOs / placeholders left behind.
- [x] Tests written and passing (`pytest tests/test_discord_bot.py` — 15 passed).
- [x] No binary files or `node_modules/`.
- [x] No `console.log` / debug statements.

## Files changed

| File | Description |
|---|---|
| `automaton/discord_bot/__init__.py` | Package init |
| `automaton/discord_bot/__main__.py` | `python -m` entry point |
| `automaton/discord_bot/config.py` | Env / .env config loader |
| `automaton/discord_bot/github_client.py` | GitHub Issues API wrapper |
| `automaton/discord_bot/embeds.py` | Issue parsing + Discord embed builder |
| `automaton/discord_bot/persistence.py` | `SeenState` idempotency store |
| `automaton/discord_bot/webhook.py` | Discord webhook sender |
| `automaton/discord_bot/poller.py` | Polling loop orchestrator |
| `automaton/discord_bot/requirements.txt` | Runtime deps |
| `automaton/discord_bot/README.md` | Module setup docs |
| `tests/test_discord_bot.py` | Unit tests |
| `Makefile` | `poll` / `poll-once` targets |
| `automaton/README.md` | New discord_bot section |
| `.env.example` | Discord bot env var entries |
| `.gitignore` | Ignore `.last_seen_bounties.json` |