### PR TITLE
fix: resolve GitHub OAuth 404 by building authorize URL directly in frontend (#821) [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,8 @@ REDIS_URL=redis://redis:6379/0
 # GitHub
 GITHUB_TOKEN=
 GITHUB_WEBHOOK_SECRET=
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
 
 # Solana - defaults to devnet for safe local development
 SOLANA_RPC_URL=https://api.devnet.solana.com
@@ -30,6 +32,8 @@ SOLANA_RPC_URL=https://api.devnet.solana.com
 # Frontend
 FRONTEND_PORT=3000
 VITE_API_URL=http://localhost:8000
+
+VITE_GITHUB_CLIENT_ID=
 
 # Deploy health-check URLs (set as GitHub repository variables, not secrets)
 STAGING_HEALTH_URL=https://staging-api.solfoundry.org/health

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ eggs/
 .eggs/
 lib/
 lib64/
+!frontend/src/lib/
 parts/
 sdist/
 var/

--- a/frontend/src/__tests__/auth.test.ts
+++ b/frontend/src/__tests__/auth.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildGitHubAuthorizeUrl, exchangeGitHubCode, consumeOAuthState } from '../api/auth';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function mockResponse(body: unknown, status = 200, statusText = 'OK'): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText,
+    json: () => Promise.resolve(body),
+    headers: new Headers({ 'content-type': 'application/json' }),
+  } as Response;
+}
+
+describe('GitHub OAuth URL handling', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    sessionStorage.clear();
+    vi.stubEnv('VITE_GITHUB_CLIENT_ID', 'test-client-id');
+  });
+
+  it('builds a direct GitHub authorize URL with callback and state', () => {
+    const url = new URL(buildGitHubAuthorizeUrl());
+
+    expect(url.origin + url.pathname).toBe('https://github.com/login/oauth/authorize');
+    expect(url.searchParams.get('client_id')).toBe('test-client-id');
+    expect(url.searchParams.get('redirect_uri')).toBe(`${window.location.origin}/auth/github/callback`);
+    expect(url.searchParams.get('scope')).toBe('read:user user:email');
+    expect(url.searchParams.get('state')).toBeTruthy();
+    expect(sessionStorage.getItem('sf_github_oauth_state')).toBe(url.searchParams.get('state'));
+  });
+
+  it('throws when VITE_GITHUB_CLIENT_ID is missing', () => {
+    vi.stubEnv('VITE_GITHUB_CLIENT_ID', '');
+    expect(() => buildGitHubAuthorizeUrl()).toThrow('VITE_GITHUB_CLIENT_ID');
+  });
+
+  it('consumes and removes the OAuth state from sessionStorage', () => {
+    sessionStorage.setItem('sf_github_oauth_state', 'test-state-123');
+    const state = consumeOAuthState();
+    expect(state).toBe('test-state-123');
+    expect(sessionStorage.getItem('sf_github_oauth_state')).toBeNull();
+  });
+
+  it('returns null when no OAuth state is stored', () => {
+    expect(consumeOAuthState()).toBeNull();
+  });
+});
+
+describe('exchangeGitHubCode', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('sends code and state to the backend', async () => {
+    const mockUser = { id: '1', username: 'testuser', avatar_url: 'https://avatars.githubusercontent.com/u/1?v=4' };
+    const mockResponse = {
+      access_token: 'test-access-token',
+      refresh_token: 'test-refresh-token',
+      token_type: 'bearer',
+      user: mockUser,
+    };
+    mockFetch.mockResolvedValueOnce(mockResponse(mockResponse));
+
+    const result = await exchangeGitHubCode('test-code', 'test-state');
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/auth/github'),
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining('test-code'),
+      }),
+    );
+    expect(result.access_token).toBe('test-access-token');
+    expect(result.user.username).toBe('testuser');
+  });
+});

--- a/frontend/src/__tests__/auth.test.ts
+++ b/frontend/src/__tests__/auth.test.ts
@@ -56,13 +56,13 @@ describe('exchangeGitHubCode', () => {
 
   it('sends code and state to the backend', async () => {
     const mockUser = { id: '1', username: 'testuser', avatar_url: 'https://avatars.githubusercontent.com/u/1?v=4' };
-    const mockResponse = {
+    const mockResponseData = {
       access_token: 'test-access-token',
       refresh_token: 'test-refresh-token',
       token_type: 'bearer',
       user: mockUser,
     };
-    mockFetch.mockResolvedValueOnce(mockResponse(mockResponse));
+    mockFetch.mockResolvedValueOnce(mockResponse(mockResponseData));
 
     const result = await exchangeGitHubCode('test-code', 'test-state');
 

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -11,6 +11,89 @@ export interface GitHubCallbackResponse extends AuthTokens {
   user: User;
 }
 
+const GITHUB_AUTHORIZE_URL = 'https://github.com/login/oauth/authorize';
+const GITHUB_OAUTH_STATE_KEY = 'sf_github_oauth_state';
+const GITHUB_OAUTH_SCOPE = 'read:user user:email';
+
+function getGitHubClientId(): string | null {
+  const clientId = import.meta.env?.VITE_GITHUB_CLIENT_ID;
+  return typeof clientId === 'string' && clientId.trim() !== '' ? clientId.trim() : null;
+}
+
+function createOAuthState(): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+/**
+ * Build a GitHub OAuth authorize URL directly in the frontend.
+ * This bypasses the backend /api/auth/github/authorize endpoint
+ * which may be unavailable or return 404.
+ */
+export function buildGitHubAuthorizeUrl(): string {
+  const clientId = getGitHubClientId();
+  if (!clientId) {
+    throw new Error('VITE_GITHUB_CLIENT_ID environment variable is required for GitHub OAuth.');
+  }
+
+  const state = createOAuthState();
+  sessionStorage.setItem(GITHUB_OAUTH_STATE_KEY, state);
+
+  const url = new URL(GITHUB_AUTHORIZE_URL);
+  url.searchParams.set('client_id', clientId);
+  url.searchParams.set('redirect_uri', `${window.location.origin}/auth/github/callback`);
+  url.searchParams.set('scope', GITHUB_OAUTH_SCOPE);
+  url.searchParams.set('state', state);
+  return url.toString();
+}
+
+/**
+ * Retrieve the stored OAuth state for CSRF validation.
+ * Returns the state value and removes it from sessionStorage (one-time use).
+ */
+export function consumeOAuthState(): string | null {
+  try {
+    const state = sessionStorage.getItem(GITHUB_OAUTH_STATE_KEY);
+    sessionStorage.removeItem(GITHUB_OAUTH_STATE_KEY);
+    return state;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Redirect the user to GitHub OAuth authorization.
+ * First tries the backend-provided URL, falls back to a direct URL.
+ */
+export async function redirectToGitHubSignIn(): Promise<void> {
+  // Try backend-provided authorize URL first
+  try {
+    const data = await apiClient<{ authorize_url: string }>('/api/auth/github/authorize');
+    if (data?.authorize_url) {
+      window.location.href = data.authorize_url;
+      return;
+    }
+  } catch {
+    // Backend endpoint unavailable — fall through to direct URL
+  }
+
+  // Fallback: build the URL directly using the GitHub client ID
+  try {
+    const url = buildGitHubAuthorizeUrl();
+    window.location.href = url;
+  } catch (err) {
+    console.error('GitHub OAuth is not configured. Missing VITE_GITHUB_CLIENT_ID.', err);
+    // Redirect to home with an error indicator
+    window.location.href = '/?auth_error=oauth_not_configured';
+  }
+}
+
+/**
+ * Fetch the GitHub OAuth authorize URL from the backend.
+ * Deprecated — use redirectToGitHubSignIn() instead.
+ */
 export async function getGitHubAuthorizeUrl(): Promise<string> {
   const data = await apiClient<{ authorize_url: string }>('/api/auth/github/authorize');
   return data.authorize_url;

--- a/frontend/src/components/auth/AuthGuard.tsx
+++ b/frontend/src/components/auth/AuthGuard.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { GitBranch } from 'lucide-react';
 import { useAuth } from '../../hooks/useAuth';
-import { getGitHubAuthorizeUrl } from '../../api/auth';
+import { redirectToGitHubSignIn } from '../../api/auth';
 
 interface AuthGuardProps {
   children: React.ReactNode;
@@ -22,13 +22,7 @@ export function AuthGuard({ children }: AuthGuardProps) {
 
   if (!isAuthenticated) {
     const handleSignIn = async () => {
-      try {
-        const url = await getGitHubAuthorizeUrl();
-        window.location.href = url;
-      } catch {
-        // fallback: redirect to backend OAuth endpoint directly
-        window.location.href = '/api/auth/github/authorize';
-      }
+      await redirectToGitHubSignIn();
     };
 
     return (

--- a/frontend/src/components/bounty/BountyDetail.tsx
+++ b/frontend/src/components/bounty/BountyDetail.tsx
@@ -7,6 +7,7 @@ import { timeLeft, timeAgo, formatCurrency, LANG_COLORS } from '../../lib/utils'
 import { useAuth } from '../../hooks/useAuth';
 import { SubmissionForm } from './SubmissionForm';
 import { fadeIn } from '../../lib/animations';
+import { redirectToGitHubSignIn } from '../../api/auth';
 
 interface BountyDetailProps {
   bounty: Bounty;
@@ -101,12 +102,13 @@ export function BountyDetail({ bounty }: BountyDetailProps) {
               ) : (
                 <div className="text-center py-6">
                   <p className="text-text-muted text-sm mb-4">Sign in with GitHub to submit a solution.</p>
-                  <a
-                    href="/api/auth/github/authorize"
+                  <button
+                    type="button"
+                    onClick={() => { void redirectToGitHubSignIn(); }}
                     className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-forge-800 border border-border hover:border-border-hover text-text-primary text-sm font-medium transition-all duration-200"
                   >
                     Sign in with GitHub
-                  </a>
+                  </button>
                 </div>
               )}
             </div>

--- a/frontend/src/components/home/HeroSection.tsx
+++ b/frontend/src/components/home/HeroSection.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { motion, useInView, animate, useMotionValue } from 'framer-motion';
 import { useStats } from '../../hooks/useStats';
-import { getGitHubAuthorizeUrl } from '../../api/auth';
+import { redirectToGitHubSignIn } from '../../api/auth';
 import { useAuth } from '../../hooks/useAuth';
 import { buttonHover, fadeIn } from '../../lib/animations';
 
@@ -78,12 +78,7 @@ export function HeroSection() {
   }, []);
 
   const handleSignIn = async () => {
-    try {
-      const url = await getGitHubAuthorizeUrl();
-      window.location.href = url;
-    } catch {
-      window.location.href = '/api/auth/github/authorize';
-    }
+    await redirectToGitHubSignIn();
   };
 
   return (

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -4,7 +4,7 @@ import { Menu, X, ChevronDown, LogOut, User } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useAuth } from '../../hooks/useAuth';
 import { useStats } from '../../hooks/useStats';
-import { getGitHubAuthorizeUrl } from '../../api/auth';
+import { redirectToGitHubSignIn } from '../../api/auth';
 
 const GitHubIcon = () => (
   <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
@@ -34,13 +34,7 @@ export function Navbar() {
   }, []);
 
   const handleGitHubSignIn = async () => {
-    try {
-      const url = await getGitHubAuthorizeUrl();
-      window.location.href = url;
-    } catch {
-      // Fallback: direct to backend authorize endpoint
-      window.location.href = '/api/auth/github/authorize';
-    }
+    await redirectToGitHubSignIn();
   };
 
   const isActive = (to: string) => {

--- a/frontend/src/lib/animations.ts
+++ b/frontend/src/lib/animations.ts
@@ -1,0 +1,47 @@
+import type { Variants } from 'framer-motion';
+
+export const fadeIn: Variants = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.28, ease: 'easeOut' } },
+};
+
+export const pageTransition: Variants = {
+  initial: { opacity: 0, y: 16 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.32, ease: 'easeOut' } },
+  exit: { opacity: 0, y: -8, transition: { duration: 0.18, ease: 'easeIn' } },
+};
+
+export const staggerContainer: Variants = {
+  initial: {},
+  animate: {
+    transition: {
+      staggerChildren: 0.07,
+      delayChildren: 0.04,
+    },
+  },
+};
+
+export const staggerItem: Variants = {
+  initial: { opacity: 0, y: 14 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.24, ease: 'easeOut' } },
+};
+
+export const cardHover: Variants = {
+  rest: { y: 0, scale: 1 },
+  hover: {
+    y: -3,
+    scale: 1.01,
+    transition: { duration: 0.18, ease: 'easeOut' },
+  },
+};
+
+export const buttonHover: Variants = {
+  rest: { scale: 1 },
+  hover: { scale: 1.03, transition: { duration: 0.15, ease: 'easeOut' } },
+  tap: { scale: 0.98, transition: { duration: 0.08, ease: 'easeOut' } },
+};
+
+export const slideInRight: Variants = {
+  initial: { opacity: 0, x: 24 },
+  animate: { opacity: 1, x: 0, transition: { duration: 0.24, ease: 'easeOut' } },
+};

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,63 @@
+export const LANG_COLORS: Record<string, string> = {
+  TypeScript: '#3178c6',
+  JavaScript: '#f1e05a',
+  Python: '#3572A5',
+  Rust: '#dea584',
+  Go: '#00ADD8',
+  Solidity: '#AA6746',
+  React: '#61dafb',
+  Next: '#ffffff',
+  Frontend: '#00E676',
+  Backend: '#E040FB',
+  Docs: '#8b949e',
+};
+
+export function formatCurrency(amount: number, token = 'USDC'): string {
+  const value = Number.isFinite(amount) ? amount : 0;
+  const normalizedToken = token.toUpperCase();
+
+  if (normalizedToken === 'USDC' || normalizedToken === 'USD') {
+    return `$${value.toLocaleString(undefined, { maximumFractionDigits: 2 })}`;
+  }
+
+  return `${value.toLocaleString(undefined, { maximumFractionDigits: 2 })} ${token}`;
+}
+
+export function timeAgo(value: string | Date): string {
+  const date = new Date(value);
+  const diffMs = Date.now() - date.getTime();
+  if (!Number.isFinite(diffMs)) return '';
+
+  const seconds = Math.max(0, Math.floor(diffMs / 1000));
+  if (seconds < 60) return 'just now';
+
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo ago`;
+
+  return `${Math.floor(months / 12)}y ago`;
+}
+
+export function timeLeft(value: string | Date): string {
+  const date = new Date(value);
+  const diffMs = date.getTime() - Date.now();
+  if (!Number.isFinite(diffMs) || diffMs <= 0) return 'Ended';
+
+  const seconds = Math.floor(diffMs / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+
+  if (days > 0) return `${days}d ${hours % 24}h left`;
+  if (hours > 0) return `${hours}h ${minutes % 60}m left`;
+  if (minutes > 0) return `${minutes}m left`;
+  return `${seconds}s left`;
+}

--- a/frontend/src/pages/GitHubCallbackPage.tsx
+++ b/frontend/src/pages/GitHubCallbackPage.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { useAuth } from '../hooks/useAuth';
-import { exchangeGitHubCode } from '../api/auth';
+import { exchangeGitHubCode, consumeOAuthState } from '../api/auth';
 import { setAuthToken } from '../services/apiClient';
 import { fadeIn } from '../lib/animations';
 
@@ -20,8 +20,22 @@ export function GitHubCallbackPage() {
     const state = searchParams.get('state');
     const error = searchParams.get('error');
 
-    if (error || !code) {
+    if (error) {
+      console.error('GitHub OAuth error:', error);
+      navigate('/?auth_error=' + encodeURIComponent(error), { replace: true });
+      return;
+    }
+
+    if (!code) {
       navigate('/', { replace: true });
+      return;
+    }
+
+    // Validate OAuth state for CSRF protection
+    const expectedState = consumeOAuthState();
+    if (expectedState && state !== expectedState) {
+      console.error('GitHub OAuth state mismatch — possible CSRF attack');
+      navigate('/?auth_error=state_mismatch', { replace: true });
       return;
     }
 
@@ -37,8 +51,9 @@ export function GitHubCallbackPage() {
         }
         navigate('/', { replace: true });
       })
-      .catch(() => {
-        navigate('/', { replace: true });
+      .catch((err) => {
+        console.error('GitHub OAuth code exchange failed:', err);
+        navigate('/?auth_error=exchange_failed', { replace: true });
       });
   }, []);
 


### PR DESCRIPTION
## Summary
Fixes #821 — the GitHub OAuth sign-in flow was returning a 404 because the backend `/api/auth/github/authorize` endpoint was unavailable.

## Changes

### Root Cause
The `getGitHubAuthorizeUrl()` function called `/api/auth/github/authorize` which returned 404. The fallback in all components redirected to `/api/auth/github/authorize` which also returned 404.

### Fix
1. **Added `redirectToGitHubSignIn()` function** in `frontend/src/api/auth.ts`:
   - First tries the backend-provided authorize URL
   - Falls back to building the GitHub OAuth URL directly using `VITE_GITHUB_CLIENT_ID`
   - Generates and stores OAuth state in sessionStorage for CSRF protection

2. **Added `consumeOAuthState()`** for CSRF validation in the callback page

3. **Updated all sign-in entry points** to use `redirectToGitHubSignIn()` instead of the broken `getGitHubAuthorizeUrl()`:
   - `AuthGuard.tsx`
   - `Navbar.tsx`
   - `HeroSection.tsx`
   - `BountyDetail.tsx` (was a hard-coded `<a>` to the broken endpoint)

4. **Improved `GitHubCallbackPage.tsx`**:
   - Validates OAuth state param for CSRF protection
   - Shows descriptive error messages in URL params
   - Maintains backward compatibility (state is optional for existing flows)

5. **Added missing `lib/animations.ts` and `lib/utils.ts`** — these modules are imported by many components but were missing from the repo (blocked by gitignore `lib/` pattern)

6. **Added `VITE_GITHUB_CLIENT_ID`** to `.env.example` and fixed `.gitignore` to include frontend lib files

7. **Added unit tests** for OAuth URL building, state consumption, and code exchange

## Verification
- `npm test -- auth.test.ts --run` — focused OAuth tests pass
- `npm run build` — production build succeeds

## Wallet
[FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]