### PR TITLE
feat: GitHub Action for External Repos to Post Bounties [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/.github/actions/post-bounty/README.md
+++ b/.github/actions/post-bounty/README.md
@@ -1,0 +1,79 @@
+# SolFoundry External Bounty GitHub Action
+
+A GitHub Action that automatically posts labeled issues from **any repository** as
+bounties on the [SolFoundry](https://solfoundry.dev) marketplace.
+
+## How It Works
+
+1. **Install** the workflow in your repository (see below)
+2. **Label** an issue with a bounty label (e.g., `bounty-t1`)
+3. **Automatically** — the action detects the label, creates a bounty on SolFoundry,
+   and comments on the issue with the bounty link
+
+## Setup
+
+### 1. Add your SolFoundry API Key
+
+Add a repository secret:
+
+| Secret Name | Value |
+|---|---|
+| `SOLFOUNDRY_API_KEY` | Your SolFoundry API key (get one at [solfoundry.dev](https://solfoundry.dev)) |
+
+### 2. Create the workflow file
+
+Copy `.github/workflows/external-bounty.yml` into your repository's
+`.github/workflows/` directory.
+
+### 3. Create labels
+
+Create these labels in your repository (or customize the names):
+
+| Label | Description |
+|---|---|
+| `bounty-t1` | Tier 1: Simple tasks (small reward) |
+| `bounty-t2` | Tier 2: Moderate complexity |
+| `bounty-t3` | Tier 3: Large features (large reward) |
+
+## Configuration
+
+All inputs are optional except `solfoundry-api-key`:
+
+| Input | Default | Description |
+|---|---|---|
+| `solfoundry-api-key` | *required* | SolFoundry API key |
+| `bounty-labels` | `bounty-t1,bounty-t2,bounty-t3` | Comma-separated labels for T1, T2, T3 |
+| `reward-tier-1` | `50000` | Reward in $FNDRY for T1 |
+| `reward-tier-2` | `500000` | Reward in $FNDRY for T2 |
+| `reward-tier-3` | `5000000` | Reward in $FNDRY for T3 |
+
+## Example: Custom Configuration
+
+```yaml
+- name: Post Bounty
+  uses: SolFoundry/solfoundry/.github/actions/post-bounty@main
+  with:
+    solfoundry-api-key: ${{ secrets.SOLFOUNDRY_API_KEY }}
+    bounty-labels: "bug-bounty,feature-bounty,security-bounty"
+    reward-tier-1: "100000"
+    reward-tier-2: "1000000"
+    reward-tier-3: "10000000"
+```
+
+## Outputs
+
+| Output | Description |
+|---|---|
+| `bounty-id` | UUID of the created bounty |
+| `bounty-url` | URL to view the bounty on SolFoundry |
+| `tier` | Tier of the created bounty (1, 2, or 3) |
+
+## Development
+
+```bash
+# Run tests
+python3 -m pytest .github/actions/post-bounty/
+
+# Lint
+python3 -m flake8 .github/actions/post-bounty/
+```

--- a/.github/actions/post-bounty/action.yml
+++ b/.github/actions/post-bounty/action.yml
@@ -1,0 +1,72 @@
+name: "Post Bounty to SolFoundry"
+description: |
+  Automatically post GitHub issues with bounty labels to the SolFoundry marketplace.
+  Detects labeled issues and converts them into SolFoundry bounties with
+  configurable reward tiers.
+
+branding:
+  icon: "dollar-sign"
+  color: "orange"
+
+inputs:
+  solfoundry-api-key:
+    description: "SolFoundry API key for authentication (store in secrets)"
+    required: true
+
+  bounty-labels:
+    description: "Comma-separated list of labels that trigger bounty posting, in order of tiers (T1, T2, T3)"
+    required: false
+    default: "bounty-t1,bounty-t2,bounty-t3"
+
+  reward-tier-1:
+    description: "Reward amount in $FNDRY for T1 (small) bounties"
+    required: false
+    default: "50000"
+
+  reward-tier-2:
+    description: "Reward amount in $FNDRY for T2 (medium) bounties"
+    required: false
+    default: "500000"
+
+  reward-tier-3:
+    description: "Reward amount in $FNDRY for T3 (large) bounties"
+    required: false
+    default: "5000000"
+
+outputs:
+  bounty-id:
+    description: "UUID of the created bounty on SolFoundry"
+  bounty-url:
+    description: "URL to view the bounty on SolFoundry"
+  tier:
+    description: "Tier of the created bounty (1, 2, or 3)"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+
+    - name: Run post-bounty script
+      id: post-bounty
+      shell: bash
+      env:
+        INPUT_SOLFOUNDRY_API_KEY: ${{ inputs.solfoundry-api-key }}
+        INPUT_BOUNTY_LABELS: ${{ inputs.bounty-labels }}
+        INPUT_REWARD_TIER_1: ${{ inputs.reward-tier-1 }}
+        INPUT_REWARD_TIER_2: ${{ inputs.reward-tier-2 }}
+        INPUT_REWARD_TIER_3: ${{ inputs.reward-tier-3 }}
+      run: |
+        python3 "${{ github.action_path }}/post-bounty.py"
+
+    - name: Export outputs
+      shell: bash
+      run: |
+        # Read outputs from the script's GITHUB_OUTPUT writes
+        if [ -n "$GITHUB_OUTPUT" ]; then
+          echo "bounty-id=$(grep '^bounty-id=' "$GITHUB_OUTPUT" | tail -1 | cut -d= -f2-)"
+          echo "bounty-url=$(grep '^bounty-url=' "$GITHUB_OUTPUT" | tail -1 | cut -d= -f2-)"
+          echo "tier=$(grep '^tier=' "$GITHUB_OUTPUT" | tail -1 | cut -d= -f2-)"
+        fi

--- a/.github/actions/post-bounty/post-bounty.py
+++ b/.github/actions/post-bounty/post-bounty.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""
+SolFoundry GitHub Action: Post labeled issues as bounties.
+
+Detects GitHub issues labeled with bounty-related labels and
+automatically posts them to the SolFoundry marketplace with
+configurable reward tiers.
+
+Usage (via GitHub Actions):
+    - name: Post Bounty
+      uses: SolFoundry/solfoundry/.github/actions/post-bounty@main
+      with:
+        solfoundry-api-key: ${{ secrets.SOLFOUNDRY_API_KEY }}
+        reward-tier-1: '50000'
+        reward-tier-2: '500000'
+        reward-tier-3: '5000000'
+        bounty-labels: 'bounty-t1,bounty-t2,bounty-t3'
+"""
+
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+
+
+def load_event() -> dict:
+    """Load the GitHub event payload from GITHUB_EVENT_PATH."""
+    path = os.environ.get("GITHUB_EVENT_PATH")
+    if not path:
+        print("::error::GITHUB_EVENT_PATH not set — not running in a GitHub Action context")
+        sys.exit(1)
+    with open(path) as f:
+        return json.load(f)
+
+
+def get_input(name: str, default: str = "") -> str:
+    """Read a GitHub Action input using the INPUT_<NAME> convention."""
+    env_name = f"INPUT_{name.upper().replace('-', '_')}"
+    return os.environ.get(env_name, default)
+
+
+def call_solfoundry_api(api_key: str, payload: dict) -> dict:
+    """Call the SolFoundry API to create a bounty."""
+    url = "https://api.solfoundry.dev/api/bounties"  # production API
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {api_key}",
+        "User-Agent": "solfoundry-github-action/1.0",
+    }
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+
+    try:
+        with urllib.request.urlopen(req) as resp:
+            body = resp.read().decode("utf-8")
+            result = json.loads(body)
+            print(f"::notice::Bounty created successfully — ID: {result.get('id', 'unknown')}")
+            return result
+    except urllib.error.HTTPError as e:
+        err_body = e.read().decode("utf-8")
+        print(f"::error::SolFoundry API error (HTTP {e.code}): {err_body}")
+        sys.exit(1)
+    except urllib.error.URLError as e:
+        print(f"::error::Network error calling SolFoundry API: {e.reason}")
+        sys.exit(1)
+
+
+def main():
+    event = load_event()
+    event_name = os.environ.get("GITHUB_EVENT_NAME", "")
+
+    # --- Read inputs ---
+    api_key = get_input("solfoundry-api-key")
+    if not api_key:
+        print("::error::solfoundry-api-key is required")
+        sys.exit(1)
+
+    tier_labels_raw = get_input("bounty-labels", "bounty-t1,bounty-t2,bounty-t3")
+    tier_labels = [t.strip() for t in tier_labels_raw.split(",") if t.strip()]
+
+    # Reward mapping: label -> reward amount ($FNDRY)
+    reward_t1 = int(get_input("reward-tier-1", "50000"))
+    reward_t2 = int(get_input("reward-tier-2", "500000"))
+    reward_t3 = int(get_input("reward-tier-3", "5000000"))
+
+    # Label-to-tier mapping
+    label_tier_map = {}
+    for i, label in enumerate(tier_labels):
+        tier_num = i + 1
+        if tier_num == 1:
+            label_tier_map[label] = (1, reward_t1)
+        elif tier_num == 2:
+            label_tier_map[label] = (2, reward_t2)
+        else:
+            label_tier_map[label] = (3, reward_t3)
+
+    # --- Detect bounty labels on the issue ---
+    if event_name not in ("issues", "pull_request"):
+        print(f"::debug::Skipping — event '{event_name}' is not 'issues' or 'pull_request'")
+        return
+
+    # Get the issue data
+    issue = event.get("issue", event.get("pull_request", {}))
+    if not issue:
+        print("::debug::No issue/pull_request found in event payload")
+        return
+
+    action = event.get("action", "")
+    # Only act on opened issues or newly labeled issues
+    if action not in ("opened", "labeled", "reopened"):
+        print(f"::debug::Skipping — action '{action}' is not 'opened', 'labeled', or 'reopened'")
+        return
+
+    issue_number = issue.get("number")
+    issue_title = issue.get("title", "")
+    issue_body = issue.get("body", "") or ""
+    issue_url = issue.get("html_url", "")
+    issue_labels = [lbl.get("name", "") for lbl in issue.get("labels", [])]
+
+    print(f"::debug::Processing issue #{issue_number}: {issue_title}")
+    print(f"::debug::Issue labels: {issue_labels}")
+
+    # Check if any of the configured bounty labels are present
+    matched_tier = None
+    matched_reward = None
+    for label in issue_labels:
+        if label in label_tier_map:
+            tier, reward = label_tier_map[label]
+            matched_tier = tier
+            matched_reward = reward
+            print(f"::debug::Matched label '{label}' → Tier {tier}, Reward {reward} $FNDRY")
+            break
+
+    if matched_tier is None:
+        print(f"::notice::No bounty label matched on issue #{issue_number}. Issue labels: {issue_labels}")
+        print(f"::notice::Configured bounty labels: {tier_labels}")
+        return
+
+    # --- Build the bounty payload ---
+    # Detect category from repo topics or labels
+    repo = os.environ.get("GITHUB_REPOSITORY", "")
+    category = "other"
+    category_keywords = {
+        "backend": "backend",
+        "frontend": "frontend",
+        "smart-contract": "smart-contract",
+        "blockchain": "smart-contract",
+        "design": "design",
+        "ui": "frontend",
+        "ux": "design",
+        "devops": "devops",
+        "infra": "devops",
+        "security": "security",
+        "docs": "documentation",
+        "documentation": "documentation",
+        "content": "content",
+    }
+    for lbl in issue_labels:
+        lbl_lower = lbl.lower()
+        for keyword, cat in category_keywords.items():
+            if keyword in lbl_lower:
+                category = cat
+                break
+
+    # Truncate title if too long
+    title = issue_title[:200] if issue_title else f"Issue #{issue_number}"
+    if len(title) < 3:
+        title = f"Bounty: Issue #{issue_number}"
+
+    # Build description from issue body
+    description = issue_body
+    if description:
+        description = f"{description[:4000]}\n\n---\n\n*Auto-posted from {issue_url}*"
+    else:
+        description = f"*Auto-posted from {issue_url}*"
+
+    payload = {
+        "title": title,
+        "description": description,
+        "tier": matched_tier,
+        "category": category,
+        "reward_amount": matched_reward,
+        "github_issue_url": issue_url,
+        "created_by": f"github:{repo}",
+    }
+
+    print(f"::group::SolFoundry Bounty Payload")
+    print(json.dumps(payload, indent=2))
+    print(f"::endgroup::")
+
+    # --- Post to SolFoundry ---
+    result = call_solfoundry_api(api_key, payload)
+
+    # Set outputs for downstream steps
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if output_path:
+        with open(output_path, "a") as f:
+            f.write(f"bounty-id={result.get('id', '')}\n")
+            f.write(f"bounty-url=https://solfoundry.dev/bounties/{result.get('id', '')}\n")
+            f.write(f"tier={matched_tier}\n")
+
+    print(f"::notice::Bounty #{result.get('id', 'unknown')} posted successfully!")
+    print(f"::notice::View at: https://solfoundry.dev/bounties/{result.get('id', '')}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/actions/post-bounty/test_post_bounty.py
+++ b/.github/actions/post-bounty/test_post_bounty.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Tests for the SolFoundry post-bounty GitHub Action."""
+
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import patch, MagicMock
+
+
+class TestPostBountyAction(unittest.TestCase):
+    """Test the post-bounty action logic."""
+
+    def setUp(self):
+        # Create a temporary event file
+        self.event_dir = tempfile.mkdtemp()
+        self.event_path = os.path.join(self.event_dir, "event.json")
+        # Store original environ
+        self._original_environ = os.environ.copy()
+
+    def tearDown(self):
+        os.environ.clear()
+        os.environ.update(self._original_environ)
+
+    def _write_event(self, event_data: dict):
+        with open(self.event_path, "w") as f:
+            json.dump(event_data, f)
+
+    def _set_env(self, **kwargs):
+        for k, v in kwargs.items():
+            os.environ[k] = str(v)
+
+    def _run_main(self):
+        """Execute the post-bounty main function."""
+        script_path = os.path.join(os.path.dirname(__file__), "post-bounty.py")
+        with open(script_path) as f:
+            code = f.read()
+        exec(compile(code, script_path, "exec"), {"__name__": "__main__"})
+
+    def test_label_detection_t1(self):
+        """Test that a bounty-t1 label is detected and API is called."""
+        event = {
+            "action": "labeled",
+            "issue": {
+                "number": 42,
+                "title": "Fix login bug",
+                "body": "Users can't log in with SSO",
+                "html_url": "https://github.com/owner/repo/issues/42",
+                "labels": [{"name": "bug"}, {"name": "bounty-t1"}],
+            },
+        }
+        self._write_event(event)
+        self._set_env(
+            GITHUB_EVENT_PATH=self.event_path,
+            GITHUB_EVENT_NAME="issues",
+            GITHUB_REPOSITORY="owner/repo",
+            GITHUB_OUTPUT=os.path.join(self.event_dir, "output.txt"),
+            INPUT_SOLFOUNDRY_API_KEY="test-key-123",
+            INPUT_BOUNTY_LABELS="bounty-t1,bounty-t2,bounty-t3",
+            INPUT_REWARD_TIER_1="50000",
+            INPUT_REWARD_TIER_2="500000",
+            INPUT_REWARD_TIER_3="5000000",
+        )
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_response = MagicMock()
+            mock_response.read.return_value = json.dumps({"id": "abc-123"}).encode()
+            mock_response.__enter__.return_value = mock_response
+            mock_urlopen.return_value = mock_response
+
+            self._run_main()
+
+            # Verify API was called
+            mock_urlopen.assert_called_once()
+            call_args = mock_urlopen.call_args
+            request = call_args[0][0]
+            body = json.loads(request.data)
+            self.assertEqual(body["title"], "Fix login bug")
+            self.assertEqual(body["tier"], 1)
+            self.assertEqual(body["reward_amount"], 50000)
+            self.assertEqual(
+                body["github_issue_url"],
+                "https://github.com/owner/repo/issues/42",
+            )
+
+    def test_label_detection_t2(self):
+        """Test that a bounty-t2 label maps to tier 2."""
+        event = {
+            "action": "opened",
+            "issue": {
+                "number": 100,
+                "title": "Add dark mode support",
+                "body": "We need dark mode",
+                "html_url": "https://github.com/owner/repo/issues/100",
+                "labels": [{"name": "feature"}, {"name": "bounty-t2"}],
+            },
+        }
+        self._write_event(event)
+        self._set_env(
+            GITHUB_EVENT_PATH=self.event_path,
+            GITHUB_EVENT_NAME="issues",
+            GITHUB_REPOSITORY="owner/repo",
+            GITHUB_OUTPUT=os.path.join(self.event_dir, "output.txt"),
+            INPUT_SOLFOUNDRY_API_KEY="test-key-123",
+            INPUT_BOUNTY_LABELS="bounty-t1,bounty-t2,bounty-t3",
+            INPUT_REWARD_TIER_1="50000",
+            INPUT_REWARD_TIER_2="500000",
+            INPUT_REWARD_TIER_3="5000000",
+        )
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_response = MagicMock()
+            mock_response.read.return_value = json.dumps({"id": "def-456"}).encode()
+            mock_response.__enter__.return_value = mock_response
+            mock_urlopen.return_value = mock_response
+
+            self._run_main()
+
+            mock_urlopen.assert_called_once()
+            request = mock_urlopen.call_args[0][0]
+            body = json.loads(request.data)
+            self.assertEqual(body["tier"], 2)
+            self.assertEqual(body["reward_amount"], 500000)
+
+    def test_no_bounty_label_skips(self):
+        """Test that issues without bounty labels do NOT call the API."""
+        event = {
+            "action": "opened",
+            "issue": {
+                "number": 200,
+                "title": "Regular bug report",
+                "body": "Just a regular issue",
+                "html_url": "https://github.com/owner/repo/issues/200",
+                "labels": [{"name": "bug"}],
+            },
+        }
+        self._write_event(event)
+        self._set_env(
+            GITHUB_EVENT_PATH=self.event_path,
+            GITHUB_EVENT_NAME="issues",
+            GITHUB_REPOSITORY="owner/repo",
+            GITHUB_OUTPUT=os.path.join(self.event_dir, "output.txt"),
+            INPUT_SOLFOUNDRY_API_KEY="test-key-123",
+            INPUT_BOUNTY_LABELS="bounty-t1,bounty-t2,bounty-t3",
+            INPUT_REWARD_TIER_1="50000",
+            INPUT_REWARD_TIER_2="500000",
+            INPUT_REWARD_TIER_3="5000000",
+        )
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            self._run_main()
+            mock_urlopen.assert_not_called()
+
+    def test_skipped_events(self):
+        """Test that non-issue events are skipped."""
+        event = {"action": "created", "issue": {"number": 1, "title": "test", "body": "test", "html_url": "http://example.com", "labels": []}}
+        self._write_event(event)
+        self._set_env(
+            GITHUB_EVENT_PATH=self.event_path,
+            GITHUB_EVENT_NAME="pull_request",
+            GITHUB_REPOSITORY="owner/repo",
+            GITHUB_OUTPUT=os.path.join(self.event_dir, "output.txt"),
+            INPUT_SOLFOUNDRY_API_KEY="test-key-123",
+            INPUT_BOUNTY_LABELS="bounty-t1,bounty-t2,bounty-t3",
+            INPUT_REWARD_TIER_1="50000",
+            INPUT_REWARD_TIER_2="500000",
+            INPUT_REWARD_TIER_3="5000000",
+        )
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            self._run_main()
+            mock_urlopen.assert_not_called()
+
+    def test_custom_label_config(self):
+        """Test that custom label names work."""
+        event = {
+            "action": "labeled",
+            "issue": {
+                "number": 300,
+                "title": "Security audit needed",
+                "body": "Need to audit the codebase",
+                "html_url": "https://github.com/owner/repo/issues/300",
+                "labels": [{"name": "security-bounty"}],
+            },
+        }
+        self._write_event(event)
+        self._set_env(
+            GITHUB_EVENT_PATH=self.event_path,
+            GITHUB_EVENT_NAME="issues",
+            GITHUB_REPOSITORY="owner/repo",
+            GITHUB_OUTPUT=os.path.join(self.event_dir, "output.txt"),
+            INPUT_SOLFOUNDRY_API_KEY="test-key-123",
+            INPUT_BOUNTY_LABELS="bug-bounty,feature-bounty,security-bounty",
+            INPUT_REWARD_TIER_1="100000",
+            INPUT_REWARD_TIER_2="1000000",
+            INPUT_REWARD_TIER_3="10000000",
+        )
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_response = MagicMock()
+            mock_response.read.return_value = json.dumps({"id": "ghi-789"}).encode()
+            mock_response.__enter__.return_value = mock_response
+            mock_urlopen.return_value = mock_response
+
+            self._run_main()
+
+            mock_urlopen.assert_called_once()
+            request = mock_urlopen.call_args[0][0]
+            body = json.loads(request.data)
+            self.assertEqual(body["tier"], 3)
+            self.assertEqual(body["reward_amount"], 10000000)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/external-bounty.yml
+++ b/.github/workflows/external-bounty.yml
@@ -1,0 +1,66 @@
+# Example: External Repository Bounty Workflow
+#
+# Install this workflow in your repository to automatically post
+# labeled issues as bounties on SolFoundry.
+#
+# Setup:
+#   1. Add SOLFOUNDRY_API_KEY to your repository secrets
+#      (Settings → Secrets and variables → Actions)
+#   2. Configure the labels you want to use for bounties
+#   3. That's it! Issues with matching labels will be auto-posted.
+#
+# Label Convention:
+#   - bounty-t1 (Tier 1, Small): Simple tasks, ~50K $FNDRY
+#   - bounty-t2 (Tier 2, Medium): Moderate complexity, ~500K $FNDRY
+#   - bounty-t3 (Tier 3, Large): Complex features, ~5M $FNDRY
+#
+# You can customize the reward amounts and label names in the workflow.
+
+name: Post Bounties to SolFoundry
+
+on:
+  issues:
+    types: [opened, labeled, reopened]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  post-bounty:
+    # Only run when the issue has a bounty label
+    if: |
+      contains(github.event.issue.labels.*.name, 'bounty-t1') ||
+      contains(github.event.issue.labels.*.name, 'bounty-t2') ||
+      contains(github.event.issue.labels.*.name, 'bounty-t3')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Post Bounty to SolFoundry
+        uses: SolFoundry/solfoundry/.github/actions/post-bounty@main
+        with:
+          solfoundry-api-key: ${{ secrets.SOLFOUNDRY_API_KEY }}
+          bounty-labels: "bounty-t1,bounty-t2,bounty-t3"
+          reward-tier-1: "50000"   # 50K $FNDRY for T1
+          reward-tier-2: "500000"  # 500K $FNDRY for T2
+          reward-tier-3: "5000000" # 5M $FNDRY for T3
+
+      - name: Comment on Issue with Bounty Link
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BOUNTY_URL: ${{ steps.post-bounty.outputs.bounty-url }}
+          BOUNTY_ID: ${{ steps.post-bounty.outputs.bounty-id }}
+          TIER: ${{ steps.post-bounty.outputs.tier }}
+        run: |
+          if [ -n "$BOUNTY_URL" ]; then
+            gh issue comment "${{ github.event.issue.number }}" \
+              --body "✨ **Bounty posted to SolFoundry!** ✨
+
+          🏆 **Tier:** T$TIER
+          💰 **Reward:** ${{ inputs.reward-tier-1 || inputs.reward-tier-2 || inputs.reward-tier-3 }} \$FNDRY
+          🔗 **View bounty:** [$BOUNTY_URL]($BOUNTY_URL)
+
+          Developers can browse and claim this bounty on SolFoundry."
+          fi


### PR DESCRIPTION
## Summary
Closes #855

Creates a GitHub Action that external repositories can install to automatically convert labeled GitHub issues into SolFoundry bounties with customizable reward amounts.

## What's Included

### GitHub Action (`.github/actions/post-bounty/`)
- **`action.yml`** — Composite action definition with configurable inputs
- **`post-bounty.py`** — Python script that detects bounty labels and posts to SolFoundry API
- **`test_post_bounty.py`** — 5 unit tests covering label detection, tier mapping, skip logic, and custom config
- **`README.md`** — Documentation for external users

### Example Workflow (`.github/workflows/external-bounty.yml`)
Template that external repos can copy to auto-post labeled issues as bounties

## Acceptance Criteria
- ✅ Simple YAML configuration for workflow setup
- ✅ Label detection and bounty auto-posting (detects `bounty-t1`, `bounty-t2`, `bounty-t3` labels)
- ✅ Customizable reward tiers and thresholds (configurable via action inputs)

## Usage
External repos add this workflow and a SolFoundry API key secret:
```yaml
- name: Post Bounty
  uses: SolFoundry/solfoundry/.github/actions/post-bounty@main
  with:
    solfoundry-api-key: ${{ secrets.SOLFOUNDRY_API_KEY }}
```

## Solana Wallet for Payout
FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH