### PR TITLE
fix: fix GitHub OAuth redirect URI and URL encoding [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -14,6 +14,7 @@ import base64
 import logging
 from datetime import datetime, timezone, timedelta
 from typing import Optional, Dict
+from urllib.parse import urlencode
 
 import httpx
 from jose import jwt, JWTError
@@ -31,7 +32,7 @@ logger = logging.getLogger(__name__)
 GITHUB_CLIENT_ID = os.getenv("GITHUB_CLIENT_ID", "")
 GITHUB_CLIENT_SECRET = os.getenv("GITHUB_CLIENT_SECRET", "")
 GITHUB_REDIRECT_URI = os.getenv(
-    "GITHUB_REDIRECT_URI", "http://localhost:3000/auth/callback"
+    "GITHUB_REDIRECT_URI", "http://localhost:3000/auth/github/callback"
 )
 
 JWT_SECRET_KEY = os.getenv("JWT_SECRET_KEY") or secrets.token_urlsafe(32)
@@ -164,11 +165,9 @@ def get_github_authorize_url(state: Optional[str] = None) -> tuple:
         "response_type": "code",
     }
     return (
-        f"https://github.com/login/oauth/authorize?{'&'.join(f'{k}={v}' for k, v in params.items())}",
+        f"https://github.com/login/oauth/authorize?{urlencode(params)}",
         state,
     )
-
-
 def verify_oauth_state(state: str) -> bool:
     """Verify the OAuth state parameter is valid."""
     if not state:


### PR DESCRIPTION
## Description

Fixes #821 — GitHub OAuth sign-in flow returns a 404 when users click "Sign in with GitHub."

## Root Cause

Two issues caused the 404:

### 1. Redirect URI mismatch
The default `GITHUB_REDIRECT_URI` was set to `http://localhost:3000/auth/callback`, but the frontend React route is `/auth/github/callback` (see `frontend/src/App.tsx`). After GitHub authorization, the redirect hit the wrong route, returning a 404.

### 2. Missing URL encoding in authorize URL construction
The `get_github_authorize_url` function constructed the GitHub OAuth URL using raw string concatenation (f-string), which does not URL-encode parameter values. The `scope` parameter contains a space (`read:user user:email`) that must be encoded as `%20` or `+` for GitHub to accept the URL. Other parameters like `redirect_uri` could also contain characters requiring encoding.

## Changes

1. **`backend/app/services/auth_service.py`**:
   - Fixed `GITHUB_REDIRECT_URI` default from `/auth/callback` to `/auth/github/callback` to match the frontend route
   - Added `from urllib.parse import urlencode` import
   - Replaced raw string concatenation with `urlencode(params)` for proper URL parameter encoding

## Verification

- [x] Redirect URI now matches frontend route: `/auth/github/callback`
- [x] Authorize URL parameters are properly URL-encoded
- [x] No new imports beyond Python stdlib