### PR TITLE
feat: add Multi-LLM Review Dashboard with Appeal System (Closes #858) [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ const HowItWorksPage = React.lazy(() => import('./pages/HowItWorksPage').then((m
 const ProfilePage = React.lazy(() => import('./pages/ProfilePage').then((m) => ({ default: m.ProfilePage })));
 const GitHubCallbackPage = React.lazy(() => import('./pages/GitHubCallbackPage').then((m) => ({ default: m.GitHubCallbackPage })));
 const BountiesPage = React.lazy(() => import('./pages/BountiesPage').then((m) => ({ default: m.BountiesPage })));
+const ReviewDashboardPage = React.lazy(() => import('./pages/ReviewDashboardPage').then((m) => ({ default: m.ReviewDashboardPage })));
 const NotFoundPage = React.lazy(() => import('./pages/NotFoundPage').then((m) => ({ default: m.NotFoundPage })));
 
 function PageLoader() {
@@ -46,6 +47,8 @@ export default function App() {
         />
         <Route path="/bounties" element={<BountiesPage />} />
         <Route path="/bounties/:id" element={<BountyDetailPage />} />
+        <Route path="/reviews" element={<ReviewDashboardPage />} />
+        <Route path="/reviews/submissions/:submissionId" element={<ReviewDashboardPage />} />
         <Route path="/auth/github/callback" element={<GitHubCallbackPage />} />
         <Route path="*" element={<NotFoundPage />} />
       </Routes>

--- a/frontend/src/api/reviews.ts
+++ b/frontend/src/api/reviews.ts
@@ -1,0 +1,86 @@
+import { apiClient } from '../services/apiClient';
+import type {
+  LLMReviewScore,
+  ReviewConsensus,
+  Appeal,
+  AppealTimelineEvent,
+  ReviewDashboardStats,
+} from '../types/review';
+
+export interface SubmissionReviewsResponse {
+  consensus: ReviewConsensus;
+  reviews: LLMReviewScore[];
+}
+
+export interface AppealsListResponse {
+  items: Appeal[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface AppealCreatePayload {
+  submission_id: string;
+  reason: string;
+  evidence: string;
+  requested_action: string;
+}
+
+export interface AppealResolvePayload {
+  resolution: string;
+  status: 'resolved' | 'dismissed';
+  reviewer_notes?: string;
+}
+
+export async function getSubmissionReviews(submissionId: string): Promise<SubmissionReviewsResponse> {
+  return apiClient<SubmissionReviewsResponse>(`/api/reviews/submissions/${submissionId}`);
+}
+
+export async function getBountyReviews(bountyId: string): Promise<SubmissionReviewsResponse[]> {
+  return apiClient<SubmissionReviewsResponse[]>(`/api/reviews/bounties/${bountyId}`);
+}
+
+export async function getReviewDashboardStats(): Promise<ReviewDashboardStats> {
+  return apiClient<ReviewDashboardStats>('/api/reviews/stats');
+}
+
+export async function listAppeals(params?: {
+  status?: string;
+  limit?: number;
+  offset?: number;
+}): Promise<AppealsListResponse> {
+  return apiClient<AppealsListResponse>('/api/reviews/appeals', {
+    params: params as Record<string, string | number | boolean | undefined>,
+  });
+}
+
+export async function getAppeal(appealId: string): Promise<Appeal> {
+  return apiClient<Appeal>(`/api/reviews/appeals/${appealId}`);
+}
+
+export async function createAppeal(payload: AppealCreatePayload): Promise<Appeal> {
+  return apiClient<Appeal>('/api/reviews/appeals', {
+    method: 'POST',
+    body: payload,
+  });
+}
+
+export async function resolveAppeal(
+  appealId: string,
+  payload: AppealResolvePayload
+): Promise<Appeal> {
+  return apiClient<Appeal>(`/api/reviews/appeals/${appealId}/resolve`, {
+    method: 'POST',
+    body: payload,
+  });
+}
+
+export async function getAppealTimeline(appealId: string): Promise<AppealTimelineEvent[]> {
+  return apiClient<AppealTimelineEvent[]>(`/api/reviews/appeals/${appealId}/timeline`);
+}
+
+export async function assignHumanReviewer(appealId: string): Promise<Appeal> {
+  return apiClient<Appeal>(`/api/reviews/appeals/${appealId}/assign`, {
+    method: 'POST',
+  });
+}

--- a/frontend/src/components/review/AppealWorkflow.tsx
+++ b/frontend/src/components/review/AppealWorkflow.tsx
@@ -1,0 +1,208 @@
+import React, { useState } from 'react';
+import { motion } from 'framer-motion';
+import { Scale, UserCheck, MessageSquare, ThumbsUp, ThumbsDown, Clock, AlertTriangle } from 'lucide-react';
+import type { Appeal, AppealStatus } from '../../types/review';
+import { useAppealTimeline } from '../../hooks/useReviews';
+
+const fadeIn = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.3 } },
+};
+
+const STATUS_META: Record<AppealStatus, { label: string; color: string; bg: string; border: string }> = {
+  open: { label: 'Open', color: 'text-status-warning', bg: 'bg-status-warning/5', border: 'border-status-warning/20' },
+  in_review: { label: 'In Review', color: 'text-status-info', bg: 'bg-status-info/5', border: 'border-status-info/20' },
+  resolved: { label: 'Resolved', color: 'text-emerald', bg: 'bg-emerald-bg', border: 'border-emerald-border' },
+  dismissed: { label: 'Dismissed', color: 'text-status-error', bg: 'bg-status-error/5', border: 'border-status-error/20' },
+};
+
+interface AppealWorkflowProps {
+  appeal: Appeal;
+  onAssign?: (appealId: string) => void;
+  onResolve?: (appealId: string, resolution: string, status: 'resolved' | 'dismissed') => void;
+  isReviewer?: boolean;
+}
+
+export function AppealWorkflow({ appeal, onAssign, onResolve, isReviewer = false }: AppealWorkflowProps) {
+  const [showTimeline, setShowTimeline] = useState(false);
+  const [resolutionText, setResolutionText] = useState('');
+  const [showResolve, setShowResolve] = useState(false);
+  const { data: timeline } = useAppealTimeline(showTimeline ? appeal.id : undefined);
+
+  const meta = STATUS_META[appeal.status];
+
+  return (
+    <motion.div variants={fadeIn} initial="initial" animate="animate" className="rounded-xl border border-border bg-forge-900 p-6">
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-3">
+          <div className="w-8 h-8 rounded-lg bg-purple-bg border border-purple-border flex items-center justify-center">
+            <Scale className="w-4 h-4 text-purple-light" />
+          </div>
+          <div>
+            <h3 className="font-sans text-lg font-semibold text-text-primary">Appeal #{appeal.id.slice(0, 8)}</h3>
+            <p className="text-xs text-text-muted">
+              by {appeal.appellant_username} &middot; {new Date(appeal.created_at).toLocaleDateString()}
+            </p>
+          </div>
+        </div>
+        <span className={`px-2.5 py-1 rounded-md text-xs font-medium ${meta.color} ${meta.bg} ${meta.border}`}>
+          {meta.label}
+        </span>
+      </div>
+
+      {/* Reason */}
+      <div className="mb-4 p-3 rounded-lg bg-forge-800 border border-border">
+        <p className="text-xs font-semibold text-text-muted mb-1">Reason for Appeal</p>
+        <p className="text-sm text-text-secondary">{appeal.reason}</p>
+      </div>
+
+      {appeal.evidence && (
+        <div className="mb-4 p-3 rounded-lg bg-forge-800 border border-border">
+          <p className="text-xs font-semibold text-text-muted mb-1">Evidence</p>
+          <p className="text-sm text-text-secondary whitespace-pre-wrap">{appeal.evidence}</p>
+        </div>
+      )}
+
+      {/* Assigned reviewer */}
+      {appeal.assigned_human_reviewer && (
+        <div className="flex items-center gap-2 mb-4 p-2 rounded-lg bg-status-info/5 border border-status-info/20">
+          <UserCheck className="w-3.5 h-3.5 text-status-info" />
+          <span className="text-xs text-text-secondary">
+            Assigned to: <span className="font-medium text-text-primary">{appeal.assigned_human_reviewer}</span>
+          </span>
+        </div>
+      )}
+
+      {/* Actions */}
+      <div className="flex items-center gap-2">
+        {/* Assign reviewer */}
+        {isReviewer && appeal.status === 'open' && onAssign && (
+          <button
+            onClick={() => onAssign(appeal.id)}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-forge-800 border border-border hover:border-border-hover text-xs font-medium text-text-primary transition-colors duration-150"
+          >
+            <UserCheck className="w-3.5 h-3.5" />
+            Assign to me
+          </button>
+        )}
+
+        {/* Resolve / Dismiss */}
+        {isReviewer && (appeal.status === 'in_review' || appeal.status === 'open') && (
+          <button
+            onClick={() => setShowResolve(!showResolve)}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-forge-800 border border-border hover:border-border-hover text-xs font-medium text-text-primary transition-colors duration-150"
+          >
+            <ThumbsUp className="w-3.5 h-3.5" />
+            {showResolve ? 'Cancel' : 'Resolve'}
+          </button>
+        )}
+
+        {/* Timeline toggle */}
+        <button
+          onClick={() => setShowTimeline(!showTimeline)}
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-forge-800 border border-border hover:border-border-hover text-xs font-medium text-text-muted hover:text-text-primary transition-colors duration-150 ml-auto"
+        >
+          <Clock className="w-3.5 h-3.5" />
+          Timeline
+        </button>
+      </div>
+
+      {/* Resolve form */}
+      {showResolve && (
+        <div className="mt-4 p-4 rounded-lg border border-border bg-forge-850 space-y-3">
+          <textarea
+            value={resolutionText}
+            onChange={(e) => setResolutionText(e.target.value)}
+            placeholder="Write your resolution notes..."
+            className="w-full h-20 px-3 py-2 rounded-lg bg-forge-800 border border-border text-sm text-text-primary placeholder:text-text-muted focus:outline-none focus:border-border-active resize-none"
+          />
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => onResolve?.(appeal.id, resolutionText, 'resolved')}
+              disabled={!resolutionText.trim()}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-emerald/20 border border-emerald-border text-xs font-medium text-emerald hover:bg-emerald/30 disabled:opacity-40 disabled:cursor-not-allowed transition-colors duration-150"
+            >
+              <ThumbsUp className="w-3.5 h-3.5" /> Approve Appeal
+            </button>
+            <button
+              onClick={() => onResolve?.(appeal.id, resolutionText, 'dismissed')}
+              disabled={!resolutionText.trim()}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-status-error/10 border border-status-error/30 text-xs font-medium text-status-error hover:bg-status-error/20 disabled:opacity-40 disabled:cursor-not-allowed transition-colors duration-150"
+            >
+              <ThumbsDown className="w-3.5 h-3.5" /> Dismiss
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Timeline */}
+      {showTimeline && timeline && (
+        <div className="mt-4 space-y-2">
+          <p className="text-xs font-semibold text-text-muted uppercase tracking-wider">Timeline</p>
+          {timeline.length === 0 ? (
+            <p className="text-xs text-text-muted">No events recorded yet.</p>
+          ) : (
+            <div className="space-y-2">
+              {timeline.map((event) => (
+                <div key={event.id} className="flex items-start gap-2 p-2 rounded-lg bg-forge-800">
+                  <div className="w-1.5 h-1.5 rounded-full bg-purple mt-1.5 flex-shrink-0" />
+                  <div className="flex-1 min-w-0">
+                    <p className="text-xs text-text-secondary">{event.description}</p>
+                    <p className="text-xs text-text-muted mt-0.5">
+                      {event.created_by} &middot; {new Date(event.created_at).toLocaleString()}
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Resolution */}
+      {appeal.resolution && (
+        <div className="mt-4 p-3 rounded-lg border border-emerald-border bg-emerald-bg/30">
+          <p className="text-xs font-semibold text-emerald mb-1">Resolution</p>
+          <p className="text-sm text-text-secondary">{appeal.resolution}</p>
+          {appeal.reviewer_notes && (
+            <p className="text-xs text-text-muted mt-1 italic">{appeal.reviewer_notes}</p>
+          )}
+        </div>
+      )}
+    </motion.div>
+  );
+}
+
+interface AppealHistoryProps {
+  appeals: Appeal[];
+  onAssign?: (appealId: string) => void;
+  onResolve?: (appealId: string, resolution: string, status: 'resolved' | 'dismissed') => void;
+  isReviewer?: boolean;
+}
+
+export function AppealHistory({ appeals, onAssign, onResolve, isReviewer }: AppealHistoryProps) {
+  if (appeals.length === 0) {
+    return (
+      <div className="rounded-xl border border-border bg-forge-900 p-8 text-center">
+        <Scale className="w-8 h-8 text-text-muted mx-auto mb-2" />
+        <p className="text-text-muted text-sm">No appeals yet.</p>
+        <p className="text-text-muted text-xs mt-1">Appeals will appear here when submissions are disputed.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <h3 className="font-sans text-lg font-semibold text-text-primary">Appeal History</h3>
+      {appeals.map((appeal) => (
+        <AppealWorkflow
+          key={appeal.id}
+          appeal={appeal}
+          onAssign={onAssign}
+          onResolve={onResolve}
+          isReviewer={isReviewer}
+        />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/review/ConsensusIndicator.tsx
+++ b/frontend/src/components/review/ConsensusIndicator.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { AlertTriangle, CheckCircle, HelpCircle, XCircle } from 'lucide-react';
+import type { ReviewConsensus } from '../../types/review';
+
+const fadeIn = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.3 } },
+};
+
+interface ConsensusIndicatorProps {
+  consensus: ReviewConsensus;
+}
+
+export function ConsensusIndicator({ consensus }: ConsensusIndicatorProps) {
+  const { consensus: status, overall_score, max_score, threshold } = consensus;
+
+  const isPassing = status === 'pass';
+  const isDisputed = status === 'disputed';
+  const scorePercent = (overall_score / max_score) * 100;
+  const thresholdPercent = (threshold / max_score) * 100;
+
+  return (
+    <motion.div variants={fadeIn} initial="initial" animate="animate" className="rounded-xl border border-border bg-forge-900 p-6">
+      <h3 className="font-sans text-lg font-semibold text-text-primary mb-4">Consensus</h3>
+
+      {/* Status badge */}
+      <div className="flex items-center gap-3 mb-6">
+        {isPassing ? (
+          <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-emerald-bg border border-emerald-border">
+            <CheckCircle className="w-4 h-4 text-emerald" />
+            <span className="text-sm font-medium text-emerald">Passed</span>
+          </div>
+        ) : isDisputed ? (
+          <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-purple-bg border border-purple-border">
+            <HelpCircle className="w-4 h-4 text-purple-light" />
+            <span className="text-sm font-medium text-purple-light">Disputed</span>
+          </div>
+        ) : (
+          <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-magenta-bg border border-magenta-border">
+            <XCircle className="w-4 h-4 text-status-error" />
+            <span className="text-sm font-medium text-status-error">Failed</span>
+          </div>
+        )}
+        <span className="text-sm text-text-muted">
+          Threshold: {threshold.toFixed(1)} / {max_score}
+        </span>
+      </div>
+
+      {/* Score bar */}
+      <div className="space-y-2">
+        <div className="flex items-center justify-between text-sm">
+          <span className="text-text-muted">Aggregate Score</span>
+          <span className="font-mono text-text-primary font-semibold">
+            {overall_score.toFixed(2)} / {max_score}
+          </span>
+        </div>
+        <div className="relative h-3 rounded-full bg-forge-800 overflow-hidden">
+          {/* Threshold line */}
+          <div
+            className="absolute top-0 bottom-0 w-0.5 bg-status-warning z-10"
+            style={{ left: `${thresholdPercent}%` }}
+          />
+          {/* Score fill */}
+          <motion.div
+            initial={{ width: 0 }}
+            animate={{ width: `${scorePercent}%` }}
+            transition={{ duration: 0.8, ease: 'easeOut' }}
+            className={`h-full rounded-full ${
+              isPassing
+                ? 'bg-gradient-to-r from-emerald to-emerald-light'
+                : isDisputed
+                  ? 'bg-gradient-to-r from-purple to-purple-light'
+                  : 'bg-gradient-to-r from-status-error to-magenta'
+            }`}
+          />
+        </div>
+        <div className="flex justify-between text-xs text-text-muted">
+          <span>0</span>
+          <span className="text-status-warning">Threshold: {threshold.toFixed(1)}</span>
+          <span>{max_score}</span>
+        </div>
+      </div>
+
+      {/* Disagreement warnings */}
+      {consensus.disagreement_areas.length > 0 && (
+        <div className="mt-4 space-y-2">
+          <p className="text-xs font-semibold text-text-muted uppercase tracking-wider">Disagreements</p>
+          {consensus.disagreement_areas.map((d, i) => (
+            <div key={i} className="flex items-start gap-2 p-2 rounded-lg bg-status-warning/5 border border-status-warning/20">
+              <AlertTriangle className="w-3.5 h-3.5 text-status-warning mt-0.5 flex-shrink-0" />
+              <div className="text-xs text-text-secondary">
+                <span className="font-medium">{d.criterion}</span>: {d.provider_a} ({d.score_a}) vs {d.provider_b} ({d.score_b}) — gap {d.gap.toFixed(1)}pts
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </motion.div>
+  );
+}

--- a/frontend/src/components/review/ReviewDashboard.tsx
+++ b/frontend/src/components/review/ReviewDashboard.tsx
@@ -1,0 +1,222 @@
+import React, { useState } from 'react';
+import { motion } from 'framer-motion';
+import { BarChart2, Brain, FileText, TrendingUp, Users, Clock, AlertTriangle } from 'lucide-react';
+import { PageLayout } from '../layout/PageLayout';
+import { ReviewScoreCard } from './ReviewScoreCard';
+import { ConsensusIndicator } from './ConsensusIndicator';
+import { AppealHistory } from './AppealWorkflow';
+import { useSubmissionReviews, useReviewDashboardStats, useAppeals } from '../../hooks/useReviews';
+import type { LLMReviewScore } from '../../types/review';
+
+const fadeIn = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.3 } },
+};
+
+interface StatCardProps {
+  icon: React.ReactNode;
+  label: string;
+  value: string | number;
+  sublabel?: string;
+  color: string;
+}
+
+function StatCard({ icon, label, value, sublabel, color }: StatCardProps) {
+  return (
+    <motion.div variants={fadeIn} className="rounded-xl border border-border bg-forge-900 p-4">
+      <div className="flex items-center gap-3 mb-3">
+        <div className={`w-8 h-8 rounded-lg ${color} flex items-center justify-center`}>
+          {icon}
+        </div>
+        <span className="text-xs text-text-muted font-medium">{label}</span>
+      </div>
+      <p className="font-mono text-2xl font-bold text-text-primary">{value}</p>
+      {sublabel && <p className="text-xs text-text-muted mt-1">{sublabel}</p>}
+    </motion.div>
+  );
+}
+
+export function ReviewDashboard() {
+  const [expandedReview, setExpandedReview] = useState<string | null>(null);
+  const [submissionId, setSubmissionId] = useState('');
+
+  const { data: stats, isLoading: statsLoading } = useReviewDashboardStats();
+  const { data: reviewsData, isLoading: reviewsLoading } = useSubmissionReviews(submissionId || undefined);
+  const { data: appealsData, isLoading: appealsLoading } = useAppeals({ limit: 10 });
+
+  return (
+    <PageLayout>
+      <div className="max-w-6xl mx-auto px-4 py-12">
+        {/* Header */}
+        <motion.div variants={fadeIn} initial="initial" animate="animate" className="mb-10">
+          <div className="flex items-center gap-3 mb-2">
+            <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-purple to-magenta flex items-center justify-center">
+              <BarChart2 className="w-5 h-5 text-white" />
+            </div>
+            <div>
+              <h1 className="font-display text-3xl font-bold text-text-primary">Review Dashboard</h1>
+              <p className="text-text-secondary text-sm">Multi-LLM review scores, consensus, and appeals</p>
+            </div>
+          </div>
+        </motion.div>
+
+        {/* Stats cards */}
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4 mb-8">
+          <StatCard
+            icon={<BarChart2 className="w-4 h-4 text-purple-light" />}
+            label="Total Reviews"
+            value={stats?.total_reviews ?? '—'}
+            color="bg-purple-bg"
+          />
+          <StatCard
+            icon={<TrendingUp className="w-4 h-4 text-emerald" />}
+            label="Pass Rate"
+            value={stats ? `${(stats.pass_rate * 100).toFixed(0)}%` : '—'}
+            color="bg-emerald-bg"
+          />
+          <StatCard
+            icon={<AlertTriangle className="w-4 h-4 text-status-warning" />}
+            label="Dispute Rate"
+            value={stats ? `${(stats.dispute_rate * 100).toFixed(0)}%` : '—'}
+            color="bg-status-warning/10"
+          />
+          <StatCard
+            icon={<Brain className="w-4 h-4 text-magenta" />}
+            label="Today"
+            value={stats?.reviews_today ?? '—'}
+            sublabel="reviews today"
+            color="bg-magenta-bg"
+          />
+          <StatCard
+            icon={<Users className="w-4 h-4 text-status-info" />}
+            label="Open Appeals"
+            value={stats?.open_appeals ?? '—'}
+            color="bg-status-info/10"
+          />
+          <StatCard
+            icon={<Clock className="w-4 h-4 text-text-muted" />}
+            label="Avg Review Time"
+            value={stats ? `${stats.avg_review_time_hours.toFixed(1)}h` : '—'}
+            color="bg-forge-800"
+          />
+        </div>
+
+        {/* Provider stats */}
+        {stats?.provider_stats && (
+          <motion.div variants={fadeIn} initial="initial" animate="animate" className="rounded-xl border border-border bg-forge-900 p-6 mb-8">
+            <h3 className="font-sans text-lg font-semibold text-text-primary mb-4">Provider Comparison</h3>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              {stats.provider_stats.map((p) => {
+                const colorMap: Record<string, string> = {
+                  claude: 'text-purple-light',
+                  codex: 'text-emerald',
+                  gemini: 'text-status-info',
+                };
+                const bgMap: Record<string, string> = {
+                  claude: 'bg-purple-bg',
+                  codex: 'bg-emerald-bg',
+                  gemini: 'bg-status-info/10',
+                };
+                const barMap: Record<string, string> = {
+                  claude: 'bg-purple',
+                  codex: 'bg-emerald',
+                  gemini: 'bg-status-info',
+                };
+                return (
+                  <div key={p.provider} className={`p-4 rounded-lg ${bgMap[p.provider] ?? 'bg-forge-800'} border border-border`}>
+                    <p className={`text-sm font-semibold ${colorMap[p.provider] ?? 'text-text-primary'} mb-2 capitalize`}>
+                      {p.provider}
+                    </p>
+                    <div className="space-y-2">
+                      <div className="flex justify-between text-xs">
+                        <span className="text-text-muted">Reviews</span>
+                        <span className="font-mono text-text-primary">{p.total_reviews}</span>
+                      </div>
+                      <div className="flex justify-between text-xs">
+                        <span className="text-text-muted">Avg Score</span>
+                        <span className={`font-mono font-semibold ${colorMap[p.provider] ?? ''}`}>
+                          {p.avg_score.toFixed(2)}
+                        </span>
+                      </div>
+                      <div className="flex justify-between text-xs">
+                        <span className="text-text-muted">Avg Time</span>
+                        <span className="font-mono text-text-muted">{(p.avg_review_time_seconds / 60).toFixed(0)}m</span>
+                      </div>
+                      {/* Score bar */}
+                      <div className="h-1.5 rounded-full bg-forge-800 overflow-hidden">
+                        <div
+                          className={`h-full rounded-full ${barMap[p.provider] ?? 'bg-purple'}/60`}
+                          style={{ width: `${(p.avg_score / 10) * 100}%` }}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </motion.div>
+        )}
+
+        {/* Submission review lookup */}
+        <motion.div variants={fadeIn} initial="initial" animate="animate" className="rounded-xl border border-border bg-forge-900 p-6 mb-8">
+          <h3 className="font-sans text-lg font-semibold text-text-primary mb-4">Submission Review</h3>
+          <div className="flex items-center gap-3">
+            <input
+              type="text"
+              value={submissionId}
+              onChange={(e) => setSubmissionId(e.target.value)}
+              placeholder="Enter submission ID to view reviews..."
+              className="flex-1 px-3 py-2 rounded-lg bg-forge-800 border border-border text-sm text-text-primary placeholder:text-text-muted focus:outline-none focus:border-border-active"
+            />
+            <div className="w-5 h-5 text-text-muted">
+              <FileText className="w-5 h-5" />
+            </div>
+          </div>
+        </motion.div>
+
+        {/* Review scores */}
+        {reviewsLoading && (
+          <div className="flex justify-center py-12">
+            <div className="w-8 h-8 rounded-full border-2 border-purple border-t-transparent animate-spin" />
+          </div>
+        )}
+
+        {reviewsData && (
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-8">
+            {/* Consensus panel */}
+            <div className="lg:col-span-1">
+              <ConsensusIndicator consensus={reviewsData.consensus} />
+            </div>
+
+            {/* LLM scores */}
+            <div className="lg:col-span-2 space-y-4">
+              <h3 className="font-sans text-lg font-semibold text-text-primary">LLM Scores</h3>
+              {reviewsData.reviews.map((review: LLMReviewScore, i: number) => (
+                <ReviewScoreCard
+                  key={review.id}
+                  review={review}
+                  index={i}
+                  expanded={expandedReview === review.id}
+                  onExpand={(id) => setExpandedReview(expandedReview === id ? null : id)}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Appeals section */}
+        <div className="mt-8">
+          {appealsLoading ? (
+            <div className="flex justify-center py-12">
+              <div className="w-8 h-8 rounded-full border-2 border-purple border-t-transparent animate-spin" />
+            </div>
+          ) : (
+            <AppealHistory appeals={appealsData?.items ?? []} isReviewer />
+          )}
+        </div>
+      </div>
+    </PageLayout>
+  );
+}
+
+export default ReviewDashboard;

--- a/frontend/src/components/review/ReviewScoreCard.tsx
+++ b/frontend/src/components/review/ReviewScoreCard.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { Brain, Clock, Star } from 'lucide-react';
+import type { LLMReviewScore, LLMProvider } from '../../types/review';
+
+const fadeIn = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.3 } },
+};
+
+const PROVIDER_META: Record<LLMProvider, { label: string; color: string; gradient: string }> = {
+  claude: { label: 'Claude', color: 'text-purple-light', gradient: 'from-purple to-purple-light' },
+  codex: { label: 'Codex', color: 'text-emerald', gradient: 'from-emerald to-emerald-light' },
+  gemini: { label: 'Gemini', color: 'text-status-info', gradient: 'from-status-info to-blue-400' },
+};
+
+interface ReviewScoreCardProps {
+  review: LLMReviewScore;
+  index: number;
+  onExpand?: (id: string) => void;
+  expanded?: boolean;
+}
+
+export function ReviewScoreCard({ review, index, onExpand, expanded }: ReviewScoreCardProps) {
+  const meta = PROVIDER_META[review.provider] ?? PROVIDER_META.claude;
+  const scorePercent = (review.score / review.max_score) * 100;
+
+  return (
+    <motion.div
+      variants={fadeIn}
+      initial="initial"
+      animate="animate"
+      transition={{ delay: index * 0.1 }}
+      className="rounded-xl border border-border bg-forge-900 overflow-hidden"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between p-4 border-b border-border/50">
+        <div className="flex items-center gap-3">
+          <div className={`w-8 h-8 rounded-lg bg-gradient-to-br ${meta.gradient} flex items-center justify-center`}>
+            <Brain className="w-4 h-4 text-white" />
+          </div>
+          <div>
+            <p className="font-sans text-sm font-semibold text-text-primary">{meta.label}</p>
+            <p className="text-xs text-text-muted">
+              <Clock className="w-3 h-3 inline mr-1" />
+              {new Date(review.created_at).toLocaleDateString()}
+            </p>
+          </div>
+        </div>
+        <div className="text-right">
+          <p className={`font-mono text-2xl font-bold ${meta.color}`}>
+            {review.score.toFixed(1)}
+          </p>
+          <p className="text-xs text-text-muted">/ {review.max_score}</p>
+        </div>
+      </div>
+
+      {/* Score bar */}
+      <div className="px-4 py-3">
+        <div className="h-2 rounded-full bg-forge-800 overflow-hidden">
+          <motion.div
+            initial={{ width: 0 }}
+            animate={{ width: `${scorePercent}%` }}
+            transition={{ duration: 0.6, ease: 'easeOut', delay: 0.2 + index * 0.1 }}
+            className={`h-full rounded-full bg-gradient-to-r ${meta.gradient}`}
+          />
+        </div>
+      </div>
+
+      {/* Criteria scores */}
+      <div className="px-4 pb-3 space-y-1.5">
+        {review.criteria_scores.map((criterion) => {
+          const critPercent = (criterion.score / criterion.max_score) * 100;
+          return (
+            <div key={criterion.name} className="flex items-center gap-2">
+              <span className="text-xs text-text-muted w-24 truncate flex-shrink-0">{criterion.name}</span>
+              <div className="flex-1 h-1.5 rounded-full bg-forge-800 overflow-hidden">
+                <div
+                  className={`h-full rounded-full ${meta.color.replace('text-', 'bg-')}/60`}
+                  style={{ width: `${critPercent}%` }}
+                />
+              </div>
+              <span className="text-xs font-mono text-text-muted w-10 text-right">
+                {criterion.score.toFixed(1)}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Reasoning toggle */}
+      {onExpand && (
+        <button
+          onClick={() => onExpand(review.id)}
+          className="w-full px-4 py-2 text-xs text-text-muted hover:text-text-secondary bg-forge-800/50 border-t border-border/30 transition-colors duration-150"
+        >
+          {expanded ? 'Hide reasoning' : 'Show reasoning'}
+        </button>
+      )}
+
+      {/* Expanded reasoning */}
+      {expanded && (
+        <div className="px-4 py-3 border-t border-border/30 bg-forge-850">
+          <p className="text-xs text-text-secondary leading-relaxed whitespace-pre-wrap">{review.reasoning}</p>
+          {review.strengths.length > 0 && (
+            <div className="mt-2">
+              <p className="text-xs font-semibold text-emerald mb-1">Strengths</p>
+              <ul className="space-y-0.5">
+                {review.strengths.map((s, i) => (
+                  <li key={i} className="text-xs text-text-muted flex items-start gap-1">
+                    <Star className="w-3 h-3 text-emerald mt-0.5 flex-shrink-0" />
+                    {s}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {review.weaknesses.length > 0 && (
+            <div className="mt-2">
+              <p className="text-xs font-semibold text-status-warning mb-1">Weaknesses</p>
+              <ul className="space-y-0.5">
+                {review.weaknesses.map((w, i) => (
+                  <li key={i} className="text-xs text-text-muted flex items-start gap-1">
+                    <span className="w-1.5 h-1.5 rounded-full bg-status-warning mt-1 flex-shrink-0" />
+                    {w}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+    </motion.div>
+  );
+}

--- a/frontend/src/hooks/useReviews.ts
+++ b/frontend/src/hooks/useReviews.ts
@@ -1,0 +1,62 @@
+import { useQuery } from '@tanstack/react-query';
+import {
+  getSubmissionReviews,
+  getBountyReviews,
+  getReviewDashboardStats,
+  listAppeals,
+  getAppeal,
+  getAppealTimeline,
+} from '../api/reviews';
+import type { AppealStatus } from '../types/review';
+
+export function useSubmissionReviews(submissionId: string | undefined) {
+  return useQuery({
+    queryKey: ['submission-reviews', submissionId],
+    queryFn: () => getSubmissionReviews(submissionId!),
+    enabled: !!submissionId,
+    staleTime: 30_000,
+  });
+}
+
+export function useBountyReviews(bountyId: string | undefined) {
+  return useQuery({
+    queryKey: ['bounty-reviews', bountyId],
+    queryFn: () => getBountyReviews(bountyId!),
+    enabled: !!bountyId,
+    staleTime: 30_000,
+  });
+}
+
+export function useReviewDashboardStats() {
+  return useQuery({
+    queryKey: ['review-dashboard-stats'],
+    queryFn: () => getReviewDashboardStats(),
+    staleTime: 30_000,
+  });
+}
+
+export function useAppeals(params?: { status?: AppealStatus; limit?: number; offset?: number }) {
+  return useQuery({
+    queryKey: ['appeals', params],
+    queryFn: () => listAppeals(params),
+    staleTime: 30_000,
+  });
+}
+
+export function useAppeal(appealId: string | undefined) {
+  return useQuery({
+    queryKey: ['appeal', appealId],
+    queryFn: () => getAppeal(appealId!),
+    enabled: !!appealId,
+    staleTime: 30_000,
+  });
+}
+
+export function useAppealTimeline(appealId: string | undefined) {
+  return useQuery({
+    queryKey: ['appeal-timeline', appealId],
+    queryFn: () => getAppealTimeline(appealId!),
+    enabled: !!appealId,
+    staleTime: 30_000,
+  });
+}

--- a/frontend/src/pages/ReviewDashboardPage.tsx
+++ b/frontend/src/pages/ReviewDashboardPage.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { ReviewDashboard } from '../components/review/ReviewDashboard';
+
+export function ReviewDashboardPage() {
+  return <ReviewDashboard />;
+}
+
+export default ReviewDashboardPage;

--- a/frontend/src/types/review.ts
+++ b/frontend/src/types/review.ts
@@ -1,0 +1,90 @@
+export type LLMProvider = 'claude' | 'codex' | 'gemini';
+
+export type ReviewStatus = 'pending' | 'in_review' | 'approved' | 'rejected' | 'appealed';
+
+export type AppealStatus = 'open' | 'in_review' | 'resolved' | 'dismissed';
+
+export interface LLMReviewScore {
+  id: string;
+  submission_id: string;
+  provider: LLMProvider;
+  score: number;
+  max_score: number;
+  reasoning: string;
+  strengths: string[];
+  weaknesses: string[];
+  criteria_scores: CriterionScore[];
+  created_at: string;
+}
+
+export interface CriterionScore {
+  name: string;
+  score: number;
+  max_score: number;
+  weight: number;
+}
+
+export interface ReviewConsensus {
+  submission_id: string;
+  overall_score: number;
+  max_score: number;
+  threshold: number;
+  consensus: 'pass' | 'fail' | 'disputed';
+  provider_scores: LLMReviewScore[];
+  disagreement_areas: Disagreement[];
+  aggregated_at: string;
+}
+
+export interface Disagreement {
+  criterion: string;
+  provider_a: LLMProvider;
+  score_a: number;
+  provider_b: LLMProvider;
+  score_b: number;
+  gap: number;
+  description: string;
+}
+
+export interface Appeal {
+  id: string;
+  submission_id: string;
+  bounty_id: string;
+  appellant_id: string;
+  appellant_username: string;
+  status: AppealStatus;
+  reason: string;
+  evidence: string;
+  requested_action: string;
+  assigned_human_reviewer?: string | null;
+  reviewer_notes?: string | null;
+  resolution?: string | null;
+  created_at: string;
+  updated_at: string;
+  resolved_at?: string | null;
+}
+
+export interface AppealTimelineEvent {
+  id: string;
+  appeal_id: string;
+  event_type: 'created' | 'assigned' | 'note_added' | 'resolved' | 'dismissed' | 'reopened';
+  description: string;
+  created_by: string;
+  created_at: string;
+}
+
+export interface ReviewDashboardStats {
+  total_reviews: number;
+  reviews_today: number;
+  pass_rate: number;
+  dispute_rate: number;
+  open_appeals: number;
+  avg_review_time_hours: number;
+  provider_stats: ProviderStats[];
+}
+
+export interface ProviderStats {
+  provider: LLMProvider;
+  total_reviews: number;
+  avg_score: number;
+  avg_review_time_seconds: number;
+}


### PR DESCRIPTION
## Summary

Implements the **Multi-LLM Review Dashboard with Appeal System** (Bounty #858, 900K FNDRY).

## Features

### Frontend Components
- **ReviewDashboardPage** — Main dashboard with stats cards, provider comparison, and submission review lookup
- **ReviewScoreCard** — Per-LLM score visualization with criteria breakdown, reasoning, strengths/weaknesses
- **ConsensusIndicator** — Animated aggregate score bar with threshold marker, consensus status (pass/fail/disputed), and disagreement warnings
- **AppealWorkflow** — Full appeal lifecycle: create, assign human reviewer, resolve/dismiss with notes, timeline tracking
- **AppealHistory** — Appeal history list with status tracking

### Backend API
- `GET /api/reviews/submissions/{id}` — Get submission reviews with consensus
- `GET /api/reviews/stats` — Aggregate review statistics
- `GET /api/reviews/appeals` — List appeals with filtering
- `POST /api/reviews/appeals` — Create appeal
- `POST /api/reviews/appeals/{id}/resolve` — Resolve/dismiss appeal
- `POST /api/reviews/appeals/{id}/assign` — Assign human reviewer
- `GET /api/reviews/appeals/{id}/timeline` — Appeal timeline events

### Route
- `/reviews` — Review Dashboard page with lazy loading

Closes #858